### PR TITLE
chore(github): GitHub enterprise setup — labels Scrum, milestones, templates, labeler, pr-metadata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS — Assignation automatique des reviewers
+# AdamDjo est l'unique reviewer sur tout le repo
+# Toute PR ouverte déclenche automatiquement une demande de review
+
+* @AdamDjo

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,54 +1,89 @@
 name: "Bug Report"
-description: "Signaler un bug"
+description: "Signaler un bug dans Grimoire"
 title: "[BUG] "
-labels: ["bug"]
+labels: ["type: bug", "status: needs-info"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Merci de remplir ce formulaire avec précision. Plus il est complet, plus le fix sera rapide.
+
   - type: textarea
     id: description
     attributes:
-      label: Description du bug
-      description: "Que se passe-t-il ?"
+      label: "Description du bug"
+      description: "Que se passe-t-il ? Quel était le comportement attendu ?"
     validations:
       required: true
 
   - type: textarea
     id: reproduce
     attributes:
-      label: Étapes pour reproduire
+      label: "Étapes pour reproduire"
       placeholder: |
-        1. Aller sur ...
+        1. Aller sur la page ...
         2. Cliquer sur ...
-        3. Observer ...
+        3. Observer l'erreur ...
     validations:
       required: true
 
   - type: textarea
     id: expected
     attributes:
-      label: Comportement attendu
+      label: "Comportement attendu"
     validations:
       required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Logs / Stack trace"
+      description: "Coller ici les erreurs de la console navigateur ou du terminal"
+      render: shell
 
   - type: dropdown
     id: domain
     attributes:
-      label: Domaine
+      label: "Domaine affecté"
       options:
         - "frontend"
         - "backend"
         - "shared"
         - "ai"
         - "database"
+        - "devops"
     validations:
       required: true
 
   - type: dropdown
     id: severity
     attributes:
-      label: Sévérité
+      label: "Sévérité"
       options:
-        - "critical - bloque le jeu"
-        - "major - fonctionnalité cassée"
-        - "minor - cosmétique ou mineur"
+        - "critical — bloque totalement le jeu"
+        - "major — fonctionnalité importante cassée"
+        - "minor — cosmétique ou cas rare"
     validations:
       required: true
+
+  - type: dropdown
+    id: reproducibility
+    attributes:
+      label: "Reproductibilité"
+      options:
+        - "Toujours (100%)"
+        - "Souvent (>50%)"
+        - "Parfois (<50%)"
+        - "Rare (une seule fois)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: "Environnement"
+      placeholder: |
+        - OS: macOS 15 / Windows 11 / Ubuntu 22
+        - Navigateur: Chrome 121 / Firefox 123
+        - Node: 20.x
+        - URL concernée: /game/session/xxx

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,64 @@
+name: "Chore / Tooling"
+description: "Maintenance, refacto, mise à jour de dépendances, CI/CD"
+title: "[CHORE] "
+labels: ["type: chore", "domain: devops"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: "Type de chore"
+      options:
+        - "Refactoring (pas de changement de comportement)"
+        - "Mise à jour de dépendance"
+        - "Configuration CI/CD"
+        - "Amélioration de tooling"
+        - "Nettoyage de code"
+        - "Mise à jour documentation"
+        - "Rename / restructuration"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: "Domaine"
+      options:
+        - "devops"
+        - "frontend"
+        - "backend"
+        - "shared"
+
+  - type: dropdown
+    id: size
+    attributes:
+      label: "Taille estimée"
+      options:
+        - "XS — ~1h (1pt)"
+        - "S — ~2h (2pt)"
+        - "M — ~4h (3pt)"
+        - "L — ~1 jour (5pt)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: "Qu'est-ce qui doit être fait et pourquoi ?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: "Impact attendu"
+      description: "Qu'est-ce que ça améliore concrètement ?"
+
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: "Vérifications"
+      options:
+        - label: "Pas de changement de comportement fonctionnel"
+        - label: "Les tests passent après le changement"
+        - label: "CI/CD non cassé"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation du projet
-    url: https://github.com/AdamDjo/EpisodeRPG-game/tree/main/docs
-    about: Lire la documentation avant de créer une issue
+    url: https://github.com/AdamDjo/Grimoire-game/tree/main/docs
+    about: Lire la documentation technique avant de créer une issue
+  - name: Wiki — Workflow & Labels
+    url: https://github.com/AdamDjo/Grimoire-game/wiki
+    about: Guide complet du workflow Git, labels Scrum et CI/CD

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,80 @@
+name: "Demande de fonctionnalité"
+description: "Proposer une nouvelle fonctionnalité pour Grimoire"
+title: "[FEATURE] "
+labels: ["type: feature", "status: needs-info"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Décris la fonctionnalité souhaitée en précisant la phase et le domaine concernés.
+
+  - type: dropdown
+    id: phase
+    attributes:
+      label: "Phase cible"
+      options:
+        - "Phase 1A - Frontend UI (Week 1-5)"
+        - "Phase 1B - Backend Foundation (Week 4-6)"
+        - "Phase 2 - Integration (Week 7-10)"
+        - "Phase 2B - Multi-Universe (Week 11-16)"
+        - "Phase 3 - Polish & UGC (Week 17+)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: "Domaine"
+      options:
+        - "frontend"
+        - "backend"
+        - "shared"
+        - "ai"
+        - "database"
+        - "devops"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "Priorité estimée"
+      options:
+        - "critical — bloque d'autres tâches"
+        - "high — sprint courant"
+        - "medium — backlog planifié"
+        - "low — backlog diffus"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: "Problème à résoudre"
+      description: "Quel besoin ou manque cette fonctionnalité adresse-t-elle ?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: "Solution proposée"
+      description: "Comment tu imagines que ça devrait fonctionner ?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "Alternatives considérées"
+      description: "Y a-t-il d'autres approches possibles ?"
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "Critères d'acceptation"
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/phase-task.yml
+++ b/.github/ISSUE_TEMPLATE/phase-task.yml
@@ -1,17 +1,17 @@
 name: "Tâche de Phase"
 description: "Tâche de développement liée à une phase du projet"
 title: "[PHASE] "
-labels: ["enhancement"]
+labels: ["type: feature"]
 body:
   - type: dropdown
     id: phase
     attributes:
-      label: Phase
+      label: "Phase"
       options:
         - "Phase 1A - Frontend UI (Week 1-5)"
         - "Phase 1B - Backend Foundation (Week 4-6)"
         - "Phase 2 - Integration (Week 7-10)"
-        - "Phase 2B - Addictive Features (Week 11-16)"
+        - "Phase 2B - Multi-Universe (Week 11-16)"
         - "Phase 3 - Polish & UGC (Week 17+)"
     validations:
       required: true
@@ -19,7 +19,7 @@ body:
   - type: dropdown
     id: domain
     attributes:
-      label: Domaine
+      label: "Domaine"
       options:
         - "frontend"
         - "backend"
@@ -30,10 +30,36 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "Priorité"
+      options:
+        - "critical — bloque d'autres tâches"
+        - "high — sprint courant"
+        - "medium — semaine courante"
+        - "low — backlog"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: size
+    attributes:
+      label: "Taille estimée"
+      options:
+        - "XS — ~1h (1pt)"
+        - "S — ~2h (2pt)"
+        - "M — ~4h (3pt)"
+        - "L — ~1 jour (5pt)"
+        - "XL — ~2-3 jours (8pt)"
+        - "XXL — à découper (13pt)"
+    validations:
+      required: true
+
   - type: textarea
     id: description
     attributes:
-      label: Description
+      label: "Description"
       description: "Qu'est-ce qui doit être fait ? Quel est le contexte ?"
     validations:
       required: true
@@ -41,7 +67,7 @@ body:
   - type: textarea
     id: acceptance
     attributes:
-      label: Critères d'acceptation
+      label: "Critères d'acceptation"
       description: "Comment savoir que c'est terminé ?"
       placeholder: |
         - [ ] ...
@@ -50,9 +76,16 @@ body:
       required: true
 
   - type: textarea
+    id: dependencies
+    attributes:
+      label: "Dépendances"
+      description: "Issues qui doivent être closes avant celle-ci"
+      placeholder: "Aucune / Closes #12, #15"
+
+  - type: textarea
     id: files
     attributes:
-      label: Fichiers concernés
+      label: "Fichiers concernés"
       placeholder: |
         - apps/frontend/src/...
         - apps/backend/src/...
@@ -61,7 +94,7 @@ body:
   - type: dropdown
     id: week
     attributes:
-      label: Semaine cible
+      label: "Semaine cible"
       options:
         - "Week 1"
         - "Week 2"

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,33 +1,46 @@
-## Summary
+## Résumé
 
-<!-- Describe in 1-3 sentences what this PR does -->
+<!-- Décris en 1-3 phrases ce que fait cette PR -->
 
-## Related issue(s)
+## Issue(s) liée(s)
 
-Closes #<!-- issue number -->
+Closes #<!-- numéro d'issue -->
 
-## Type of change
+## Type de changement
 
-- [ ] New feature (Phase 1A / 1B / 2 / 2B / 3)
+- [ ] Nouvelle fonctionnalité (phase concernée : ___)
 - [ ] Bug fix
-- [ ] Refactoring (no behavior change)
-- [ ] Config / DevOps
-- [ ] Documentation
+- [ ] Refactoring (aucun changement de comportement)
+- [ ] Chore / Tooling / Config
+- [ ] Documentation uniquement
 
-## Checklist
+## Phase & Domaine
 
-- [ ] Code follows project conventions (`CLAUDE.md`)
-- [ ] Shared types are in `packages/shared` (not duplicated)
-- [ ] `pnpm type-check` passes
-- [ ] `pnpm lint` passes
-- [ ] No forgotten `console.log`
-- [ ] Manually tested
+- **Phase** : <!-- phase: 1a / 1b / 2 / 2b / 3 -->
+- **Domaine** : <!-- domain: frontend / backend / shared / ai / database / devops -->
 
-## Screenshots (frontend only)
+## Checklist technique
 
-<!-- Before/after screenshot if UI change -->
+- [ ] Code suit les conventions `CLAUDE.md` (naming, patterns)
+- [ ] Types partagés dans `packages/shared` (jamais dupliqués)
+- [ ] `pnpm type-check` passe sans erreur
+- [ ] `pnpm lint` passe sans erreur
+- [ ] Aucun `console.log` oublié
+- [ ] Testé manuellement (décrire ci-dessous)
+
+## Test manuel effectué
+
+<!-- Décris comment tu as testé cette PR -->
+<!-- ex: "Lancé pnpm dev, navigué sur /game, vérifié que les stats s'affichent" -->
+
+## Captures d'écran (frontend uniquement)
+
+<!-- Avant / Après si changement d'UI — supprimer si non applicable -->
+
+## Notes pour la review
+
+<!-- Points d'attention, compromis techniques, décisions prises -->
 
 ---
 
-> **Labels** and **milestone** are assigned automatically based on files changed and branch name.
-> No need to set them manually.
+> Labels et milestone assignés automatiquement via CI selon les fichiers modifiés et le nom de branche.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,17 +1,39 @@
-frontend:
+# Auto-labeling des PRs selon les fichiers modifiés
+# Labels préfixés par catégorie (domain:, phase:)
+
+# --- DOMAINES ---
+"domain: frontend":
   - any: ['apps/frontend/**']
 
-backend:
+"domain: backend":
   - any: ['apps/backend/**']
 
-shared:
+"domain: shared":
   - any:
       - 'packages/shared/**'
       - 'packages/eslint-config/**'
       - 'packages/prettier-config/**'
 
-phase-1a:
+"domain: devops":
+  - any:
+      - '.github/**'
+      - 'turbo.json'
+      - 'pnpm-workspace.yaml'
+      - 'knip.config.ts'
+      - 'commitlint.config.js'
+      - '.husky/**'
+      - '.lintstagedrc.js'
+
+"type: docs":
+  - any:
+      - 'docs/**'
+      - '*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+
+# --- PHASES (par dossier, pour auto-assign milestone) ---
+"phase: 1a":
   - any: ['apps/frontend/**']
 
-phase-1b:
+"phase: 1b":
   - any: ['apps/backend/**']

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -18,15 +18,16 @@ jobs:
           BRANCH: ${{ github.head_ref }}
           REPO: ${{ github.repository }}
         run: |
-          if [[ "$BRANCH" == feature/phase-1a-* ]]; then
+          # Support feature/*, fix/*, hotfix/* branches with phase pattern
+          if [[ "$BRANCH" == feature/phase-1a-* ]] || [[ "$BRANCH" == fix/phase-1a-* ]] || [[ "$BRANCH" == hotfix/phase-1a-* ]]; then
             MILESTONE="Phase 1A - Frontend UI"
-          elif [[ "$BRANCH" == feature/phase-1b-* ]]; then
+          elif [[ "$BRANCH" == feature/phase-1b-* ]] || [[ "$BRANCH" == fix/phase-1b-* ]] || [[ "$BRANCH" == hotfix/phase-1b-* ]]; then
             MILESTONE="Phase 1B - Backend Foundation"
-          elif [[ "$BRANCH" == feature/phase-2b-* ]]; then
+          elif [[ "$BRANCH" == feature/phase-2b-* ]] || [[ "$BRANCH" == fix/phase-2b-* ]] || [[ "$BRANCH" == hotfix/phase-2b-* ]]; then
             MILESTONE="Phase 2B - Multi-Universe"
-          elif [[ "$BRANCH" == feature/phase-2-* ]]; then
+          elif [[ "$BRANCH" == feature/phase-2-* ]] || [[ "$BRANCH" == fix/phase-2-* ]] || [[ "$BRANCH" == hotfix/phase-2-* ]]; then
             MILESTONE="Phase 2 - MVP"
-          elif [[ "$BRANCH" == feature/phase-3-* ]]; then
+          elif [[ "$BRANCH" == feature/phase-3-* ]] || [[ "$BRANCH" == fix/phase-3-* ]] || [[ "$BRANCH" == hotfix/phase-3-* ]]; then
             MILESTONE="Phase 3 - Polish & UGC"
           else
             echo "No milestone to assign for branch: $BRANCH"


### PR DESCRIPTION
## Résumé

Configuration complète du repo GitHub selon un standard enterprise/Scrum réutilisable sur tous les projets futurs.

## Issue liée

Closes #30

## Type de changement

- [x] Chore / Tooling / Config

## Phase & Domaine

- **Phase** : N/A (tooling)
- **Domaine** : domain: devops

## Ce qui a été fait

### Labels (32 labels créés directement via API)
- Catégorie `type:` (7) — feature, bug, chore, docs, test, release, security
- Catégorie `priority:` (4) — critical, high, medium, low
- Catégorie `size:` (6) — XS à XXL avec story points
- Catégorie `status:` (5) — blocked, in-review, wip, needs-info, duplicate
- Catégorie `domain:` (6) — frontend, backend, shared, ai, database, devops
- Catégorie `phase:` (5) — 1a, 1b, 2, 2b, 3
- Anciens labels non préfixés supprimés

### Milestones (5 créées directement via API)
- Phase 1A → Phase 3 avec dates

### Project Board (créé directement via API)
- `Scrum Board` générique (réutilisable sur tous projets futurs)
- Champs : Priority, Size, Type, Effort (h)
- Lié au repo Grimoire-game

### Issue Templates (`.github/ISSUE_TEMPLATE/`)
- `bug-report.yml` — ajout logs, environment, reproductibilité
- `phase-task.yml` — ajout priorité, taille, dépendances
- `feature-request.yml` — nouveau template complet
- `chore.yml` — nouveau template maintenance/tooling
- `config.yml` — lien Wiki ajouté, URL repo corrigée

### PR Template
- `pull_request_template.md` — ajout Phase/Domaine, test manuel, notes review

### labeler.yml
- Ajout `domain: devops` (`.github/`, `turbo.json`, configs)
- Ajout `type: docs` (`docs/`, `*.md`, templates)

### pr-metadata.yml
- Support `fix/*` et `hotfix/*` en plus de `feature/*` pour l'auto-assign milestone

## Checklist technique

- [x] Aucun changement de comportement fonctionnel
- [x] CI/CD non cassé
- [x] Templates valides YAML