### PR TITLE
chore(rename): rename project from EpisodeRPG-game to Grimoire

### DIFF
--- a/.claude/agents/code-reviewer/agent.md
+++ b/.claude/agents/code-reviewer/agent.md
@@ -19,6 +19,7 @@ You are a senior staff engineer performing code reviews. You follow standards fr
 ## What You Review
 
 ### Code Quality
+
 - [ ] TypeScript strict compliance (no `any`, no `as` casts without justification)
 - [ ] Single responsibility principle
 - [ ] No code duplication (DRY but not over-abstracted)
@@ -27,6 +28,7 @@ You are a senior staff engineer performing code reviews. You follow standards fr
 - [ ] Proper error handling at every level
 
 ### Security (OWASP Top 10)
+
 - [ ] No hardcoded secrets or credentials
 - [ ] Input validation on all user-facing endpoints
 - [ ] No SQL injection vectors
@@ -35,18 +37,21 @@ You are a senior staff engineer performing code reviews. You follow standards fr
 - [ ] Rate limiting on sensitive endpoints
 
 ### Architecture
-- [ ] Types imported from `@rpg-game/shared`, never duplicated
+
+- [ ] Types imported from `@grimoire/shared`, never duplicated
 - [ ] Backend owns game logic, frontend is display-only
 - [ ] Proper separation: routes -> services -> data layer
 - [ ] AI output validated before use
 
 ### Performance
+
 - [ ] No N+1 queries
 - [ ] No unnecessary re-renders (frontend)
 - [ ] Proper use of server/client components
 - [ ] No blocking operations on main thread
 
 ### Conventions (from CLAUDE.md)
+
 - [ ] File naming: kebab-case
 - [ ] Type naming: PascalCase
 - [ ] Named exports only
@@ -58,16 +63,19 @@ You are a senior staff engineer performing code reviews. You follow standards fr
 Organize feedback by severity:
 
 ### CRITICAL (must fix before merge)
+
 - Security vulnerabilities
 - Data loss risks
 - Breaking bugs
 
 ### WARNING (should fix)
+
 - Performance issues
 - Missing validation
 - Convention violations
 
 ### SUGGESTION (nice to have)
+
 - Readability improvements
 - Minor refactoring opportunities
 

--- a/.claude/agents/frontend-dev/agent.md
+++ b/.claude/agents/frontend-dev/agent.md
@@ -21,6 +21,7 @@ You work ONLY in `apps/frontend/`. Never modify files outside this directory exc
 ## Implementation Standards (Vercel/Industry Best Practices)
 
 ### Next.js App Router Conventions
+
 - Server Components by default, `'use client'` only when needed (interactivity, hooks, browser APIs)
 - Use route groups: `(auth)`, `(menu)`, `(game)` for layout isolation
 - Loading states via `loading.tsx`, errors via `error.tsx`
@@ -29,19 +30,22 @@ You work ONLY in `apps/frontend/`. Never modify files outside this directory exc
 - Use `next/link` for client-side navigation
 
 ### Component Architecture
+
 - Small, focused components (< 150 lines)
-- Props defined with TypeScript interfaces, imported from `@rpg-game/shared` when shared
+- Props defined with TypeScript interfaces, imported from `@grimoire/shared` when shared
 - Composition over inheritance
 - Separate presentational components from logic (hooks)
 - Co-locate related files: `ComponentName.tsx` next to `use-component-name.ts`
 
 ### State Management
+
 - **Zustand** for client/UI state (theme, sidebar, modals)
 - **React Query (@tanstack/react-query)** for all server data
 - Never duplicate server state in Zustand
 - Custom hooks abstract all data fetching: `useGameSession()`, `useCharacter()`, etc.
 
 ### Styling (Tailwind CSS v4)
+
 - Utility-first, no CSS modules
 - Design tokens via CSS custom properties
 - Responsive: mobile-first approach
@@ -49,12 +53,14 @@ You work ONLY in `apps/frontend/`. Never modify files outside this directory exc
 - Consistent spacing, typography, and color scales
 
 ### Performance
+
 - Minimize client-side JavaScript (server components where possible)
 - Lazy load heavy components with `React.lazy` or dynamic imports
 - Optimize re-renders: `useMemo`, `useCallback` only when measured necessary
 - No premature optimization
 
 ### Accessibility
+
 - Semantic HTML (`button` not `div onClick`)
 - ARIA labels where needed
 - Keyboard navigation support

--- a/.claude/skills/bug/SKILL.md
+++ b/.claude/skills/bug/SKILL.md
@@ -13,7 +13,7 @@ Exécuter dans l'ordre :
 1. **Créer l'issue GitHub**
    - Demander : "Décris le bug en une phrase (pour l'issue GitHub)"
    - Créer l'issue via mcp**github**create_issue avec :
-     - owner: AdamDjo, repo: EpisodeRPG-game
+     - owner: AdamDjo, repo: Grimoire-game
      - labels: ["bug"]
      - title: "fix(<args>): <description du bug>"
    - Noter le numéro de l'issue créée → `<numéro>`

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -8,15 +8,18 @@ allowed-tools: Bash
 Run quality checks on the monorepo. Execute these commands sequentially and report results:
 
 1. Run TypeScript type-check:
+
 ```bash
-cd /c/Users/ABM/dev/frontend/rpg-game && pnpm type-check
+cd /c/Users/ABM/dev/frontend/grimoire && pnpm type-check
 ```
 
 2. If type-check passes, run lint:
+
 ```bash
-cd /c/Users/ABM/dev/frontend/rpg-game && pnpm lint
+cd /c/Users/ABM/dev/frontend/grimoire && pnpm lint
 ```
 
 3. Report results clearly:
+
 - If all pass: confirm everything is clean
 - If errors: list each error with file path and line number, then suggest fixes

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -14,7 +14,7 @@ Exécuter dans l'ordre :
    - Demander : "Décris la feature en une phrase (pour l'issue GitHub)"
    - Demander : "Quels labels ? (ex: frontend, backend, phase-1a, phase-1b...)"
    - Créer l'issue via mcp**github**create_issue avec :
