### PR TITLE
feat(tooling): add Husky, commitlint and lint-staged git hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+pnpm commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm lint-staged

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,38 @@
+/** @type {import('@commitlint/types').UserConfig} */
+const config = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      ['feat', 'fix', 'chore', 'docs', 'refactor', 'test'],
+    ],
+    'body-max-line-length': [0],
+    'no-claude-co-authored-by': [2, 'always'],
+  },
+  plugins: [
+    {
+      rules: {
+        // Block Claude auto-generated Co-Authored-By lines (noreply@anthropic.com)
+        'no-claude-co-authored-by': ({ raw }) => {
+          if (!raw) return [true]
+          const lines = raw.split('\n')
+          for (const line of lines) {
+            if (
+              /^Co-Authored-By:/i.test(line.trim()) &&
+              /noreply@anthropic\.com/i.test(line)
+            ) {
+              return [
+                false,
+                `Claude auto-generated Co-Authored-By is forbidden (see CLAUDE.md): "${line.trim()}"`,
+              ]
+            }
+          }
+          return [true]
+        },
+      },
+    },
+  ],
+}
+
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -5,10 +5,35 @@
     "dev": "turbo dev",
     "build": "turbo build",
     "lint": "turbo lint",
-    "type-check": "turbo type-check"
+    "type-check": "turbo type-check",
+    "prepare": "husky",
+    "knip": "knip",
+    "test": "turbo test",
+    "test:e2e": "turbo test:e2e"
   },
   "packageManager": "pnpm@9.15.0",
   "devDependencies": {
+    "@commitlint/cli": "^19",
+    "@commitlint/config-conventional": "^19",
+    "husky": "^9",
+    "knip": "^5",
+    "lint-staged": "^15",
     "turbo": "^2.3.0"
+  },
+  "lint-staged": {
+    "apps/frontend/**/*.{ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "apps/backend/**/*.ts": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "packages/**/*.{ts,tsx,js}": [
+      "prettier --write"
+    ],
+    "*.{json,md,yml,yaml}": [
+      "prettier --write"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Husky v9 installé avec deux hooks : `pre-commit` (lint-staged) et `commit-msg` (commitlint)
- `commitlint.config.js` : types restreints à `feat/fix/chore/docs/refactor/test`, règle custom qui bloque tout footer `Co-Authored-By: ...noreply@anthropic.com`
- `lint-staged` : ESLint + Prettier sur les fichiers stagés par workspace
- Script `prepare` pour installation automatique des hooks après `pnpm install`

## Test plan

- [ ] `pnpm install` → `.husky/` hooks actifs
- [ ] `echo "WIP" | pnpm commitlint` → échoue
- [ ] `echo "feat(tooling): test" | pnpm commitlint` → passe
- [ ] Commit avec `Co-Authored-By: Claude <noreply@anthropic.com>` → bloqué
- [ ] `git commit` sur fichier stagé → lint-staged se lance

Closes #13