### PR TITLE
chore(github): disable CODEOWNERS for solo project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
-# CODEOWNERS — Assignation automatique des reviewers
-# AdamDjo est l'unique reviewer sur tout le repo
-# Toute PR ouverte déclenche automatiquement une demande de review
+# CODEOWNERS — désactivé pour projet solo
+# GitHub Enterprise uniquement supporte le bypass par acteur.
+# Sur repo personnel, CODEOWNERS force le reviewer même pour le propriétaire.
+# Réactiver si le projet passe en organisation ou avec des collaborateurs.
 
-* @AdamDjo
+# * @AdamDjo


### PR DESCRIPTION
## Summary

- Commente la règle `* @AdamDjo` dans CODEOWNERS
- GitHub Enterprise est requis pour le bypass par acteur — non disponible sur repo personnel
- Supprime l'obligation de reviewer sur toutes les PRs du propriétaire

## Test plan

- [ ] Ouvrir une nouvelle PR → plus de reviewer assigné automatiquement
- [ ] La CI continue de tourner normalement

Closes #72