-     - owner: AdamDjo, repo: EpisodeRPG-game
+     - owner: AdamDjo, repo: Grimoire-game
      - title: "feat(<args>): <description>"
      - labels fournis par l'utilisateur
    - Noter le numéro de l'issue créée → `<numéro>`

--- a/.claude/skills/hotfix/SKILL.md
+++ b/.claude/skills/hotfix/SKILL.md
@@ -13,7 +13,7 @@ Exécuter dans l'ordre :
 1. **Créer l'issue GitHub**
    - Demander : "Décris le problème en production en une phrase"
    - Créer l'issue via mcp**github**create_issue avec :
-     - owner: AdamDjo, repo: EpisodeRPG-game
+     - owner: AdamDjo, repo: Grimoire-game
      - labels: ["bug", "priority"]
      - title: "hotfix(<args>): <description>"
    - Noter le numéro de l'issue créée → `<numéro>`

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -63,7 +63,7 @@ Exécuter dans l'ordre :
 
 8. **Créer la PR via mcp**github**create_pull_request**
    - owner: AdamDjo
-   - repo: EpisodeRPG-game
+   - repo: Grimoire-game
    - head: branche courante
    - base: cible déterminée à l'étape 3
 

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -12,8 +12,9 @@ Show the current project status by:
 3. Present a clean summary:
 
 Format:
+
 ```
-PROJECT STATUS: RPG Narratif Web
+PROJECT STATUS: Grimoire
 ================================
 Phase 1: Architecture        [####] 100%
 Phase 2: Backend Infra       [##--]  50%

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Narrative RPG Web - AI-Powered
+# Grimoire — AI-Powered Narrative RPG
 
 ## IMPORTANT: Project Memory
 
@@ -38,7 +38,7 @@ Interactive narrative RPG web game where AI generates unique universes for each 
 ## Project Structure
 
 ```
-rpg-game/
+grimoire/
 ├── apps/frontend/          # Next.js 15 app (proxy API)
 ├── apps/backend/           # Express API (game engine, AI, rules)
 └── packages/shared/        # Shared TypeScript types & constants
@@ -61,7 +61,7 @@ pnpm type-check             # TypeScript check all
 
 - TypeScript strict mode everywhere
 - All types shared between frontend/backend go in `packages/shared`
-- Never duplicate types - always import from `@rpg-game/shared`
+- Never duplicate types - always import from `@grimoire/shared`
 - Use named exports, not default exports
 - Use `async/await`, never raw Promises with `.then()`
 
