### PR TITLE
feat(#111): mémoire narrative N2 — compression de scène auto

### DIFF
--- a/apps/backend/prisma/migrations/20260713160149_add_memory_chunk/migration.sql
+++ b/apps/backend/prisma/migrations/20260713160149_add_memory_chunk/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "MemoryChunk" (
+    "id" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "keyFacts" JSONB NOT NULL,
+    "keyFactsPinned" JSONB NOT NULL,
+    "mood" TEXT NOT NULL,
+    "npcsEvolution" JSONB NOT NULL,
+    "turnRangeStart" INTEGER NOT NULL,
+    "turnRangeEnd" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MemoryChunk_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "MemoryChunk" ADD CONSTRAINT "MemoryChunk_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "GameSession"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -75,7 +75,8 @@ model GameSession {
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 
-  scenes SceneLog[]
+  scenes        SceneLog[]
+  memoryChunks  MemoryChunk[]
 }
 
 model SceneLog {
@@ -96,6 +97,28 @@ model SceneLog {
   /// Jet de dés serveur pour ce tour, si applicable (DiceRoll | null).
   diceRoll   Json?
   source     String // "ai" | "stub"
+
+  createdAt DateTime @default(now())
+}
+
+model MemoryChunk {
+  id        String      @id @default(uuid())
+  sessionId String
+  session   GameSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+
+  /// Résumé narratif à la 3e personne (~150 tokens max).
+  summary   String
+  /// Faits clés du segment compressé (String[] sérialisé, 3-5 items).
+  keyFacts       Json
+  /// Sous-ensemble de faits critiques épinglés (mort PNJ, artefact, quête, choix moral).
+  keyFactsPinned Json
+  /// Ambiance dominante du segment : calm | tense | festive | sacred | dangerous.
+  mood           String
+  /// Évolution des PNJ croisés (NpcEvolution[] sérialisé).
+  npcsEvolution  Json
+
+  turnRangeStart Int
+  turnRangeEnd   Int
 
   createdAt DateTime @default(now())
 }

--- a/apps/backend/src/ai/compression-validator.ts
+++ b/apps/backend/src/ai/compression-validator.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+/**
+ * Zod schema for the raw N2 compression payload the AI produces from a batch
+ * of turns. The AI decides `keyFactsPinned` directly via the auto-pinning
+ * rules given in its prompt (NPC death, artifact gained/lost, quest started,
+ * major moral choice) — the backend only validates the shape, never re-derives it.
+ */
+export const compressionOutputSchema = z.object({
+  summary: z.string().min(1).max(800),
+  key_facts: z.array(z.string().min(1)).min(3).max(5),
+  key_facts_pinned: z.array(z.string().min(1)).max(10),
+  mood: z.enum(['calm', 'tense', 'festive', 'sacred', 'dangerous']),
+  npcs_evolution: z.array(
+    z.object({
+      name: z.string().min(1),
+      status: z.string().min(1),
+      last_seen: z.string().min(1),
+    })
+  ),
+})
+
+export type CompressionOutput = z.infer<typeof compressionOutputSchema>
+
+export interface CompressionValidationResult {
+  success: boolean
+  data?: CompressionOutput
+  error?: string
+}
+
+/** Parses and validates raw AI compression output; malformed output is rejected, never passed through. */
+export function validateCompressionOutput(raw: unknown): CompressionValidationResult {
+  const parsed = compressionOutputSchema.safeParse(raw)
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues.map((i) => i.message).join('; ') }
+  }
+  return { success: true, data: parsed.data }
+}

--- a/apps/backend/src/ai/game-master.service.ts
+++ b/apps/backend/src/ai/game-master.service.ts
@@ -1,19 +1,36 @@
 import { hasOpenRouterKey } from '../config/env'
+import { prisma } from '../lib/prisma'
 
 import { callOpenRouter } from './openrouter.provider'
 import { buildStubScene } from './scene-stub'
 import { type AiScenePayload, validateAiScene } from './scene-validator'
 import { buildSystemPrompt } from './system-prompt'
 
+import type { MemoryChunkModel } from '../generated/prisma/models'
 import type { Character, Locale } from '@grimoire/shared'
 
 export interface GameMasterInput {
   character: Character
   locale: Locale
+  /** Session this scene belongs to — used to load N2 memory context. */
+  sessionId: string
   /** Label of the choice the player just took, if any. */
   chosenActionText?: string
   /** Free-form action typed by the player, if any. */
   freeAction?: string
+}
+
+/**
+ * Loads the N2 memory context for the prompt: the 5 most recent chunks (for
+ * the "story so far" summaries) plus every chunk's pinned facts, deduplicated
+ * downstream by `buildSystemPrompt` — bounded per feedback_challenge_canon_scalability.
+ */
+async function loadMemoryChunks(sessionId: string): Promise<MemoryChunkModel[]> {
+  return prisma.memoryChunk.findMany({
+    where: { sessionId },
+    orderBy: { turnRangeEnd: 'desc' },
+    take: 5,
+  })
 }
 
 export interface GameMasterResult {
@@ -43,8 +60,10 @@ export async function generateScene(input: GameMasterInput): Promise<GameMasterR
     return { scene: buildStubScene(input.character, input.locale), source: 'stub' }
   }
 
