### PR TITLE
chore(ci): refactor GitHub Actions — CI pur, pr.yml, fix pnpm install

### DIFF
--- a/.claude/skills/bug/SKILL.md
+++ b/.claude/skills/bug/SKILL.md
@@ -14,17 +14,25 @@ Exécuter dans l'ordre :
    - Demander : "Décris le bug en une phrase (pour l'issue GitHub)"
    - Créer l'issue via mcp**github**create_issue avec :
      - owner: AdamDjo, repo: Grimoire-game
-     - labels: ["bug"]
-     - title: "fix(<args>): <description du bug>"
+     - title: "fix: <description du bug>"
+     - labels: ["type: bug"]
+     - assignees: ["AdamDjo"]
    - Noter le numéro de l'issue créée → `<numéro>`
 
-2. **Mettre develop à jour**
+2. **Ajouter l'issue au projet Scrum Board**
+
+   ```bash
+   ISSUE_NODE_ID=$(gh api repos/AdamDjo/Grimoire-game/issues/<numéro> --jq '.node_id')
+   gh api graphql -f query='mutation { addProjectV2ItemById(input: { projectId: "PVT_kwHOAacnj84BU6rS" contentId: "'$ISSUE_NODE_ID'" }) { item { id } } }'
+   ```
+
+3. **Mettre develop à jour**
 
    ```bash
    git checkout develop && git pull origin develop
    ```
 
-3. **Créer la branche avec le numéro d'issue**
+4. **Créer la branche avec le numéro d'issue**
 
    ```bash
    git checkout -b fix/<numéro>-<args>
@@ -32,10 +40,10 @@ Exécuter dans l'ordre :
 
    Exemple : issue #30 + args "login-crash" → `fix/30-login-crash`
 
-4. **Confirmer à l'utilisateur :**
+5. **Confirmer à l'utilisateur :**
 
    ```
-   ✅ Issue #<numéro> créée
+   ✅ Issue #<numéro> créée — assignée à AdamDjo, ajoutée au Scrum Board
    ✅ Branche 'fix/<numéro>-<args>' créée depuis develop
 
    Workflow :

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -12,20 +12,34 @@ Exécuter dans l'ordre :
 
 1. **Créer l'issue GitHub**
    - Demander : "Décris la feature en une phrase (pour l'issue GitHub)"
-   - Demander : "Quels labels ? (ex: frontend, backend, phase-1a, phase-1b...)"
+   - Déduire les labels depuis le nom de branche (nomenclature avec préfixe catégorie) :
+     - `*phase-1a*` → `["type: chore", "phase: 1a", "domain: frontend"]`
+     - `*phase-1b*` → `["type: chore", "phase: 1b", "domain: backend"]`
+     - `*phase-2b*` → `["type: chore", "phase: 2b"]`
+     - `*phase-2*` → `["type: chore", "phase: 2"]`
+     - `*phase-3*` → `["type: chore", "phase: 3"]`
+     - Sinon → `["type: chore"]`
    - Créer l'issue via mcp**github**create_issue avec :
      - owner: AdamDjo, repo: Grimoire-game
-     - title: "feat(<args>): <description>"
-     - labels fournis par l'utilisateur
+     - title: "feat: <description>"
+     - labels déduits ci-dessus
+     - assignees: ["AdamDjo"]
    - Noter le numéro de l'issue créée → `<numéro>`
 
-2. **Mettre develop à jour**
+2. **Ajouter l'issue au projet Scrum Board**
+
+   ```bash
+   ISSUE_NODE_ID=$(gh api repos/AdamDjo/Grimoire-game/issues/<numéro> --jq '.node_id')
+   gh api graphql -f query='mutation { addProjectV2ItemById(input: { projectId: "PVT_kwHOAacnj84BU6rS" contentId: "'$ISSUE_NODE_ID'" }) { item { id } } }'
+   ```
+
+3. **Mettre develop à jour**
 
    ```bash
    git checkout develop && git pull origin develop
    ```
 
-3. **Créer la branche avec le numéro d'issue**
+4. **Créer la branche avec le numéro d'issue**
 
    ```bash
    git checkout -b feature/<numéro>-<args>
@@ -33,10 +47,10 @@ Exécuter dans l'ordre :
 
    Exemple : issue #29 + args "phase-1a-landing-page" → `feature/29-phase-1a-landing-page`
 
-4. **Confirmer à l'utilisateur :**
+5. **Confirmer à l'utilisateur :**
 
    ```
-   ✅ Issue #<numéro> créée
+   ✅ Issue #<numéro> créée — assignée à AdamDjo, ajoutée au Scrum Board
    ✅ Branche 'feature/<numéro>-<args>' créée depuis develop
 
    Workflow :