@@ -158,7 +158,12 @@ fix/31-login-crash                 # Issue #31, bug fix
 hotfix/32-auth-token-leak          # Issue #32, hotfix prod
 ```
 
-**Règle absolue : toujours créer l'issue avant la branche.** Utiliser les skills `/feature`, `/bug`, `/hotfix` qui font ça automatiquement.
+**Règles absolues — sans aucune exception :**
+
+- Toujours créer l'issue avant la branche
+- Ne jamais commiter directement sur `develop` ou `main` — même pour du tooling, config, rename, ou chore
+- Avant tout `git commit`, vérifier qu'on est sur une branche `feature/*`, `fix/*`, `hotfix/*` — jamais sur `develop`/`main`
+- Utiliser les skills `/feature`, `/bug`, `/hotfix` qui créent l'issue et la branche automatiquement
 
 ### Workflow Claude → GitHub (MCP github server)
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,11 +1,13 @@
-# RPG Narratif Web - Progress Tracker
+# Grimoire - Progress Tracker
 
 ## Current Status: Phase 2 - Backend Implementation
+
 **Last updated**: 2026-02-11
 
 ---
 
 ## Phase 1: Architecture & Shared Types [COMPLETED]
+
 - [x] Monorepo setup (Turborepo + pnpm workspaces)
 - [x] TypeScript configs (strict mode)
 - [x] Shared types: API, Character, Combat, Inventory, Quest, Scene, Session, Universe
@@ -20,6 +22,7 @@
 - [x] MCP Servers: Context7 (docs), Supabase (DB)
 
 ## Phase 2: Backend - Core Infrastructure [IN PROGRESS]
+
 - [ ] Supabase client setup + environment config
 - [ ] Error handler middleware
 - [ ] Auth middleware (Supabase JWT)
@@ -27,6 +30,7 @@
 - [ ] Database schema (SQL migrations)
 
 ## Phase 3: Backend - Routes & Services
+
 - [ ] Auth routes + service (register, login, session)
 - [ ] Character routes + service (CRUD, validation)
 - [ ] Universe routes + service (generate, list, get)
@@ -34,6 +38,7 @@
 - [ ] Game routes + service (action, scene flow)
 
 ## Phase 4: Backend - AI Integration
+
 - [ ] AI Provider interface implementation
 - [ ] OpenAI provider
 - [ ] Claude provider
@@ -44,6 +49,7 @@
 - [ ] Scene generation prompts
 
 ## Phase 5: Backend - Game Engine
+
 - [ ] Game engine service (orchestrator)
 - [ ] Combat system (rules, dice, resolution)
 - [ ] Inventory management (add, remove, equip, use)
@@ -52,12 +58,14 @@
 - [ ] Game over conditions
 
 ## Phase 6: Frontend - Core Setup
+
 - [ ] App layout with providers (QueryClient, Zustand)
 - [ ] API proxy route (catch-all)
 - [ ] Auth pages (login, register)
 - [ ] Navigation & route guards
 
 ## Phase 7: Frontend - Game UI
+
 - [ ] Main menu page
 - [ ] Universe selection/generation page
 - [ ] Character creation page
@@ -70,6 +78,7 @@
 - [ ] Game over screen
 
 ## Phase 8: Frontend - Polish
+
 - [ ] Responsive design
 - [ ] Animations & transitions
 - [ ] Sound effects (optional)
@@ -77,6 +86,7 @@
 - [ ] Error handling UI
 
 ## Phase 9: Integration & Testing
+
 - [ ] End-to-end game flow test
 - [ ] AI response validation tests
 - [ ] Combat system tests
@@ -85,10 +95,11 @@
 ---
 
 ## Decision Log
-| Date | Decision | Reason |
-|------|----------|--------|
-| 2026-02-11 | Sequential agent workflow | Avoid conflicts, ensure quality |
-| 2026-02-11 | Start with backend infrastructure | Frontend depends on API |
-| 2026-02-11 | Context7 MCP (free, no key) | Up-to-date docs for all libs |
-| 2026-02-11 | Supabase MCP (OAuth, no project yet) | Direct DB access when ready |
-| 2026-02-11 | 3 custom agents + 3 custom skills | Structured workflow, code quality |
+
+| Date       | Decision                             | Reason                            |
+| ---------- | ------------------------------------ | --------------------------------- |
+| 2026-02-11 | Sequential agent workflow            | Avoid conflicts, ensure quality   |
+| 2026-02-11 | Start with backend infrastructure    | Frontend depends on API           |
+| 2026-02-11 | Context7 MCP (free, no key)          | Up-to-date docs for all libs      |
+| 2026-02-11 | Supabase MCP (OAuth, no project yet) | Direct DB access when ready       |
+| 2026-02-11 | 3 custom agents + 3 custom skills    | Structured workflow, code quality |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EpisodeRPG — AI-Powered Narrative RPG
+# Grimoire — AI-Powered Narrative RPG
 
 An interactive web narrative RPG where AI generates unique universes every playthrough. Players create a character, read narrative scenes, and choose from text options. Roadwarden-style gameplay: stats, inventory, choices with permanent consequences, and Game Over possible. Infinite replayability through AI generation.
 
@@ -10,8 +10,8 @@ An interactive web narrative RPG where AI generates unique universes every playt
 ## Installation
 
 ```bash
-git clone https://github.com/AdamDjo/EpisodeRPG-game.git
-cd EpisodeRPG-game
+git clone https://github.com/AdamDjo/Grimoire-game.git
+cd Grimoire-game
 pnpm install
 ```
 
@@ -33,8 +33,8 @@ cp .mcp.json.example .mcp.json
 # Fill in your tokens in .mcp.json
 ```
 
-| Placeholder | Where to get it |
-|-------------|-----------------|
+| Placeholder           | Where to get it                                                 |
+| --------------------- | --------------------------------------------------------------- |
 | `ghp_YOUR_TOKEN_HERE` | GitHub → Settings → Developer Settings → Personal Access Tokens |
 
 > ⚠️ Never commit `.mcp.json` — it contains your secrets. It is listed in `.gitignore`.
@@ -53,14 +53,14 @@ pnpm type-check                # TypeScript check across all packages
 ## Project Structure
 
 ```
-EpisodeRPG-game/
+Grimoire-game/
 ├── apps/
 │   ├── frontend/              # Next.js 16 (App Router) — port 3000
 │   └── backend/               # Express + TypeScript — port 3001
 ├── packages/
-│   ├── shared/                # Shared types & constants (@rpg-game/shared)
-│   ├── eslint-config/         # Shared ESLint config (@rpg-game/eslint-config)
-│   └── prettier-config/       # Shared Prettier config (@rpg-game/prettier-config)
+│   ├── shared/                # Shared types & constants (@grimoire/shared)
+│   ├── eslint-config/         # Shared ESLint config (@grimoire/eslint-config)
+│   └── prettier-config/       # Shared Prettier config (@grimoire/prettier-config)
 ├── docs/
 │   ├── GAME_DESIGN.md         # Game vision, phases, classes, universes
 │   ├── FRONTEND_ARCHITECTURE.md  # Pages, components, Next.js structure
@@ -87,11 +87,11 @@ Feature branches follow the convention `feature/<issue-number>-<description>` to
 
 ## Tech Stack
 
-| Layer | Technology |
-|-------|------------|
-| Frontend | Next.js 16, React 19, Tailwind CSS v4 |
-| Backend | Express, TypeScript, Zod |
-| Database | Supabase (PostgreSQL) |
-| State management | Zustand + React Query |
-| AI | Claude, Gemini, Mistral (fallback chain) |
-| Monorepo | Turborepo + pnpm workspaces |
+| Layer            | Technology                               |
+| ---------------- | ---------------------------------------- |
+| Frontend         | Next.js 16, React 19, Tailwind CSS v4    |
+| Backend          | Express, TypeScript, Zod                 |
+| Database         | Supabase (PostgreSQL)                    |
+| State management | Zustand + React Query                    |
+| AI               | Claude, Gemini, Mistral (fallback chain) |
+| Monorepo         | Turborepo + pnpm workspaces              |

--- a/apps/backend/.prettierrc.js
+++ b/apps/backend/.prettierrc.js
@@ -1,1 +1,1 @@
-module.exports = require('@rpg-game/prettier-config')
+module.exports = require('@grimoire/prettier-config')

--- a/apps/backend/CLAUDE.md
+++ b/apps/backend/CLAUDE.md
@@ -1,15 +1,18 @@
 # Backend Agent Instructions
 
 ## Scope
+
 This agent works ONLY on `apps/backend/`. Never modify files outside this directory.
 
 ## Architecture
+
 - Express + TypeScript API server on port 3001
 - Supabase for database, auth, and storage
 - All game logic lives here (stats, combat, inventory, quests)
 - AI generates narrative content only; backend validates everything
 
 ## Directory Structure
+
 ```
 src/
 ├── config/         # Environment & Supabase config
@@ -22,9 +25,10 @@ src/
 ```
 
 ## Rules
+
 - Always validate inputs with zod schemas
 - All responses: `{ success: boolean, data?: T, error?: string }`
-- Import types ONLY from `@rpg-game/shared`, never duplicate
+- Import types ONLY from `@grimoire/shared`, never duplicate
 - Use `async/await`, never `.then()`
 - Files: `kebab-case.ts` (e.g., `game-engine.service.ts`)
 - Named exports only, no default exports
@@ -33,11 +37,13 @@ src/
 - Supabase admin client for server operations, user client for RLS
 
 ## Key Dependencies
-- `@rpg-game/shared` - All shared types
+
+- `@grimoire/shared` - All shared types
 - `@supabase/supabase-js` - Database & auth
 - `zod` - Input validation
 - `express-rate-limit` - Rate limiting
 
 ## Testing
+
 - Run `pnpm type-check --filter backend` to verify types
 - Run `pnpm dev --filter backend` to test the server starts

--- a/apps/backend/eslint.config.js
+++ b/apps/backend/eslint.config.js
@@ -1,6 +1,6 @@
 // @ts-check
 'use strict'
 
-const { createBackendConfig } = require('@rpg-game/eslint-config/backend')
+const { createBackendConfig } = require('@grimoire/eslint-config/backend')
 
 module.exports = createBackendConfig({ tsconfigRootDir: __dirname })

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rpg-game/backend",
+  "name": "@grimoire/backend",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -13,7 +13,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@rpg-game/shared": "workspace:*",
+    "@grimoire/shared": "workspace:*",
     "@supabase/supabase-js": "^2.47.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.0",
@@ -22,8 +22,8 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@rpg-game/eslint-config": "workspace:*",
-    "@rpg-game/prettier-config": "workspace:*",
+    "@grimoire/eslint-config": "workspace:*",
+    "@grimoire/prettier-config": "workspace:*",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -12,7 +12,7 @@
     "sourceMap": true,
     "declaration": true,
     "paths": {
-      "@rpg-game/shared": ["../../packages/shared/src"]
+      "@grimoire/shared": ["../../packages/shared/src"]
     }
   },
   "include": ["src/**/*"]

