### PR TITLE
feat(#120): élargir la fenêtre N2 de 5 à 8 chunks récents

### DIFF
--- a/apps/backend/src/ai/game-master.service.test.ts
+++ b/apps/backend/src/ai/game-master.service.test.ts
@@ -74,6 +74,19 @@ describe('generateScene — N1 recent-turns loading', () => {
     })
   })
 
+  it('queries the 8 most recent memory chunks ordered by turnRangeEnd desc', async () => {
+    hasOpenRouterKey.mockReturnValue(true)
+    callOpenRouter.mockResolvedValue({ success: true, content: JSON.stringify(validAiPayload) })
+
+    await generateScene({ character, locale: 'en', sessionId: 's1' })
+
+    expect(memoryChunkFindMany).toHaveBeenCalledWith({
+      where: { sessionId: 's1' },
+      orderBy: { turnRangeEnd: 'desc' },
+      take: 8,
+    })
+  })
+
   it('passes the loaded recent turns through to buildSystemPrompt', async () => {
     hasOpenRouterKey.mockReturnValue(true)
     const recentTurns = [

--- a/apps/backend/src/ai/game-master.service.ts
+++ b/apps/backend/src/ai/game-master.service.ts
@@ -21,15 +21,17 @@ export interface GameMasterInput {
 }
 
 /**
- * Loads the N2 memory context for the prompt: the 5 most recent chunks (for
+ * Loads the N2 memory context for the prompt: the 8 most recent chunks (for
  * the "story so far" summaries) plus every chunk's pinned facts, deduplicated
- * downstream by `buildSystemPrompt` — bounded per feedback_challenge_canon_scalability.
+ * downstream by `buildSystemPrompt`. 8 chunks (64 turns) covers nearly the
+ * full history of a vertical-slice run (45-70 min, ~40-60 turns) — see #120,
+ * which replaced semantic recall (#114, deferred) with this wider window.
  */
 async function loadMemoryChunks(sessionId: string): Promise<MemoryChunkModel[]> {
   return prisma.memoryChunk.findMany({
     where: { sessionId },
     orderBy: { turnRangeEnd: 'desc' },
-    take: 5,
+    take: 8,
   })
 }
 


### PR DESCRIPTION
## Résumé

- Élargit la fenêtre de contexte N2 injectée dans le prompt du Game Master : `loadMemoryChunks` passe de 5 à 8 chunks récents (`apps/backend/src/ai/game-master.service.ts`).
- Alternative retenue à la place de #114 (pgvector/rappel sémantique), différé au backlog : un run vertical-slice type (45-70 min, ~40-60 tours) ne produit que 5-8 `MemoryChunk`, donc la fenêtre de 5 couvrait déjà quasiment tout l'historique — le rappel sémantique est prématuré à l'échelle MVP actuelle.
- Pas de nouvelle dépendance, pas de migration, pas de nouveau provider IA.

## Test plan

- [x] `pnpm type-check --filter @grimoire/backend`
- [x] `pnpm lint --filter @grimoire/backend`
- [x] `pnpm test --filter @grimoire/backend` (49/49, nouveau test ajouté pour `memoryChunkFindMany` avec `take: 8`)

Closes #120