### PR TITLE
chore(docker): add Dockerfile for frontend/backend and docker-compose

### DIFF
--- a/apps/backend/.dockerignore
+++ b/apps/backend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.env
+.env.*
+!.env.example
+coverage
+*.log

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,11 +2,6 @@
 PORT=3001
 FRONTEND_URL=http://localhost:3000
 
-# PostgreSQL (Docker local)
-POSTGRES_USER=grimoire
-POSTGRES_PASSWORD=change-me-locally
-POSTGRES_DB=grimoire
-
 # Supabase
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_KEY=your-service-role-key

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,6 +2,11 @@
 PORT=3001
 FRONTEND_URL=http://localhost:3000
 
+# PostgreSQL (Docker local)
+POSTGRES_USER=grimoire
+POSTGRES_PASSWORD=change-me-locally
+POSTGRES_DB=grimoire
+
 # Supabase
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_KEY=your-service-role-key

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,6 +2,11 @@
 PORT=3001
 FRONTEND_URL=http://localhost:3000
 
+# PostgreSQL (Docker local — rempli avec tes propres valeurs)
+POSTGRES_USER=
+POSTGRES_PASSWORD=
+POSTGRES_DB=
+
 # Supabase
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_KEY=your-service-role-key

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:20-alpine AS base
+RUN npm install -g pnpm@9.15.0
+WORKDIR /app
+
+FROM base AS deps
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY packages/eslint-config/package.json ./packages/eslint-config/
+COPY packages/prettier-config/package.json ./packages/prettier-config/
+COPY packages/shared/package.json ./packages/shared/
+COPY apps/backend/package.json ./apps/backend/
+RUN pnpm install --frozen-lockfile
+
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/backend/node_modules ./apps/backend/node_modules
+COPY packages/ ./packages/
+COPY apps/backend/ ./apps/backend/
+COPY turbo.json ./
+RUN pnpm --filter backend build
+
+FROM node:20-alpine AS runner
+RUN npm install -g pnpm@9.15.0
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=builder /app/apps/backend/dist ./dist
+COPY --from=builder /app/apps/backend/package.json ./
+COPY --from=deps /app/apps/backend/node_modules ./node_modules
+
+EXPOSE 3001
+CMD ["node", "dist/index.js"]

--- a/apps/frontend/.dockerignore
+++ b/apps/frontend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+.env
+.env.*
+!.env.example
+coverage
+*.log
+cypress/screenshots
+cypress/videos

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:20-alpine AS base
+RUN npm install -g pnpm@9.15.0
+WORKDIR /app
+
+FROM base AS deps
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY packages/eslint-config/package.json ./packages/eslint-config/
+COPY packages/prettier-config/package.json ./packages/prettier-config/
+COPY packages/shared/package.json ./packages/shared/
+COPY apps/frontend/package.json ./apps/frontend/
+RUN pnpm install --frozen-lockfile
+
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/frontend/node_modules ./apps/frontend/node_modules
+COPY packages/ ./packages/
+COPY apps/frontend/ ./apps/frontend/
+COPY turbo.json ./
+ENV NEXT_TELEMETRY_DISABLED=1
+ARG DOCKER_BUILD=true
+ENV DOCKER_BUILD=${DOCKER_BUILD}
+RUN pnpm --filter frontend build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+COPY --from=builder /app/apps/frontend/.next/standalone ./
+COPY --from=builder /app/apps/frontend/.next/static ./apps/frontend/.next/static
+COPY --from=builder /app/apps/frontend/public ./apps/frontend/public
+
+EXPOSE 3000
+CMD ["node", "apps/frontend/server.js"]

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -7,7 +7,7 @@ const withBundleAnalyzer = bundleAnalyzer({
 })
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: process.env.DOCKER_BUILD === 'true' ? 'standalone' : undefined,
 }
 
 export default withBundleAnalyzer(nextConfig)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,4 @@
 services:
-  postgres:
-    image: postgres:16-alpine
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER:-grimoire}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your .env}
-      POSTGRES_DB: ${POSTGRES_DB:-grimoire}
-    ports:
-      - "5432:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-grimoire}"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-
   backend:
     build:
       context: .
@@ -29,9 +12,6 @@ services:
       SUPABASE_SERVICE_KEY: ${SUPABASE_SERVICE_KEY}
     ports:
       - "3001:3001"
-    depends_on:
-      postgres:
-        condition: service_healthy
 
   frontend:
     build:
@@ -49,6 +29,3 @@ services:
       - "3000:3000"
     depends_on:
       - backend
-
-volumes:
-  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,15 @@ services:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_USER: grimoire
-      POSTGRES_PASSWORD: grimoire
-      POSTGRES_DB: grimoire
+      POSTGRES_USER: ${POSTGRES_USER:-grimoire}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in your .env}
+      POSTGRES_DB: ${POSTGRES_DB:-grimoire}
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U grimoire"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-grimoire}"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,21 @@
 services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   backend:
     build:
       context: .
@@ -12,6 +29,9 @@ services:
       SUPABASE_SERVICE_KEY: ${SUPABASE_SERVICE_KEY}
     ports:
       - "3001:3001"
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   frontend:
     build:
@@ -29,3 +49,6 @@ services:
       - "3000:3000"
     depends_on:
       - backend
+
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: grimoire
+      POSTGRES_PASSWORD: grimoire
+      POSTGRES_DB: grimoire
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U grimoire"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: .
+      dockerfile: apps/backend/Dockerfile
+    restart: unless-stopped
+    environment:
+      NODE_ENV: development
+      PORT: 3001
+      FRONTEND_URL: http://localhost:3000
+      SUPABASE_URL: ${SUPABASE_URL}
+      SUPABASE_SERVICE_KEY: ${SUPABASE_SERVICE_KEY}
+    ports:
+      - "3001:3001"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: .
+      dockerfile: apps/frontend/Dockerfile
+      args:
+        DOCKER_BUILD: "true"
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      NEXT_PUBLIC_API_URL: http://localhost:3001
+      NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary

- Ajout de `Dockerfile` multi-stage (Node 20 Alpine) pour `apps/frontend` et `apps/backend`
- Ajout de `docker-compose.yml` à la racine : frontend + backend + PostgreSQL 16
- Ajout des `.dockerignore` dans chaque app
- `DOCKER_BUILD` env var active le mode `standalone` de Next.js uniquement pour les builds Docker (sans impact sur `pnpm dev`)

## Test plan

- [ ] `lint` + `type-check` passent
- [ ] `docker-compose up --build` démarre les 3 services sans erreur
- [ ] `http://localhost:3000` répond (frontend)
- [ ] `http://localhost:3001/api/health` répond `{ status: 'ok' }` (backend)
- [ ] PostgreSQL accessible sur le port 5432

Closes #41