### PR TITLE
docs: add CONTRIBUTING.md and SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing
+
+## Prerequisites
+
+- Node 20+
+- pnpm 9+
+- Git
+
+## Getting started
+
+```bash
+git clone https://github.com/AdamDjo/Grimoire-game.git
+cd Grimoire-game
+bash scripts/setup.sh
+```
+
+Fill in `apps/backend/.env` and `apps/frontend/.env.local`, then:
+
+```bash
+pnpm dev
+```
+
+## Branch naming
+
+```
+feature/<issue>-<description>   # new feature
+fix/<issue>-<description>        # bug fix
+hotfix/<issue>-<description>     # urgent production fix
+release/<semver>                 # release candidate
+```
+
+Always create a GitHub issue before branching. With Claude Code, use `/feature`, `/bug`, or `/hotfix` — they create the issue and branch automatically.
+
+## Commit format
+
+We use [Conventional Commits](https://www.conventionalcommits.org):
+
+```
+feat(scope): add something new
+fix(scope): correct a bug
+chore(scope): tooling or config change
+docs(scope): documentation only
+refactor(scope): no behavior change
+test(scope): add or update tests
+```
+
+Rules:
+
+- No `Co-Authored-By: Claude` lines
+- Keep the subject under 72 characters
+- Reference the issue in the body: `Closes #42`
+
+## Workflow
+
+1. Create an issue (or use `/feature <name>`)
+2. Branch from `develop`
+3. Commit with conventional format
+4. Open a PR → `develop` (use `/pr`)
+5. CI must pass before merge
+
+## Useful commands
+
+```bash
+pnpm dev             # start all apps
+pnpm lint            # lint all
+pnpm type-check      # TypeScript check all
+pnpm test            # unit tests
+pnpm build           # build all
+```
+
+## Code conventions
+
+See [CLAUDE.md](./CLAUDE.md) for the full conventions (naming, imports, architecture rules).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | ✅        |
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Please report them via [GitHub Private Security Advisory](https://github.com/AdamDjo/Grimoire-game/security/advisories/new) or by emailing **adem.benmessaoud.dev@gmail.com**.
+
+Include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+You can expect an acknowledgement within **48 hours** and a resolution timeline within **7 days** for critical issues.


### PR DESCRIPTION
## Summary

- Ajout de `CONTRIBUTING.md` — guide de contribution : prérequis, branch naming, commit format, workflow issue → branche → PR, commandes utiles
- Ajout de `SECURITY.md` — politique de signalement de failles via GitHub Private Advisory ou email, SLA 48h acknowledgement / 7j résolution

## Test plan

- [ ] GitHub affiche le lien "Contributing guidelines" sur les nouvelles issues/PRs
- [ ] GitHub affiche `SECURITY.md` dans l'onglet Security du repo
- [ ] Contenu relié au workflow existant (commits, branches, skills Claude)

Closes #43