+  const memoryChunks = await loadMemoryChunks(input.sessionId)
+
   const result = await callOpenRouter([
-    { role: 'system', content: buildSystemPrompt(input.character, input.locale) },
+    { role: 'system', content: buildSystemPrompt(input.character, input.locale, memoryChunks) },
     { role: 'user', content: buildUserPrompt(input) },
   ])
 

--- a/apps/backend/src/ai/openrouter.provider.ts
+++ b/apps/backend/src/ai/openrouter.provider.ts
@@ -12,16 +12,30 @@ export interface OpenRouterResult {
   error?: string
 }
 
+export interface OpenRouterCallOptions {
+  /** Overrides `env.openRouter.model` for this call (e.g. N2 compression). */
+  model?: string
+  /** Aborts the request if it exceeds this duration. */
+  timeoutMs?: number
+}
+
 /**
  * Calls OpenRouter's chat completions endpoint.
  * The API key stays server-side and is never logged or returned.
  */
-export async function callOpenRouter(messages: OpenRouterMessage[]): Promise<OpenRouterResult> {
-  const { apiKey, model, baseUrl } = env.openRouter
+export async function callOpenRouter(
+  messages: OpenRouterMessage[],
+  options?: OpenRouterCallOptions
+): Promise<OpenRouterResult> {
+  const { apiKey, model: defaultModel, baseUrl } = env.openRouter
+  const model = options?.model ?? defaultModel
 
   if (!apiKey) {
     return { success: false, error: 'OpenRouter API key not configured' }
   }
+
+  const controller = options?.timeoutMs ? new AbortController() : undefined
+  const timeout = controller ? setTimeout(() => controller.abort(), options?.timeoutMs) : undefined
 
   try {
     const response = await fetch(`${baseUrl}/chat/completions`, {
@@ -39,6 +53,7 @@ export async function callOpenRouter(messages: OpenRouterMessage[]): Promise<Ope
         temperature: 0.8,
         response_format: { type: 'json_object' },
       }),
+      signal: controller?.signal,
     })
 
     if (!response.ok) {
@@ -57,8 +72,13 @@ export async function callOpenRouter(messages: OpenRouterMessage[]): Promise<Ope
 
     return { success: true, content }
   } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      return { success: false, error: 'OpenRouter request timed out' }
+    }
     // Log the message only (never the request headers, which carry the key).
     const message = err instanceof Error ? err.message : 'unknown error'
     return { success: false, error: `OpenRouter request errored: ${message}` }
+  } finally {
+    if (timeout) clearTimeout(timeout)
   }
 }

--- a/apps/backend/src/ai/system-prompt.test.ts
+++ b/apps/backend/src/ai/system-prompt.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildSystemPrompt } from './system-prompt'
+
+import type { MemoryChunkModel } from '../generated/prisma/models'
+
+const character = {
+  id: 'char1',
+  userId: 'user1',
+  name: 'Yarel of the Salt Roads',
+  people: 'sahelin',
+  vocation: 'salt-walker',
+  stats: {
+    attributes: { blood: 10, breath: 10, ash: 10 },
+    survival: { hp: 20, maxHp: 20, thirst: 100, hunger: 100, energy: 100, calamine: 0 },
+    conditions: [],
+  },
+  createdAt: new Date().toISOString(),
+}
+
+function chunk(overrides: Partial<MemoryChunkModel>): MemoryChunkModel {
+  return {
+    id: 'c1',
+    sessionId: 's1',
+    summary: 'Yarel crossed the salt flats.',
+    keyFacts: ['crossed the flats'],
+    keyFactsPinned: [],
+    mood: 'calm',
+    npcsEvolution: [],
+    turnRangeStart: 1,
+    turnRangeEnd: 8,
+    createdAt: new Date(),
+    ...overrides,
+  }
+}
+
+describe('buildSystemPrompt — N2 memory injection', () => {
+  it('injects no memory section when there are no chunks', () => {
+    const prompt = buildSystemPrompt(character, 'en')
+
+    expect(prompt).not.toContain('Story so far')
+    expect(prompt).not.toContain('Critical facts to always remember')
+  })
+
+  it('injects the summaries of every passed chunk, in the order given', () => {
+    const chunks = [
+      chunk({ id: 'c2', turnRangeStart: 9, turnRangeEnd: 16, summary: 'Second chunk summary' }),
+      chunk({ id: 'c1', turnRangeStart: 1, turnRangeEnd: 8, summary: 'First chunk summary' }),
+    ]
+
+    const prompt = buildSystemPrompt(character, 'en', chunks)
+
+    expect(prompt).toContain('Story so far')
+    expect(prompt).toContain('(turns 9-16) Second chunk summary')
+    expect(prompt).toContain('(turns 1-8) First chunk summary')
+    expect(prompt.indexOf('Second chunk summary')).toBeLessThan(
+      prompt.indexOf('First chunk summary')
+    )
+  })
+
+  it('deduplicates pinned facts cumulated across all passed chunks', () => {
+    const chunks = [
+      chunk({
+        id: 'c1',
+        keyFactsPinned: ['NPC died: the Trader', 'Artifact obtained: shrine relic'],
+      }),
+      chunk({
+        id: 'c2',
+        keyFactsPinned: ['Artifact obtained: shrine relic', 'Quest started: find the well'],
+      }),
+    ]
+
+    const prompt = buildSystemPrompt(character, 'en', chunks)
+
+    expect(prompt).toContain('Critical facts to always remember')
+    const occurrences = prompt.split('Artifact obtained: shrine relic').length - 1
+    expect(occurrences).toBe(1)
+    expect(prompt).toContain('NPC died: the Trader')
+    expect(prompt).toContain('Quest started: find the well')
+  })
+
+  it('omits the pinned-facts section when no chunk has any pinned fact', () => {
+    const chunks = [chunk({ keyFactsPinned: [] })]
+
+    const prompt = buildSystemPrompt(character, 'en', chunks)
+
+    expect(prompt).toContain('Story so far')
+    expect(prompt).not.toContain('Critical facts to always remember')
+  })
+})

