### PR TITLE
feat(tooling): add CI workflows, GitHub templates and PR automation (#6)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,36 +1,33 @@
-## Résumé
+## Summary
 
-<!-- Décris en 1-3 phrases ce que fait cette PR -->
+<!-- Describe in 1-3 sentences what this PR does -->
 
-## Issue(s) liée(s)
+## Related issue(s)
 
-Closes #<!-- numéro de l'issue -->
+Closes #<!-- issue number -->
 
-## Type de changement
+## Type of change
 
-- [ ] Nouvelle feature (Phase 1A/1B/2/2B/3)
+- [ ] New feature (Phase 1A / 1B / 2 / 2B / 3)
 - [ ] Bug fix
-- [ ] Refactoring (pas de changement de comportement)
+- [ ] Refactoring (no behavior change)
 - [ ] Config / DevOps
 - [ ] Documentation
 
-## Domaine
-
-- [ ] `frontend` (`apps/frontend/`)
-- [ ] `backend` (`apps/backend/`)
-- [ ] `shared` (`packages/shared/`)
-- [ ] `ai`
-- [ ] `database`
-
 ## Checklist
 
-- [ ] Le code suit les conventions du projet (`CLAUDE.md`)
-- [ ] Les types partagés sont dans `packages/shared` (pas dupliqués)
-- [ ] `pnpm type-check` passe
-- [ ] `pnpm lint` passe
-- [ ] Pas de `console.log` oubliés
-- [ ] Testé manuellement
+- [ ] Code follows project conventions (`CLAUDE.md`)
+- [ ] Shared types are in `packages/shared` (not duplicated)
+- [ ] `pnpm type-check` passes
+- [ ] `pnpm lint` passes
+- [ ] No forgotten `console.log`
+- [ ] Manually tested
 
-## Screenshots (si frontend)
+## Screenshots (frontend only)
 
-<!-- Capture d'écran avant/après si changement UI -->
+<!-- Before/after screenshot if UI change -->
+
+---
+
+> **Labels** and **milestone** are assigned automatically based on files changed and branch name.
+> No need to set them manually.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+frontend:
+  - any: ['apps/frontend/**']
+
+backend:
+  - any: ['apps/backend/**']
+
+shared:
+  - any:
+      - 'packages/shared/**'
+      - 'packages/eslint-config/**'
+      - 'packages/prettier-config/**'
+
+phase-1a:
+  - any: ['apps/frontend/**']
+
+phase-1b:
+  - any: ['apps/backend/**']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,18 @@ jobs:
       - name: Type check
         run: pnpm type-check
 
+  label:
+    name: Auto Label
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -1,0 +1,48 @@
+name: PR Metadata
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
+jobs:
+  milestone:
+    name: Assign Milestone
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Assign milestone based on branch name
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH: ${{ github.head_ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [[ "$BRANCH" == feature/phase-1a-* ]]; then
+            MILESTONE="Phase 1A - Frontend UI"
+          elif [[ "$BRANCH" == feature/phase-1b-* ]]; then
+            MILESTONE="Phase 1B - Backend Foundation"
+          elif [[ "$BRANCH" == feature/phase-2b-* ]]; then
+            MILESTONE="Phase 2B - Multi-Universe"
+          elif [[ "$BRANCH" == feature/phase-2-* ]]; then
+            MILESTONE="Phase 2 - MVP"
+          elif [[ "$BRANCH" == feature/phase-3-* ]]; then
+            MILESTONE="Phase 3 - Polish & UGC"
+          else
+            echo "No milestone to assign for branch: $BRANCH"
+            exit 0
+          fi
+
+          MILESTONE_NUMBER=$(gh api repos/$REPO/milestones \
+            --jq ".[] | select(.title == \"$MILESTONE\") | .number")
+
+          if [ -z "$MILESTONE_NUMBER" ]; then
+            echo "Milestone '$MILESTONE' not found, skipping."
+            exit 0
+          fi
+
+          gh api repos/$REPO/issues/$PR_NUMBER \
+            --method PATCH \
+            --field milestone=$MILESTONE_NUMBER
+
+          echo "Assigned milestone '$MILESTONE' to PR #$PR_NUMBER"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,11 +181,33 @@ release/0.1.0                      # depuis develop quand MVP prêt
 | Phase 2B - Multi-Universe | Week 16 | 3 univers, 14 classes |
 | Phase 3 - Polish & UGC | Week 17+ | Community features |
 
-### Comment demander à Claude de créer des issues
-Exemples de commandes valides :
-- "Crée les issues pour la Phase 1A Week 1 depuis la doc"
-- "Crée une issue pour implémenter le composant UniverseCard"
-- "Crée une PR feature/phase-1a-landing-page → develop"
-- "Crée la release branch 0.1.0"
+### PR Automation (automatic — no manual action needed)
 
-Claude lira la doc pertinente et créera automatiquement les issues/branches/PRs avec les bons labels et milestones.
+**Labels** → auto-applied by `actions/labeler@v5` via `.github/labeler.yml`:
+- Files in `apps/frontend/` → labels `frontend` + `phase-1a`
+- Files in `apps/backend/` → labels `backend` + `phase-1b`
+- Files in `packages/` → label `shared`
+
+**Milestone** → auto-assigned by `.github/workflows/pr-metadata.yml` based on branch name:
+| Branch pattern | Milestone |
+|----------------|-----------|
+| `feature/phase-1a-*` | Phase 1A - Frontend UI |
+| `feature/phase-1b-*` | Phase 1B - Backend Foundation |
+| `feature/phase-2-*` | Phase 2 - MVP |
+| `feature/phase-2b-*` | Phase 2B - Multi-Universe |
+| `feature/phase-3-*` | Phase 3 - Polish & UGC |
+| `feature/tooling-*` | _(none)_ |
+
+**Reviewers** → assigned manually (solo project).
+
+> When creating PRs via MCP github tool, still pass `labels` explicitly —
+> GitHub Actions automation only runs on GitHub-triggered events, not via API calls.
+
+### How to ask Claude to create issues
+Valid commands:
+- "Create issues for Phase 1A Week 1 from the docs"
+- "Create an issue to implement the UniverseCard component"
+- "Create a PR feature/phase-1a-landing-page → develop"
+- "Create the release branch 0.1.0"
+
+Claude will read the relevant docs and automatically create issues/branches/PRs with the correct labels and milestones.

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -298,6 +298,29 @@ PHASE 3 (Week 17+): UGC + Polish
 
 If unclear: Check README.md → GAME_DESIGN.md → specific doc
 
+## ⚙️ CI / GitHub Automation (Active)
+
+### PR Labels (auto-applied)
+Labels are auto-applied via `actions/labeler@v5` in `.github/workflows/ci.yml` based on files changed:
+- `apps/frontend/**` → `frontend`, `phase-1a`
+- `apps/backend/**` → `backend`, `phase-1b`
+- `packages/**` → `shared`
+
+Config: `.github/labeler.yml`
+
+### PR Milestones (auto-assigned)
+Milestones are auto-assigned via `.github/workflows/pr-metadata.yml` based on branch name:
+- `feature/phase-1a-*` → Phase 1A - Frontend UI
+- `feature/phase-1b-*` → Phase 1B - Backend Foundation
+- `feature/phase-2-*` → Phase 2 - MVP
+- `feature/phase-2b-*` → Phase 2B - Multi-Universe
+- `feature/phase-3-*` → Phase 3 - Polish & UGC
+- `feature/tooling-*` → no milestone (tooling branches)
+
+**Note**: When creating PRs via MCP GitHub tool, pass labels/milestone explicitly since automation only triggers on GitHub Actions events.
+
+---
+
 ## 📞 When to Update MEMORY.md
 
 - [ ] Phase completed


### PR DESCRIPTION
## Summary

Set up the full GitHub Actions pipeline and PR automation for the monorepo.

- CI workflow: lint, type-check, build on every push/PR
- Release workflow: auto-release + PR to main on `release/*` branches
- Auto-label PRs via `actions/labeler@v5` based on files changed
- Auto-assign milestones via `pr-metadata.yml` based on branch name convention
- Issue templates (phase-task, bug-report) and PR template
- `.mcp.json.example` documenting the 3 MCP servers (Context7, Supabase, GitHub)
- `.mcp.json` added to `.gitignore` to prevent secrets from being committed
- Updated `CLAUDE.md` and `docs/MEMORY.md` with PR automation documentation

## Related issue(s)

Closes #6

## Type of change

- [x] Config / DevOps

## Checklist

- [x] Code follows project conventions (`CLAUDE.md`)
- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] No forgotten `console.log`
- [x] Manually tested