--- a/apps/frontend/.prettierrc.js
+++ b/apps/frontend/.prettierrc.js
@@ -1,1 +1,1 @@
-module.exports = require('@rpg-game/prettier-config')
+module.exports = require('@grimoire/prettier-config')

--- a/apps/frontend/CLAUDE.md
+++ b/apps/frontend/CLAUDE.md
@@ -1,9 +1,11 @@
 # Frontend Agent Instructions
 
 ## Scope
+
 This agent works ONLY on `apps/frontend/`. Never modify files outside this directory.
 
 ## Architecture
+
 - Next.js 15 (App Router) + React 19 + TypeScript
 - Tailwind CSS 4 for styling (no CSS modules)
 - Zustand for UI/client state
@@ -12,6 +14,7 @@ This agent works ONLY on `apps/frontend/`. Never modify files outside this direc
 - Frontend is display-only: shows scenes, presents choices, displays stats
 
 ## Directory Structure
+
 ```
 src/
 ├── app/
@@ -32,7 +35,8 @@ src/
 ```
 
 ## Rules
-- Import types ONLY from `@rpg-game/shared`
+
+- Import types ONLY from `@grimoire/shared`
 - React components: `PascalCase.tsx` (e.g., `SceneDisplay.tsx`)
 - Other files: `kebab-case.ts` (e.g., `use-game-session.ts`)
 - Named exports only
@@ -41,16 +45,19 @@ src/
 - Tailwind for all styling, use design tokens/theme variables
 
 ## State Management
+
 - **Zustand stores**: UI state (sidebar open, theme, modals)
 - **React Query**: All server data (sessions, characters, scenes)
 - Never duplicate server state in Zustand
 
 ## API Pattern
+
 ```typescript
 // All API calls go through the proxy:
 // Frontend -> /api/game/action -> Backend -> /api/game/action
 ```
 
 ## Testing
+
 - Run `pnpm type-check --filter frontend` to verify types
 - Run `pnpm dev --filter frontend` to test dev server

--- a/apps/frontend/eslint.config.js
+++ b/apps/frontend/eslint.config.js
@@ -1,6 +1,6 @@
 // @ts-check
 'use strict'
 