--- a/apps/backend/src/ai/system-prompt.ts
+++ b/apps/backend/src/ai/system-prompt.ts
@@ -1,3 +1,4 @@
+import type { MemoryChunkModel } from '../generated/prisma/models'
 import type { Character, Locale } from '@grimoire/shared'
 
 /** Human-readable language name for the locale, injected into the prompt. */
@@ -7,12 +8,46 @@ const LOCALE_NAME: Record<Locale, string> = {
 }
 
 /**
+ * Builds the N2 memory section: the caller passes at most the 5 most recent
+ * chunks (bounded to keep the prompt cheap on long runs — see
+ * feedback_challenge_canon_scalability), plus a deduplicated list of every
+ * pinned fact across those chunks so critical events are never forgotten.
+ */
+function buildMemorySection(memoryChunks: MemoryChunkModel[]): string[] {
+  if (memoryChunks.length === 0) return []
+
+  const summaries = memoryChunks.map(
+    (chunk) => `- (turns ${chunk.turnRangeStart}-${chunk.turnRangeEnd}) ${chunk.summary}`
+  )
+
+  const pinnedFacts = Array.from(
+    new Set(
+      memoryChunks.flatMap((chunk) =>
+        Array.isArray(chunk.keyFactsPinned) ? (chunk.keyFactsPinned as string[]) : []
+      )
+    )
+  )
+
+  const section = ['Story so far (past scenes, most recent first):', ...summaries]
+
+  if (pinnedFacts.length > 0) {
+    section.push('', 'Critical facts to always remember:', ...pinnedFacts.map((f) => `- ${f}`))
+  }
+
+  return ['', ...section]
+}
+
+/**
  * Builds the Game Master system prompt.
  * The AI writes narration and choice labels only; the backend owns all rules,
  * dice, stats, and canon consistency. Canon brand terms are NOT re-translated —
  * the app supplies a curated dictionary for those.
  */