--- a/.claude/skills/hotfix/SKILL.md
+++ b/.claude/skills/hotfix/SKILL.md
@@ -14,17 +14,25 @@ Exécuter dans l'ordre :
    - Demander : "Décris le problème en production en une phrase"
    - Créer l'issue via mcp**github**create_issue avec :
      - owner: AdamDjo, repo: Grimoire-game
-     - labels: ["bug", "priority"]
-     - title: "hotfix(<args>): <description>"
+     - title: "hotfix: <description>"
+     - labels: ["type: bug", "priority: high"]
+     - assignees: ["AdamDjo"]
    - Noter le numéro de l'issue créée → `<numéro>`
 
-2. **Partir de main (pas develop — c'est urgent)**
+2. **Ajouter l'issue au projet Scrum Board**
+
+   ```bash
+   ISSUE_NODE_ID=$(gh api repos/AdamDjo/Grimoire-game/issues/<numéro> --jq '.node_id')
+   gh api graphql -f query='mutation { addProjectV2ItemById(input: { projectId: "PVT_kwHOAacnj84BU6rS" contentId: "'$ISSUE_NODE_ID'" }) { item { id } } }'
+   ```
+
+3. **Partir de main (pas develop — c'est urgent)**
 
    ```bash
    git checkout main && git pull origin main
    ```
 
-3. **Créer la branche hotfix avec le numéro d'issue**
+4. **Créer la branche hotfix avec le numéro d'issue**
 
    ```bash
    git checkout -b hotfix/<numéro>-<args>
@@ -32,12 +40,12 @@ Exécuter dans l'ordre :
 
    Exemple : issue #31 + args "auth-crash" → `hotfix/31-auth-crash`
 
-4. **Confirmer à l'utilisateur :**
+5. **Confirmer à l'utilisateur :**
 
    ```
    ⚠️  HOTFIX — tu pars de main (production)
 
-   ✅ Issue #<numéro> créée (priority)
+   ✅ Issue #<numéro> créée — assignée à AdamDjo, ajoutée au Scrum Board
    ✅ Branche 'hotfix/<numéro>-<args>' créée depuis main
 
    Workflow :

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -22,6 +22,7 @@ Exécuter dans l'ordre :
 3. **Déterminer la branche cible selon le préfixe :**
    - `feature/*` → cible : `develop`
    - `fix/*` → cible : `develop`
+   - `chore/*` → cible : `develop`
    - `hotfix/*` → cible : `main`
    - `release/*` → cible : `main`
 
@@ -53,18 +54,53 @@ Exécuter dans l'ordre :
      Closes #<numéro issue>
      ```
 
-7. **Déterminer les labels selon le préfixe de branche :**
-   - `feature/*phase-1a*` → `["frontend", "phase-1a"]`
-   - `feature/*phase-1b*` → `["backend", "phase-1b"]`
-   - `feature/*phase-2*` → `["frontend", "backend", "phase-2"]`
-   - `fix/*` → `["bug"]`
-   - `hotfix/*` → `["bug", "priority"]`
-   - `release/*` → `["release"]`
+7. **Déterminer les labels selon le préfixe de branche (nomenclature avec préfixe catégorie) :**
+   - `feature/*phase-1a*` ou fichiers dans `apps/frontend/` → `["phase: 1a", "domain: frontend"]`
+   - `feature/*phase-1b*` ou fichiers dans `apps/backend/` → `["phase: 1b", "domain: backend"]`
+   - `feature/*phase-2b*` → `["phase: 2b"]`
+   - `feature/*phase-2*` → `["phase: 2"]`
+   - `feature/*phase-3*` → `["phase: 3"]`
+   - `fix/*` → `["type: bug"]`
+   - `hotfix/*` → `["type: bug", "priority: high"]`
+   - `chore/*` → `["type: chore"]`
+   - `release/*` → `["type: release"]`
+   - Ajouter `domain: devops` si les fichiers modifiés sont dans `.github/`
+   - Ajouter `domain: shared` si les fichiers modifiés sont dans `packages/`
 
 8. **Créer la PR via mcp**github**create_pull_request**
-   - owner: AdamDjo
-   - repo: Grimoire-game
+   - owner: `AdamDjo`
+   - repo: `Grimoire-game`
    - head: branche courante
    - base: cible déterminée à l'étape 3
+   - assignees: `["AdamDjo"]`
+   - reviewers: `["AdamDjo"]` — TOUJOURS assigner AdamDjo comme reviewer
 
-9. **Confirmer à l'utilisateur avec l'URL de la PR**
+9. **Assigner la PR au projet Scrum Board et au milestone via CLI**
+
+   ```bash
+   # Récupérer le node_id de la PR
+   PR_NODE_ID=$(gh api repos/AdamDjo/Grimoire-game/pulls/<PR_NUMBER> --jq '.node_id')
+
+   # Ajouter au projet Scrum Board (Projects V2)
+   gh api graphql -f query='
+   mutation {
+     addProjectV2ItemById(input: {
+       projectId: "PVT_kwHOAacnj84BU6rS"
+       contentId: "'$PR_NODE_ID'"
+     }) {
+       item { id }
+     }
+   }'
+
+   # Assigner le milestone selon le pattern de branche (même logique que pr.yml)
+   # feature/*phase-1a* → "Phase 1A - Frontend UI"
+   # feature/*phase-1b* → "Phase 1B - Backend Foundation"
+   # feature/*phase-2b* → "Phase 2B - Multi-Universe"
+   # feature/*phase-2* → "Phase 2 - MVP"
+   # feature/*phase-3* → "Phase 3 - Polish & UGC"
+   MILESTONE_NUMBER=$(gh api repos/AdamDjo/Grimoire-game/milestones --jq '.[] | select(.title == "<MILESTONE_TITLE>") | .number')
+   gh api repos/AdamDjo/Grimoire-game/issues/<PR_NUMBER> --method PATCH --field milestone=$MILESTONE_NUMBER
+   ```
+
+10. **Confirmer à l'utilisateur avec l'URL de la PR**
+    - Indiquer : assignee ✅, reviewer ✅, project ✅, milestone ✅ (ou "pas de milestone pour cette branche")

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,3 @@
-# Auto-labeling des PRs selon les fichiers modifiés
-# Syntaxe actions/labeler@v5 — changed-files avec any-glob-to-any-file
-
-# --- DOMAINES ---
 "domain: frontend":
   - changed-files:
       - any-glob-to-any-file: ["apps/frontend/**"]
@@ -36,7 +32,6 @@
           - ".github/ISSUE_TEMPLATE/**"
           - ".github/PULL_REQUEST_TEMPLATE/**"
 
-# --- PHASES ---
 "phase: 1a":
   - changed-files:
       - any-glob-to-any-file: ["apps/frontend/**"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      - name: Install pnpm
+        run: npm install -g pnpm@9.15.0
 
       - uses: actions/setup-node@v4
         with:
@@ -33,18 +34,6 @@ jobs:
         run: pnpm audit --audit-level=high
         continue-on-error: true
 
-  label:
-    name: Auto Label
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/labeler@v5
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -52,7 +41,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      - name: Install pnpm
+        run: npm install -g pnpm@9.15.0
 
       - uses: actions/setup-node@v4
         with:
@@ -72,7 +62,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      - name: Install pnpm
+        run: npm install -g pnpm@9.15.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,10 +1,21 @@
-name: PR Metadata
+name: PR Automation
 
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
 
 jobs:
+  label:
+    name: Auto Label
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
   milestone:
     name: Assign Milestone
     runs-on: ubuntu-latest
@@ -18,7 +29,6 @@ jobs:
           BRANCH: ${{ github.head_ref }}
           REPO: ${{ github.repository }}
         run: |
-          # Support feature/*, fix/*, hotfix/* branches with phase pattern
           if [[ "$BRANCH" == feature/phase-1a-* ]] || [[ "$BRANCH" == fix/phase-1a-* ]] || [[ "$BRANCH" == hotfix/phase-1a-* ]]; then
             MILESTONE="Phase 1A - Frontend UI"
           elif [[ "$BRANCH" == feature/phase-1b-* ]] || [[ "$BRANCH" == fix/phase-1b-* ]] || [[ "$BRANCH" == hotfix/phase-1b-* ]]; then


### PR DESCRIPTION
## Summary

- **`ci.yml`** : suppression du job `label` — uniquement lint + typecheck + test + build. Remplace `pnpm/action-setup@v4` (cassé) par `npm install -g pnpm@9.15.0`
- **`pr.yml`** (nouveau) : regroupe auto-label + assignation milestone, déclenché uniquement sur `pull_request`
- **`pr-metadata.yml`** : supprimé, fusionné dans `pr.yml`
- **Skills `/pr`, `/feature`, `/bug`, `/hotfix`** : assignee + reviewer (AdamDjo) + projet Scrum Board + milestone + labels avec nomenclature préfixée sur toutes les PRs et issues

## Test plan

- [x] CI vert sur la PR (lint + typecheck + test + build)
- [x] PR Automation vert (labeler + milestone)
- [x] CodeQL vert

Closes #34