-const { createNextConfig } = require('@rpg-game/eslint-config/next')
+const { createNextConfig } = require('@grimoire/eslint-config/next')
 
 module.exports = createNextConfig({ tsconfigRootDir: __dirname })

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rpg-game/frontend",
+  "name": "@grimoire/frontend",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -17,7 +17,7 @@
     "analyze": "ANALYZE=true pnpm build"
   },
   "dependencies": {
-    "@rpg-game/shared": "workspace:*",
+    "@grimoire/shared": "workspace:*",
     "@supabase/supabase-js": "^2.47.0",
     "@tanstack/react-query": "^5.55.0",
     "axios": "^1.7.0",
@@ -32,8 +32,8 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^15",
-    "@rpg-game/eslint-config": "workspace:*",
-    "@rpg-game/prettier-config": "workspace:*",
+    "@grimoire/eslint-config": "workspace:*",
+    "@grimoire/prettier-config": "workspace:*",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6",
     "@testing-library/react": "^16",

--- a/docs/FRONTEND_ARCHITECTURE.md
+++ b/docs/FRONTEND_ARCHITECTURE.md
@@ -99,7 +99,7 @@ apps/frontend/
 │   │   └── game-constants.ts
 │   │
 │   ├── types/
-│   │   └── index.ts (import from @rpg-game/shared)
+│   │   └── index.ts (import from @grimoire/shared)
 │   │
 │   └── styles/
 │       └── globals.css
@@ -114,6 +114,7 @@ apps/frontend/
 **Purpose**: First page before login
 
 **Layout**:
+
 ```
 ┌─────────────────────────────────────────┐
 │  Narrative RPG Logo       [Login] [Sign] │
@@ -137,6 +138,7 @@ apps/frontend/
 ```
 
 **Components Used**:
+
 - `Header.tsx` (branding, navigation)
 - `Card.tsx` (feature cards)
 - `Button.tsx` (CTA buttons)
@@ -148,6 +150,7 @@ apps/frontend/
 **Purpose**: User authentication
 
 **Layout**:
+
 ```
 ┌─────────────────────────────────────────┐
 │  Narrative RPG                          │
@@ -166,11 +169,13 @@ apps/frontend/
 ```
 
 **Components Used**:
+
 - `LoginForm.tsx` (form logic)
 - `Input.tsx` (form inputs)
 - `Button.tsx` (submit)
 
 **Form Validation**:
+
 - Email required, valid email
 - Password required, min 6 chars
 - Show error messages
@@ -184,6 +189,7 @@ apps/frontend/
 **Layout**: Similar to Login, but with password confirmation
 
 **Components Used**:
+
 - `SignupForm.tsx`
 - `Input.tsx`
 - `Button.tsx`
@@ -195,6 +201,7 @@ apps/frontend/
 **Purpose**: Main menu after login
 
 **Layout**:
+
 ```
 ┌─────────────────────────────────────────┐
 │ Profile: John Doe   [Settings] [Logout] │
@@ -231,25 +238,27 @@ apps/frontend/
 ```
 
 **Components Used**:
+
 - `Header.tsx` (user info)
 - `Card.tsx` (sections)
 - `Button.tsx` (actions)
 
 **Data Structure** (Mock for MVP):
+
 ```typescript
 interface UserSession {
-  characterName: string
-  class: string
-  level: number
-  playtimeSeconds: number
-  lastPlayedAt: Date
+  characterName: string;
+  class: string;
+  level: number;
+  playtimeSeconds: number;
+  lastPlayedAt: Date;
 }
 
 interface UserStats {
-  totalSessionsPlayed: number
-  totalHoursPlayed: number
-  bestCompletionTime: number
-  achievementsUnlocked: number
+  totalSessionsPlayed: number;
+  totalHoursPlayed: number;
+  bestCompletionTime: number;
+  achievementsUnlocked: number;
 }
 ```
 
@@ -260,6 +269,7 @@ interface UserStats {
 **Purpose**: Choose the universe before character creation
 
 **Layout**:
+
 ```
 ┌──────────────────────────────────────────┐
 │ ◄ Back              Choose Your Universe │
@@ -295,6 +305,7 @@ interface UserStats {
 ```
 
 **Components Used**:
+
 - `UniverseSelector.tsx` (main component)
 - `UniverseCard.tsx` (individual universe card)
 - `UniversePreview.tsx` (preview modal with lore)
@@ -302,15 +313,17 @@ interface UserStats {
 - `Card.tsx`
 
 **State Management**:
+
 ```typescript
 interface UniverseState {
-  selectedUniverse: UniverseType | null
-  availableUniverses: UniverseDefinition[]
-  selectUniverse: (universeId: string) => void
+  selectedUniverse: UniverseType | null;
+  availableUniverses: UniverseDefinition[];
+  selectUniverse: (universeId: string) => void;
 }
 ```
 
 **Phase Rollout**:
+
 - **Phase 1 (MVP)**: Fantasy clickable, others disabled
 - **Phase 2B**: All 3 universes clickable
 - **Phase 3**: + Custom universe creator
@@ -322,6 +335,7 @@ interface UniverseState {
 **Purpose**: Create a character for the selected universe
 
 **Layout** (Fantasy example):
+
 ```
 ┌──────────────────────────────────────────┐
 │ ◄ Back              Character Creation   │
@@ -377,6 +391,7 @@ interface UniverseState {
 ```
 
 **Components Used**:
+
 - `CharacterCreator.tsx` (main form)
 - `ClassSelector.tsx` (universe-aware, loads correct classes)
 - `StatDistributor.tsx` (universal stats: HP/Mana/Str/Agi/Int/Cha/Luck)
@@ -385,34 +400,36 @@ interface UniverseState {
 - `Input.tsx`
 
 **State Management** (Zustand):
+
 ```typescript
 interface CharacterState {
-  name: string
-  universeType: UniverseType  // 'fantasy' | 'apocalypse' | 'scifi'
-  selectedClass: ClassDefinition
-  baseStats: UniversalStats
-  addPointToStat: (stat: StatKey) => void
-  removePointFromStat: (stat: StatKey) => void
-  getFinalStats: () => UniversalStats
-  isValid: () => boolean
+  name: string;
+  universeType: UniverseType; // 'fantasy' | 'apocalypse' | 'scifi'
+  selectedClass: ClassDefinition;
+  baseStats: UniversalStats;
+  addPointToStat: (stat: StatKey) => void;
+  removePointFromStat: (stat: StatKey) => void;
+  getFinalStats: () => UniversalStats;
+  isValid: () => boolean;
 }
 
 interface UniversalStats {
-  hp: number
-  maxHp: number
-  mana: number
-  maxMana: number
-  strength: number
-  agility: number
-  intelligence: number
-  charisma: number
-  luck: number
-  level: number
-  xp: number
+  hp: number;
+  maxHp: number;
+  mana: number;
+  maxMana: number;
+  strength: number;
+  agility: number;
+  intelligence: number;
+  charisma: number;
+  luck: number;
+  level: number;
+  xp: number;
 }
 ```
 
 **Notes**:
+
 - Classes loaded dynamically based on `universeType`
 - Stats adapted to context (e.g., "Mana" → "Stamina" in apocalypse, "Shield Energy" in scifi)
 - Identical UI but labels change depending on universe
@@ -424,6 +441,7 @@ interface UniversalStats {
 **Purpose**: MAIN GAME SCREEN - 70% of gameplay happens here
 
 **Layout**:
+
 ```
 ┌────────────────────────────────────────────────────────┐
 │ [Menu] Thrall | HP 85/100 | San 70/100 | Stamina 75/100│
@@ -470,6 +488,7 @@ interface UniversalStats {
 ```
 
 **Components Used**:
+
 - `SceneDisplay.tsx` (scene title + description)
 - `EventLog.tsx` (last 3-4 events)
 - `ChoicesList.tsx` (all 4 choices)
@@ -479,6 +498,7 @@ interface UniversalStats {
 - `Header.tsx` (top bar with quick stats)
 
 **Interactions**:
+
 1. User clicks choice button
 2. POST `/api/game/action` { sessionId, choiceId }
 3. Scene updates with animation
@@ -486,19 +506,20 @@ interface UniversalStats {
 5. Stats potentially change
 
 **State Management**:
+
 ```typescript
 interface GameSessionState {
-  sessionId: string
-  character: Character
-  currentScene: Scene
-  eventLog: LogEntry[]
-  inventory: InventoryItem[]
-  stats: Stats
-  level: number
-  xp: number
+  sessionId: string;
+  character: Character;
+  currentScene: Scene;
+  eventLog: LogEntry[];
+  inventory: InventoryItem[];
+  stats: Stats;
+  level: number;
+  xp: number;
 
-  selectChoice: (choiceId: string) => Promise<void>
-  updateFromAPI: (data: APIResponse) => void
+  selectChoice: (choiceId: string) => Promise<void>;
+  updateFromAPI: (data: APIResponse) => void;
 }
 ```
 
@@ -509,6 +530,7 @@ interface GameSessionState {
 **Purpose**: Display game summary
 
 **Layout**:
+
 ```
 ┌──────────────────────────────────────────┐
 │                                          │
@@ -537,6 +559,7 @@ interface GameSessionState {
 ```
 
 **Components Used**:
+
 - `GameOverScreen.tsx` (main)
 - `Card.tsx` (summary box)
 - `Button.tsx`
@@ -548,6 +571,7 @@ interface GameSessionState {
 **Purpose**: View global scores
 
 **Layout**:
+
 ```
 ┌──────────────────────────────────────────┐
 │ Leaderboards                             │
@@ -572,6 +596,7 @@ interface GameSessionState {
 **Purpose**: User settings
 
 **Options**:
+
 - Sound on/off
 - Difficulty (Easy/Normal/Hard)
 - Narrative style (Dark/Comedy/Epic)
@@ -584,44 +609,48 @@ interface GameSessionState {
 ## Component Library (Reusable UI)
 
 ### Button.tsx
+
 ```typescript
 interface ButtonProps {
-  children: React.ReactNode
-  onClick?: () => void
-  disabled?: boolean
-  variant?: 'primary' | 'secondary' | 'danger'
-  size?: 'sm' | 'md' | 'lg'
-  className?: string
+  children: React.ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  variant?: "primary" | "secondary" | "danger";
+  size?: "sm" | "md" | "lg";
+  className?: string;
 }
 ```
 
 ### Input.tsx
+
 ```typescript
 interface InputProps {
-  type?: 'text' | 'email' | 'password'
-  placeholder?: string
-  value: string
-  onChange: (value: string) => void
-  error?: string
-  disabled?: boolean
+  type?: "text" | "email" | "password";
+  placeholder?: string;
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+  disabled?: boolean;
 }
 ```
 
 ### Card.tsx
+
 ```typescript
 interface CardProps {
-  children: React.ReactNode
-  title?: string
-  className?: string
-  onClick?: () => void
+  children: React.ReactNode;
+  title?: string;
+  className?: string;
+  onClick?: () => void;
 }
 ```
 
 ### Badge.tsx (for rarity)
+
 ```typescript
 interface BadgeProps {
-  rarity: 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary'
-  children: React.ReactNode
+  rarity: "common" | "uncommon" | "rare" | "epic" | "legendary";
+  children: React.ReactNode;
 }
 // Colors: white, green, blue, purple, orange
 ```
@@ -631,6 +660,7 @@ interface BadgeProps {
 ## Styling Strategy
 
 **Colors (Tailwind)**:
+
 ```
 Primary: Indigo-600 (buttons, focus)
 Secondary: Slate-700 (text, backgrounds)
@@ -647,6 +677,7 @@ Rarity Colors:
 ```
 
 **Typography**:
+
 - H1: 3xl bold (page titles)
 - H2: 2xl bold (section titles)
 - H3: xl bold (subsection titles)
@@ -658,6 +689,7 @@ Rarity Colors:
 ## Phase 1A Milestone (Week 5)
 
 **By end of week 5, DONE**:
+
 - ✅ All 10 pages created + navigable
 - ✅ Universe selector (Fantasy active, 2 disabled)
 - ✅ All components built
@@ -666,6 +698,7 @@ Rarity Colors:
 - ✅ No API calls yet (all static)
 
 **Pages ready to integrate with backend**:
+
 1. Login/Signup (auth endpoints)
 2. Dashboard (session list)
 3. Universe Selection (universe metadata)
@@ -676,6 +709,7 @@ Rarity Colors:
 8. Settings (user prefs)
 
 **Multi-Universe Architecture**:
+
 - ✅ Code supports 3 universes from Phase 1
 - ✅ UI shows 3 cards (2 disabled with "COMING SOON")
 - ✅ ClassSelector loads correct classes based on universeType

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1,4 +1,4 @@
-# RPG Game - Project Memory & Status
+# Grimoire - Project Memory
 
 **Last Updated**: February 2026
 **Current Phase**: Planning Complete → Ready for Phase 1A ✅
@@ -18,14 +18,14 @@
 
 **ALL DOCS ARE HERE**: `docs/` folder
 
-| Doc | Purpose | Read When |
-|-----|---------|-----------|
-| **README.md** | Index + overview | First! Shows structure |
-| **GAME_DESIGN.md** | Game vision, phases, design | Understand WHAT to build |
-| **FRONTEND_ARCHITECTURE.md** | All pages & components | Build frontend |
-| **NARRATIVE_DESIGN.md** | Story standards, AI prompts | Code backend/AI |
-| **TECH_STACK.md** | Libraries, patterns, security | Code anything |
-| **MEMORY.md** | This file - status tracking | Every session |
+| Doc                          | Purpose                       | Read When                |
+| ---------------------------- | ----------------------------- | ------------------------ |
+| **README.md**                | Index + overview              | First! Shows structure   |
+| **GAME_DESIGN.md**           | Game vision, phases, design   | Understand WHAT to build |
+| **FRONTEND_ARCHITECTURE.md** | All pages & components        | Build frontend           |
+| **NARRATIVE_DESIGN.md**      | Story standards, AI prompts   | Code backend/AI          |
+| **TECH_STACK.md**            | Libraries, patterns, security | Code anything            |
+| **MEMORY.md**                | This file - status tracking   | Every session            |
 
 **Note**: Old docs (PROJECT_SPECIFICATION.md, ROADMAP_DETAILED.md, TECH_RECOMMENDATIONS.md) → MERGED into consolidated docs above. Keep for reference if needed, but not authoritative.
 
@@ -34,6 +34,7 @@
 ## 🤖 How Claude Uses Docs
 
 **EVERY SESSION**:
+
 1. Read this MEMORY.md first (current status)
 2. Check GAME_DESIGN.md for context (game vision)
 3. Reference specific doc based on task:
@@ -51,6 +52,7 @@
 ## 📋 Project State
 
 ### Setup
+
 - ✅ Monorepo: Turborepo + pnpm
 - ✅ Frontend: Next.js 15 (installed)
 - ✅ Backend: Express + TypeScript (ready)
@@ -58,6 +60,7 @@
 - ✅ Git hook: pnpm type-check active
 
 ### Documentation
+
 - ✅ Game design (GAME_DESIGN.md)
 - ✅ Frontend spec (FRONTEND_ARCHITECTURE.md)
 - ✅ Narrative standards (NARRATIVE_DESIGN.md)
@@ -65,6 +68,7 @@
 - ✅ All docs indexed (README.md)
 
 ### Code
+
 - ⏳ Frontend: NOT STARTED (ready to start Week 1)
 - ⏳ Backend: NOT STARTED (starts Week 4)
 - ⏳ Shared types: 95% complete (minor updates as needed)
@@ -74,6 +78,7 @@
 ## 🎮 Game Overview (For Claude Memory)
 
 ### Concept
+
 - Player chooses a **universe** (Fantasy, Apocalypse, or Sci-Fi)
 - Player creates character (14 classes total, 5/4/5 per universe)
 - AI generates narrative scenes adapted to the universe
@@ -83,6 +88,7 @@
 - Each playthrough feels different (AI + multi-universe)
 
 ### Core Addictive Loop
+
 1. Choose universe (theme selection)
 2. Create character (identity + class)
 3. See scene (immersion)
@@ -95,24 +101,28 @@
 ### 3 Base Universes
 
 **1. Valorain (Fantasy)**
+
 - Medieval fantasy, magic, mythical creatures
 - 5 regions, 4 factions, original creatures
 - WoW-inspired but legally original
 - Classes: Warrior, Mage, Thief, Healer, Ranger
 
 **2. Terre Desolee (Apocalypse)**
+
 - Post-apocalypse, survival, scarce resources
 - Ruins, radioactive zones, human factions
 - Fallout/Metro-inspired but original
 - Classes: Scavenger, Brawler, Medic, Engineer
 
 **3. Nova Galaxia (Sci-Fi)**
+
 - Space opera, advanced tech, aliens
 - Space stations, colonized planets
 - Mass Effect/Star Wars-inspired but original
 - Classes: Pilot, Soldier, Hacker, Diplomat, Psionic
 
 ### Universal Stats
+
 - HP, Mana, Strength, Agility, Intelligence, Charisma, Luck
 - Same stats for all universes (contextual adaptation)
 
@@ -189,6 +199,7 @@ PHASE 3 (Week 17+): UGC + Polish
 **When Starting Phase 1A ("Start Phase 1A - Frontend UI")**:
 
 ### Week 1
+
 - [ ] Next.js structure confirmed
 - [ ] Tailwind CSS setup done
 - [ ] Component library started (Button, Input, Card, etc.)
@@ -197,6 +208,7 @@ PHASE 3 (Week 17+): UGC + Polish
 - [ ] Auth form validation working (frontend)
 
 ### Week 2-3
+
 - [ ] Universe selector (3 cards: Fantasy, Apocalypse disabled, Sci-Fi disabled)
 - [ ] Character creation form complete
 - [ ] Class selector (5 fantasy classes visible)
@@ -206,6 +218,7 @@ PHASE 3 (Week 17+): UGC + Polish
 - [ ] Responsive design checked
 
 ### Week 4
+
 - [ ] Game session screen layout (main complexity)
 - [ ] Scene display component
 - [ ] Choices list (4 buttons)
@@ -214,6 +227,7 @@ PHASE 3 (Week 17+): UGC + Polish
 - [ ] Event log component
 
 ### Week 5
+
 - [ ] Game over screen
 - [ ] Leaderboard mockup
 - [ ] Settings page
@@ -228,6 +242,7 @@ PHASE 3 (Week 17+): UGC + Polish
 ## 📝 Session Template (For Claude)
 
 **At START of session**:
+
 ```
 ✓ Read MEMORY.md (current status)
 ✓ Check docs (README.md shows which to read)
@@ -236,6 +251,7 @@ PHASE 3 (Week 17+): UGC + Polish
 ```
 
 **During session**:
+
 ```
 ✓ Reference specific docs as needed
 ✓ Update MEMORY.md with progress
@@ -244,6 +260,7 @@ PHASE 3 (Week 17+): UGC + Polish
 ```
 
 **At END of session**:
+
 ```
 ✓ Update MEMORY.md with:
   - What was accomplished
@@ -257,24 +274,25 @@ PHASE 3 (Week 17+): UGC + Polish
 
 ## 🔗 Important Files
 
-| Path | Purpose |
-|------|---------|
-| `docs/README.md` | Index + structure overview |
-| `docs/GAME_DESIGN.md` | Full game spec |
-| `docs/FRONTEND_ARCHITECTURE.md` | All pages + components |
-| `docs/NARRATIVE_DESIGN.md` | Story standards |
-| `docs/TECH_STACK.md` | Libraries + patterns |
-| `docs/MEMORY.md` | This file - status |
-| `CLAUDE.md` | Root rules (conventions, etc.) |
-| `apps/frontend/src/` | Frontend code (when building) |
-| `apps/backend/src/` | Backend code (when building) |
-| `packages/shared/src/` | Shared types |
+| Path                            | Purpose                        |
+| ------------------------------- | ------------------------------ |
+| `docs/README.md`                | Index + structure overview     |
+| `docs/GAME_DESIGN.md`           | Full game spec                 |
+| `docs/FRONTEND_ARCHITECTURE.md` | All pages + components         |
+| `docs/NARRATIVE_DESIGN.md`      | Story standards                |
+| `docs/TECH_STACK.md`            | Libraries + patterns           |
+| `docs/MEMORY.md`                | This file - status             |
+| `CLAUDE.md`                     | Root rules (conventions, etc.) |
+| `apps/frontend/src/`            | Frontend code (when building)  |
+| `apps/backend/src/`             | Backend code (when building)   |
+| `packages/shared/src/`          | Shared types                   |
 
 ---
 
 ## 🎯 Success Criteria
 
 **MVP Success (Week 10)**:
+
 - ✅ User can create character (all 5 classes)
 - ✅ Game generates unique scenes via AI
 - ✅ Choices have visible consequences
@@ -286,6 +304,7 @@ PHASE 3 (Week 17+): UGC + Polish
 - ✅ **Player wants to play again immediately**
 
 **Phase 2B Success (Week 16)**:
+
 - ✅ NPCs reappear, remember you
 - ✅ World events add surprise
 - ✅ Class affects content (30-40% different)
@@ -301,7 +320,9 @@ If unclear: Check README.md → GAME_DESIGN.md → specific doc
 ## ⚙️ CI / GitHub Automation (Active)
 
 ### PR Labels (auto-applied)
+
 Labels are auto-applied via `actions/labeler@v5` in `.github/workflows/ci.yml` based on files changed:
+
 - `apps/frontend/**` → `frontend`, `phase-1a`
 - `apps/backend/**` → `backend`, `phase-1b`
 - `packages/**` → `shared`
@@ -309,7 +330,9 @@ Labels are auto-applied via `actions/labeler@v5` in `.github/workflows/ci.yml` b
 Config: `.github/labeler.yml`
 
 ### PR Milestones (auto-assigned)
+
 Milestones are auto-assigned via `.github/workflows/pr-metadata.yml` based on branch name:
+
 - `feature/phase-1a-*` → Phase 1A - Frontend UI
 - `feature/phase-1b-*` → Phase 1B - Backend Foundation
 - `feature/phase-2-*` → Phase 2 - MVP

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rpg-game",
+  "name": "grimoire",
   "private": true,
   "scripts": {
     "dev": "turbo dev",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rpg-game/eslint-config",
+  "name": "@grimoire/eslint-config",
   "version": "0.1.0",
   "private": true,
   "main": "index.js",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rpg-game/prettier-config",
+  "name": "@grimoire/prettier-config",
   "version": "0.1.0",
   "private": true,
   "main": "index.js",

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -1,12 +1,15 @@
 # Shared Package Agent Instructions
 
 ## Scope
+
 This agent works ONLY on `packages/shared/`. Never modify files outside this directory.
 
 ## Purpose
-Single source of truth for all TypeScript types and constants shared between frontend and backend. Published as `@rpg-game/shared`.
+
+Single source of truth for all TypeScript types and constants shared between frontend and backend. Published as `@grimoire/shared`.
 
 ## Directory Structure
+
 ```
 src/
 ├── types/              # All TypeScript interfaces & types
@@ -26,6 +29,7 @@ src/
 ```
 
 ## Rules
+
 - Types/Interfaces: `PascalCase` (e.g., `GameSession`)
 - Constants: `UPPER_SNAKE_CASE` for values, `camelCase` for helper functions
 - Files: `kebab-case.ts`
@@ -36,9 +40,11 @@ src/
 - Never import from `apps/frontend` or `apps/backend`
 
 ## When to Modify
+
 - Before implementing a new feature in backend/frontend, define types here first
 - When a backend/frontend change requires a shared contract change
 - When adding new game constants (items, skills, etc.)
 
 ## Testing
+
 - Run `pnpm type-check --filter shared` to verify types compile

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rpg-game/shared",
+  "name": "@grimoire/shared",
   "version": "0.1.0",
   "private": true,
   "main": "./src/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
 
   apps/backend:
     dependencies:
-      "@rpg-game/shared":
+      "@grimoire/shared":
         specifier: workspace:*
         version: link:../../packages/shared
       "@supabase/supabase-js":
@@ -50,10 +50,10 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
-      "@rpg-game/eslint-config":
+      "@grimoire/eslint-config":
         specifier: workspace:*
         version: link:../../packages/eslint-config
-      "@rpg-game/prettier-config":
+      "@grimoire/prettier-config":
         specifier: workspace:*
         version: link:../../packages/prettier-config
       "@types/cors":
@@ -86,7 +86,7 @@ importers:
 
   apps/frontend:
     dependencies:
-      "@rpg-game/shared":
+      "@grimoire/shared":
         specifier: workspace:*
         version: link:../../packages/shared
       "@supabase/supabase-js":
@@ -123,15 +123,15 @@ importers:
         specifier: ^5.0.0
         version: 5.0.11(@types/react@19.2.14)(react@19.2.3)
     devDependencies:
+      "@grimoire/eslint-config":
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      "@grimoire/prettier-config":
+        specifier: workspace:*
+        version: link:../../packages/prettier-config
       "@next/bundle-analyzer":
         specifier: ^15
         version: 15.5.15
-      "@rpg-game/eslint-config":
-        specifier: workspace:*
-        version: link:../../packages/eslint-config
-      "@rpg-game/prettier-config":
-        specifier: workspace:*
-        version: link:../../packages/prettier-config
       "@tailwindcss/postcss":
         specifier: ^4
         version: 4.1.18


### PR DESCRIPTION
## Summary

- Rename all `@rpg-game/*` package scopes to `@grimoire/*`
- Rename root package name from `rpg-game` to `grimoire`
- Update repo references from `EpisodeRPG-game` to `Grimoire-game` in all skills, CLAUDE.md, docs, README
- Add strict workflow rule: never commit directly to `develop`/`main`, always go through issue → branch → PR
- Regenerate `pnpm-lock.yaml` with new package names

## Test plan

- [x] `pnpm install` — lockfile regenerated
- [x] `pnpm lint` — 0 erreurs
- [x] `pnpm type-check` — 0 erreurs
- [x] `pnpm build` — frontend + backend OK

Closes #22