-export function buildSystemPrompt(character: Character, locale: Locale): string {
+export function buildSystemPrompt(
+  character: Character,
+  locale: Locale,
+  memoryChunks: MemoryChunkModel[] = []
+): string {
   const languageName = LOCALE_NAME[locale]
 
   return [
@@ -28,6 +63,7 @@ export function buildSystemPrompt(character: Character, locale: Locale): string 
     '- Offer 2 to 4 choices. Mark each with a plausible riskLevel (safe/low/medium/high/deadly).',
     '',
     `Player character: ${character.name} — people "${character.people}", vocation "${character.vocation}".`,
+    ...buildMemorySection(memoryChunks),
     '',
     'Respond with a single JSON object and nothing else, matching exactly:',
     '{',

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -17,9 +17,15 @@ export const env = {
     apiKey: process.env.OPENROUTER_API_KEY ?? '',
     /** Free multilingual model by default; override with OPENROUTER_MODEL. */
     model: process.env.OPENROUTER_MODEL ?? 'meta-llama/llama-3.3-70b-instruct:free',
+    /** Lightweight model used for N2 scene compression; override with OPENROUTER_COMPRESSION_MODEL. */
+    compressionModel:
+      process.env.OPENROUTER_COMPRESSION_MODEL ?? 'mistralai/mistral-small-24b-instruct:free',
     baseUrl: 'https://openrouter.ai/api/v1',
   },
 } as const
+
+/** Hardcoded fallback model for N2 compression if the primary model call fails. */
+export const COMPRESSION_FALLBACK_MODEL = 'meta-llama/llama-3.3-70b-instruct:free'
 
 /** True when an OpenRouter key is configured. Never exposes the key itself. */
 export const hasOpenRouterKey = (): boolean => env.openRouter.apiKey.length > 0

--- a/apps/backend/src/services/memory.service.test.ts
+++ b/apps/backend/src/services/memory.service.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callOpenRouter = vi.fn()
+vi.mock('../ai/openrouter.provider', () => ({ callOpenRouter }))
+
+const memoryChunkCreate = vi.fn()
+vi.mock('../lib/prisma', () => ({
+  prisma: { memoryChunk: { create: memoryChunkCreate } },
+}))
+
+const { compressScene } = await import('./memory.service')
+
+const character = {
+  id: 'char1',
+  userId: 'user1',
+  name: 'Yarel of the Salt Roads',
+  people: 'sahelin',
+  vocation: 'salt-walker',
+  stats: {
+    attributes: { blood: 10, breath: 10, ash: 10 },
+    survival: { hp: 20, maxHp: 20, thirst: 100, hunger: 100, energy: 100, calamine: 0 },
+    conditions: [],
+  },
+  createdAt: new Date().toISOString(),
+}
+
+const turns = Array.from({ length: 8 }, (_, i) => ({
+  id: `turn${i + 1}`,
+  sessionId: 's1',
+  turnNumber: i + 1,
+  sceneType: 'exploration',
+  location: 'Calamine',
+  narrative: `Narrative for turn ${i + 1}`,
+  choices: [],
+  chosenChoice: null,
+  consequences: null,
+  diceRoll: null,
+  source: 'ai',
+  createdAt: new Date(),
+}))
+
+const validCompression = {
+  summary: 'Yarel crossed the salt flats and found an old shrine.',
+  key_facts: ['found a shrine', 'lost a waterskin', 'met a wandering trader'],
+  key_facts_pinned: ['Artifact obtained: shrine relic'],
+  mood: 'tense',
+  npcs_evolution: [{ name: 'Trader', status: 'alive', last_seen: 'Calamine' }],
+}
+
+describe('compressScene', () => {
+  beforeEach(() => {
+    callOpenRouter.mockReset()
+    memoryChunkCreate.mockReset()
+  })
+
+  it('creates a MemoryChunk when the primary model succeeds', async () => {
+    callOpenRouter.mockResolvedValueOnce({
+      success: true,
+      content: JSON.stringify(validCompression),
+    })
+
+    await compressScene('s1', turns, character, 'Calamine')
+
+    expect(callOpenRouter).toHaveBeenCalledTimes(1)
+    expect(memoryChunkCreate).toHaveBeenCalledWith({
+      data: {
+        sessionId: 's1',
+        summary: validCompression.summary,
+        keyFacts: validCompression.key_facts,
+        keyFactsPinned: validCompression.key_facts_pinned,
+        mood: validCompression.mood,
+        npcsEvolution: validCompression.npcs_evolution,
+        turnRangeStart: 1,
+        turnRangeEnd: 8,
+      },
+    })
+  })
+
+  it('falls back to the second model when the primary model fails', async () => {
+    callOpenRouter
+      .mockResolvedValueOnce({ success: false, error: 'OpenRouter request timed out' })
+      .mockResolvedValueOnce({ success: true, content: JSON.stringify(validCompression) })
+
+    await compressScene('s1', turns, character, 'Calamine')
+
+    expect(callOpenRouter).toHaveBeenCalledTimes(2)
+    expect(memoryChunkCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it('never throws and creates no chunk when both models fail', async () => {
+    callOpenRouter
+      .mockResolvedValueOnce({ success: false, error: 'timeout' })
+      .mockResolvedValueOnce({ success: false, error: 'timeout' })
+
+    await expect(compressScene('s1', turns, character, 'Calamine')).resolves.toBeUndefined()
+
+    expect(callOpenRouter).toHaveBeenCalledTimes(2)
+    expect(memoryChunkCreate).not.toHaveBeenCalled()
+  })
+
+  it('never throws and creates no chunk when the AI returns non-JSON', async () => {
+    callOpenRouter.mockResolvedValue({ success: true, content: 'not json' })
+
+    await expect(compressScene('s1', turns, character, 'Calamine')).resolves.toBeUndefined()
+
+    expect(memoryChunkCreate).not.toHaveBeenCalled()
+  })
+
+  it('never throws and creates no chunk when the AI JSON fails Zod validation', async () => {
+    callOpenRouter.mockResolvedValue({
+      success: true,
+      content: JSON.stringify({ summary: 'too short a payload' }),
+    })
+
+    await expect(compressScene('s1', turns, character, 'Calamine')).resolves.toBeUndefined()
+
+    expect(memoryChunkCreate).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/services/memory.service.ts
+++ b/apps/backend/src/services/memory.service.ts
@@ -1,0 +1,113 @@
+import { type CompressionOutput, validateCompressionOutput } from '../ai/compression-validator'
+import { callOpenRouter } from '../ai/openrouter.provider'
+import { COMPRESSION_FALLBACK_MODEL, env } from '../config/env'
+import { prisma } from '../lib/prisma'
+
+import type { SceneLog } from '../generated/prisma/client'
+import type { Character } from '@grimoire/shared'
+
+const COMPRESSION_TIMEOUT_MS = 8000
+
+/** Builds the exact canon compression prompt (docs/private/raw/16-MEMORY.md §5). */
+function buildCompressionPrompt(character: Character, location: string, turns: SceneLog[]): string {
+  const rawTurns = turns
+    .slice()
+    .sort((a, b) => a.turnNumber - b.turnNumber)
+    .map((turn) => `[Turn ${turn.turnNumber}] ${turn.narrative}`)
+    .join('\n')
+
+  return [
+    'Tu compresses 8 tours de jeu en un résumé structuré.',
+    '',
+    '[CONTEXTE]',
+    `${character.name}, ${character.vocation}, ${character.people}, à Velkhar.`,
+    `Lieu actuel : ${location}.`,
+    '',
+    '[TOURS BRUTS]',
+    rawTurns,
+    '',
+    '[INSTRUCTION]',
+    'Génère STRICTEMENT en JSON :',
+    '{',
+    '  "summary": "150 tokens max, narratif 3e personne",',
+    '  "key_facts": ["fait 1", "fait 2", "fait 3"],',
+    '  "key_facts_pinned": [/* faits critiques selon règles */],',
+    '  "mood": "calm | tense | festive | sacred | dangerous",',
+    '  "npcs_evolution": [{"name": "...", "status": "...", "last_seen": "..."}]',
+    '}',
+    '',
+    'Règles de pinning automatique :',
+    '- PNJ mort → key_facts_pinned',
+    '- Artefact obtenu/perdu → key_facts_pinned',
+    '- Quête activée → key_facts_pinned',
+    '- Choix moral majeur → key_facts_pinned',
+  ].join('\n')
+}
+
+/** Calls OpenRouter with the given model and returns validated compression output, or null. */
+async function tryCompress(prompt: string, model: string): Promise<CompressionOutput | null> {
+  const result = await callOpenRouter([{ role: 'user', content: prompt }], {
+    model,
+    timeoutMs: COMPRESSION_TIMEOUT_MS,
+  })
+
+  if (!result.success || !result.content) {
+    return null
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(result.content)
+  } catch {
+    return null
+  }
+
+  const validated = validateCompressionOutput(parsed)
+  return validated.success && validated.data ? validated.data : null
+}
+
+/**
+ * Compresses a batch of turns into a `MemoryChunk` (N2 memory). Fire-and-forget:
+ * called without `await` from `resolveTurn`. Never throws — on double failure
+ * (primary + fallback model, invalid JSON, or failed Zod validation) it logs a
+ * warning and returns without persisting anything; the turns simply stay
+ * uncompressed rather than crashing the game loop.
+ */
+export async function compressScene(
+  sessionId: string,
+  turns: SceneLog[],
+  character: Character,
+  location: string
+): Promise<void> {
+  if (turns.length === 0) {
+    return
+  }
+
+  const prompt = buildCompressionPrompt(character, location, turns)
+
+  const output =
+    (await tryCompress(prompt, env.openRouter.compressionModel)) ??
+    (await tryCompress(prompt, COMPRESSION_FALLBACK_MODEL))
+
+  if (!output) {
+    console.warn(`[Memory] compression failed for session ${sessionId}, turns stay uncompressed`)
+    return
+  }
+
+  const sortedTurns = turns.slice().sort((a, b) => a.turnNumber - b.turnNumber)
+  const turnRangeStart = sortedTurns[0].turnNumber
+  const turnRangeEnd = sortedTurns[sortedTurns.length - 1].turnNumber
+
+  await prisma.memoryChunk.create({
+    data: {
+      sessionId,
+      summary: output.summary,
+      keyFacts: output.key_facts,
+      keyFactsPinned: output.key_facts_pinned,
+      mood: output.mood,
+      npcsEvolution: output.npcs_evolution,
+      turnRangeStart,
+      turnRangeEnd,
+    },
+  })
+}

--- a/apps/backend/src/services/session.service.trigger.test.ts
+++ b/apps/backend/src/services/session.service.trigger.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const transaction = vi.fn().mockResolvedValue(undefined)
+const sceneLogCreate = vi.fn()
+const sceneLogFindMany = vi.fn().mockResolvedValue([])
+const characterUpdate = vi.fn()
+const gameSessionUpdate = vi.fn()
+vi.mock('../lib/prisma', () => ({
+  prisma: {
+    $transaction: transaction,
+    sceneLog: { create: sceneLogCreate, findMany: sceneLogFindMany },
+    character: { update: characterUpdate },
+    gameSession: { update: gameSessionUpdate },
+  },
+}))
+
+const resolveChoice = vi.fn()
+vi.mock('../game-rules/consequences', () => ({ resolveChoice }))
+
+const generateScene = vi.fn()
+vi.mock('../ai/game-master.service', () => ({ generateScene }))
+
+const assembleScene = vi.fn()
+vi.mock('./scene-assembler', () => ({ assembleScene }))
+
+const compressScene = vi.fn().mockResolvedValue(undefined)
+vi.mock('./memory.service', () => ({ compressScene }))
+
+const { resolveTurn } = await import('./session.service')
+
+import type { Character as DbCharacter, GameSession } from '../generated/prisma/client'
+
+const character = {
+  id: 'char1',
+  userId: 'user1',
+  name: 'Yarel of the Salt Roads',
+  people: 'sahelin',
+  vocation: 'salt-walker',
+  blood: 10,
+  breath: 10,
+  ash: 10,
+  hp: 20,
+  maxHp: 20,
+  thirst: 100,
+  hunger: 100,
+  energy: 100,
+  calamine: 0,
+  conditions: [],
+  createdAt: new Date(),
+} as unknown as DbCharacter
+
+function session(turnNumber: number): GameSession {
+  return {
+    id: 's1',
+    characterId: 'char1',
+    turnNumber,
+    location: 'Calamine',
+    status: 'active',
+    endReason: null,
+    createdAt: new Date(),
+  } as unknown as GameSession
+}
+
+const choice = { id: 'c1', text: 'move on', type: 'action' as const, riskLevel: 'safe' as const }
+
+describe('resolveTurn — N2 compression trigger', () => {
+  beforeEach(() => {
+    transaction.mockClear()
+    sceneLogFindMany.mockClear()
+    compressScene.mockClear()
+
+    resolveChoice.mockReturnValue({
+      updatedSurvival: {
+        hp: 20,
+        maxHp: 20,
+        thirst: 95,
+        hunger: 95,
+        energy: 95,
+        calamine: 0,
+      },
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({ scene: {}, source: 'ai' })
+    assembleScene.mockReturnValue({
+      sceneType: 'exploration',
+      location: 'Calamine',
+      narrative: 'text',
+      choices: [],
+    })
+  })
+
+  it('does not trigger compression on a turn that is not a multiple of 8', async () => {
+    await resolveTurn({ session: session(6), character, choice, locale: 'en' })
+    // Flush any fire-and-forget microtasks.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(sceneLogFindMany).not.toHaveBeenCalled()
+    expect(compressScene).not.toHaveBeenCalled()
+  })
+
+  it('triggers compression fire-and-forget when the next turn is a multiple of 8', async () => {
+    const result = await resolveTurn({ session: session(7), character, choice, locale: 'en' })
+    expect(result).toBeDefined()
+
+    // compressScene is fire-and-forget: resolveTurn must not await it.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(sceneLogFindMany).toHaveBeenCalledWith({
+      where: { sessionId: 's1' },
+      orderBy: { turnNumber: 'desc' },
+      take: 8,
+    })
+    expect(compressScene).toHaveBeenCalledTimes(1)
+    expect(compressScene.mock.calls[0][0]).toBe('s1')
+  })
+})

--- a/apps/backend/src/services/session.service.ts
+++ b/apps/backend/src/services/session.service.ts
@@ -15,6 +15,7 @@ import { persistedChoicesSchema } from '../ai/scene-validator'
 import { resolveChoice } from '../game-rules/consequences'
 import { prisma } from '../lib/prisma'
 
+import { compressScene } from './memory.service'
 import { assembleScene } from './scene-assembler'
 
 import type { Character as DbCharacter, GameSession } from '../generated/prisma/client'
@@ -199,6 +200,7 @@ export async function buildOpeningScene(
   const gm = await generateScene({
     character: toGmCharacter(character, attributes, survival),
     locale,
+    sessionId: session.id,
   })
   const scene = assembleScene({
     payload: gm.scene,
@@ -294,6 +296,7 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
   const gm = await generateScene({
     character: toGmCharacter(character, attributes, resolution.updatedSurvival),
     locale,
+    sessionId: session.id,
     chosenActionText,
     freeAction,
   })
@@ -342,6 +345,26 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
       },
     }),
   ])
+
+  if (nextTurn % 8 === 0) {
+    void (async () => {
+      try {
+        const recentTurns = await prisma.sceneLog.findMany({
+          where: { sessionId: session.id },
+          orderBy: { turnNumber: 'desc' },
+          take: 8,
+        })
+        await compressScene(
+          session.id,
+          recentTurns,
+          toGmCharacter(character, attributes, resolution.updatedSurvival),
+          scene.location
+        )
+      } catch (err) {
+        console.warn(`[Memory] failed to load turns for session ${session.id}:`, err)
+      }
+    })()
+  }
 
   return {
     scene,

--- a/docs/public/current-state/NEXT_ACTIONS.md
+++ b/docs/public/current-state/NEXT_ACTIONS.md
@@ -2,26 +2,32 @@
 type: actions
 visibility: public
 rag: true
-updated: 2026-07-11
+updated: 2026-07-13
 ---
 
 # Next Actions
 
 ## Immédiat
 
-1. **Reviewer + merger la PR [#102](https://github.com/AdamDjo/Grimoire-game/pull/102)** vers `develop` (ferme l'EPIC #95 et #96→#100).
-2. **Régénérer la clé OpenRouter** (`sk-or-v1-…`) et remettre la valeur dans `apps/backend/.env` local — jamais committée, révocation par principe.
+1. **Finaliser + merger #111** (mémoire N2 — compression de scène) vers `develop` : implémenté et testé, reste PR + review.
 
-## Phase 1B — suite (après merge #102)
+## A3 — mémoire narrative, suite (après merge #111)
 
-3. **Durcir le moteur de session côté backend** : rapatrier le d20 + les conséquences (aujourd'hui simulés au front dans `_lib/consequences.ts`), validation Zod, world-state persistant. Le backend reste souverain.
-4. **Écran Auberge de L'Aveugle** (backlog priorité 1) : `app/(game)/velkhar/aveugle/page.tsx` + `aveugle.service.ts` backend.
-5. **Écran Character Create (la Forge)** : 4 vocations + concept libre, peuples, attribution triptyque. Dépend de B1 (déjà fait).
-6. **Écran World Map (Makhzen)** : carte désertique, régions, points d'intérêt.
+2. [#113](https://github.com/AdamDjo/Grimoire-game/issues/113) — **N1, fenêtre court-terme** : grill le choix Redis vs requête DB directe avant d'implémenter, puis brancher l'injection dans `system-prompt.ts`.
+3. [#114](https://github.com/AdamDjo/Grimoire-game/issues/114) — **pgvector / rappel sémantique** sur les `MemoryChunk`.
+4. [#115](https://github.com/AdamDjo/Grimoire-game/issues/115) — **Souvenirs nommés (N3)**, inter-runs.
+5. [#116](https://github.com/AdamDjo/Grimoire-game/issues/116) — **Chronique de fin de run** (inclut la purge `SceneLog` post-génération).
+6. [#117](https://github.com/AdamDjo/Grimoire-game/issues/117) — **World events (Level C)**, priorité basse (dépend du contenu design, pas du code).
+
+## Phase 1B — écrans restants
+
+7. **Écran Auberge de L'Aveugle** (backlog priorité 1) : `app/(game)/velkhar/aveugle/page.tsx` + `aveugle.service.ts` backend.
+8. **Écran Character Create (la Forge)** : 4 vocations + concept libre, peuples, attribution triptyque.
+9. **Écran World Map (Makhzen)** : carte désertique, régions, points d'intérêt.
 
 ## Différé
 
-7. #101 — fallback chain multi-modèles OpenRouter (ouvert, non implémenté).
-8. Ticket dédié vulnérabilités Dependabot (3 critiques sur `develop`).
+10. #101 — fallback chain multi-modèles OpenRouter (ouvert, non implémenté).
+11. Ticket dédié vulnérabilités Dependabot (3 critiques sur `develop`).
 
 > Garde-fous produit inchangés : **Velkhar only**, MVP court (vertical slice 45-70 min), lore progressif, moat backend d'abord. Voir [[PHASE-1B-BACKLOG]].

--- a/docs/public/current-state/PROJECT_STATUS.md
+++ b/docs/public/current-state/PROJECT_STATUS.md
@@ -3,7 +3,7 @@ type: status
 visibility: public
 rag: true
 source_of_truth: true
-updated: 2026-07-12
+updated: 2026-07-13
 ---
 
 # Project Status
@@ -11,34 +11,39 @@ updated: 2026-07-12
 ## État actuel
 
 - Projet : **GRIMOIRE — Of Ash and Salt**
-- Phase actuelle : **Phase 1B — vertical slice gamesession**
-- Branche active : `feature/95-demo-gamesession-vertical-slice` (PR [#102](https://github.com/AdamDjo/Grimoire-game/pull/102) ouverte → `develop`)
-- Priorité active : merger #102, puis attaquer les écrans 1B restants (Auberge de L'Aveugle en priorité 1).
+- Phase actuelle : **Phase 1B — vertical slice gamesession** (moteur backend) + chantier A3 mémoire narrative en cours
+- Branche active : `feature/111-memoire-n2-compression-scene` (worktree `-claude`)
+- Priorité active : terminer/merger #111 (N2 compression — implémenté, testé, 32/32), puis enchaîner sur le backlog A3 (#113→#117).
 - Chantier parallèle (Codex) : UI Kit Grimoire, `feature/93-ui-kit-grimoire-complet` (#93). Ne pas toucher au code du main folder.
 
 ## Livré récemment
 
 - **Phase 1A — landing** : ✅ mergée (#94).
-- **EPIC #95 — vertical slice gamesession Velkhar** : ✅ code fini, en PR #102 (ferme #95→#100).
-  - #96 types canon triptyque (blood/breath/ash + survie) dans `@grimoire/shared`.
-  - #97 perso Velkhar canonique mocké.
-  - #98 OpenRouter Game Master + route `POST /api/game/action`.
-  - #99 écran gamesession jouable branché sur le MJ IA (composants provisoires `_components/`, jetables, zéro collision avec #93).
-  - #100 bundler tsup pour un dist backend autonome.
-- **#107 — auth Supabase** : ✅ implémentée (worktree `-claude`, `feature/107-supabase-auth-magic-link-oauth`). Tier anonyme (`signInAnonymously`), magic link + OAuth Google/Discord, JWT vérifié via JWKS dans `requireAuth`, `userId` client retiré du body, proxy `app/api/[...path]/route.ts` qui injecte le Bearer, cap 30 req anonymes → 403 → blocage forcé UI. Bug email anonyme vide (P2002) résolu. Vérifié live. Détail : [[../tech/AUTH]].
+- **EPIC #95 — vertical slice gamesession Velkhar** : ✅ mergée sur `develop` (PR #102, commit `9bb37a5`). Ferme #95→#100.
+- **#107 — auth Supabase** : ✅ livrée, en PR [#108](https://github.com/AdamDjo/Grimoire-game/pull/108) → `develop`. Tier anonyme (`signInAnonymously`), magic link + OAuth Google/Discord, JWT vérifié via JWKS dans `requireAuth`, cap 30 req anonymes → 403. Vérifiée live. Détail : [[../tech/AUTH]].
+- **#109 — moteur de session durci (A1+A2)** : ✅ mergé (PR #110 → `develop`). D20 + conséquences rapatriés côté backend, world-state persistant, `endReason` posé sur `GameSession`.
+- **#111 — mémoire narrative N2 (compression de scène)** : ✅ implémenté et testé (32/32), branche `feature/111-memoire-n2-compression-scene`. Compression fire-and-forget tous les 8 tours via Mistral Small (fallback Llama 3.3), stockage `MemoryChunk`, injection des 5 chunks récents + faits épinglés dans le prompt système. Reste à merger.
+
+## Backlog A3 — mémoire narrative (après #111)
+
+Chantier découpé en sous-tickets indépendants, tous rattachés à A3 :
+
+- [#113](https://github.com/AdamDjo/Grimoire-game/issues/113) — **N1, fenêtre court-terme** (3-5 derniers tours en clair). Gap confirmé : aucune implémentation actuelle, trou de continuité entre le tour 1 et le premier chunk N2 (tour 8).
+- [#114](https://github.com/AdamDjo/Grimoire-game/issues/114) — **pgvector / rappel sémantique** sur les `MemoryChunk` N2. Dépend de #111 (livré).
+- [#115](https://github.com/AdamDjo/Grimoire-game/issues/115) — **Souvenirs nommés (N3)**, persistants inter-runs. Dépend de `key_facts_pinned` (#111, livré).
+- [#116](https://github.com/AdamDjo/Grimoire-game/issues/116) — **Chronique de fin de run**. Génère un récit ~400 mots à partir de N2 + Souvenirs + `endReason`. Inclut la purge des `SceneLog` bruts post-génération (ancien scope #112, fermé et absorbé ici).
+- [#117](https://github.com/AdamDjo/Grimoire-game/issues/117) — **World events (Level C)**, scriptés manuellement, jamais IA-générés. Indépendant du reste de A3.
 
 ## Dette / non-autoritatif à durcir
 
-- Le moteur de conséquences + le d20 de #99 sont **simulés côté front** (démo). À rapatrier côté backend (règles souveraines) lors de l'implémentation réelle de la Session.
-- #101 (fallback multi-modèles OpenRouter) : ouvert, non implémenté.
+- #101 (fallback multi-modèles OpenRouter pour le Game Master principal) : ouvert, non implémenté.
 - 91 vulnérabilités Dependabot sur `develop` (3 critiques) — à traiter dans un ticket dédié.
-- **Cap anonyme contournable** (#107) : vider les cookies `sb-*` réinitialise le quota (nouvel `auth.users.id`). Dette V1 assumée (friction, pas sécurité). À durcir avec un rate-limit / cap par IP quand l'IA payante remplacera le stub. Détail : [[../tech/AUTH]].
+- **Cap anonyme contournable** (#107) : vider les cookies `sb-*` réinitialise le quota (nouvel `auth.users.id`). Dette V1 assumée (friction, pas sécurité). Détail : [[../tech/AUTH]].
 - **RLS Postgres** différé (#107, décision #7) : autorisation V1 = filtrage `userId` explicite côté Express.
 
 ## Critères pour avancer dans la Phase 1B
 
-- PR #102 reviewée et mergée sur `develop`.
-- Moteur de session durci côté backend (validation Zod, d20 serveur, world-state).
+- #111 mergé sur `develop`.
 - Écrans Auberge de L'Aveugle + Character Create branchés sur le triptyque canon.
 
 ## Sources liées


### PR DESCRIPTION
## Summary
- Compression fire-and-forget toutes les 8 tours (Mistral Small, fallback Llama 3.3 via OpenRouter) des `SceneLog` en `MemoryChunk` (résumé, faits clés, faits épinglés, ambiance, évolution PNJ)
- Injection des 5 chunks N2 les plus récents + faits épinglés cumulés dans le prompt système du Game Master
- Migration Prisma `MemoryChunk` + extension `callOpenRouter` (modèle/timeout optionnels) + validation Zod du output de compression
- Mise à jour `PROJECT_STATUS.md` / `NEXT_ACTIONS.md` : reflète l'état réel (#95, #107, #109 livrés/en PR, #111 implémenté) + backlog A3 découpé en tickets #113→#117

Closes #111

## Test plan
- [x] `pnpm type-check --filter @grimoire/backend`
- [x] `pnpm test --filter @grimoire/backend` — 32/32 (dont `system-prompt.test.ts`, `memory.service.test.ts`, `session.service.trigger.test.ts`)
- [x] Vérification manuelle : `SceneLog` inchangé, `resolveTurn` non bloquant sur la compression, `callOpenRouter` rétrocompatible sans options