### PR TITLE
feat(#115): souvenirs nommés (N3 mémoire inter-run)

### DIFF
--- a/apps/backend/prisma/migrations/20260714000000_add_souvenir_model/migration.sql
+++ b/apps/backend/prisma/migrations/20260714000000_add_souvenir_model/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "Souvenir" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "characterId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "sharedWithAveugle" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Souvenir_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Souvenir" ADD CONSTRAINT "Souvenir_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -3,13 +3,13 @@
 
 // ---------------------------------------------------------------------------
 // Vision domaine complète (voir docs/private/raw/*.md) — NON migrée ici :
-// Peuples, Vocations (catalogues statiques, pas de table), Souvenirs
-// (méta-monde cross-run), Factions/réputation, Quêtes, Inventaire/Items,
-// Chroniques (résumé fin de run). Ces modèles arriveront avec les écrans
-// qui en ont besoin (Character Create, Auberge, World Map).
+// Peuples, Vocations (catalogues statiques, pas de table), Factions/réputation,
+// Quêtes, Inventaire/Items, Chroniques (résumé fin de run). Ces modèles
+// arriveront avec les écrans qui en ont besoin (Character Create, Auberge,
+// World Map).
 //
 // Migré maintenant (coeur du world-state de session) : User, Character,
-// GameSession, SceneLog.
+// GameSession, SceneLog, MemoryChunk, Souvenir.
 // ---------------------------------------------------------------------------
 
 generator client {
@@ -28,6 +28,7 @@ model User {
   anonymousRequestCount Int @default(0)
   createdAt  DateTime    @default(now())
   characters Character[]
+  souvenirs  Souvenir[]
 }
 
 model Character {
@@ -121,6 +122,30 @@ model MemoryChunk {
 
   turnRangeStart Int
   turnRangeEnd   Int
+
+  createdAt DateTime @default(now())
+}
+
+/// Named Souvenir (N3 inter-run memory, #115). Cross-run and permanent —
+/// linked to `User` only (no cascade relation to Session/Character, which
+/// must be free to disappear while the Souvenir survives them). `characterId`
+/// and `sessionId` are kept as plain strings for provenance/display only.
+model Souvenir {
+  id     String @id @default(uuid())
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  characterId String
+  sessionId   String
+
+  title String
+  body  String
+  /// SouvenirType (@grimoire/shared) stored as a plain string, matching
+  /// SceneLog.sceneType's convention — no Prisma enum in this schema.
+  type  String
+
+  /// Placeholder for the future Aveugle Souvenir-for-lore exchange (#133). Unused for now.
+  sharedWithAveugle Boolean @default(false)
 
   createdAt DateTime @default(now())
 }

--- a/apps/backend/src/ai/game-master.service.test.ts
+++ b/apps/backend/src/ai/game-master.service.test.ts
@@ -5,10 +5,12 @@ vi.mock('../config/env', () => ({ hasOpenRouterKey }))
 
 const memoryChunkFindMany = vi.fn().mockResolvedValue([])
 const sceneLogFindMany = vi.fn().mockResolvedValue([])
+const souvenirFindMany = vi.fn().mockResolvedValue([])
 vi.mock('../lib/prisma', () => ({
   prisma: {
     memoryChunk: { findMany: memoryChunkFindMany },
     sceneLog: { findMany: sceneLogFindMany },
+    souvenir: { findMany: souvenirFindMany },
   },
 }))
 
@@ -47,6 +49,7 @@ describe('generateScene — N1 recent-turns loading', () => {
     hasOpenRouterKey.mockReset()
     memoryChunkFindMany.mockClear()
     sceneLogFindMany.mockClear()
+    souvenirFindMany.mockClear()
     buildSystemPrompt.mockClear()
     callOpenRouter.mockReset()
   })
@@ -58,6 +61,7 @@ describe('generateScene — N1 recent-turns loading', () => {
 
     expect(result.source).toBe('stub')
     expect(sceneLogFindMany).not.toHaveBeenCalled()
+    expect(souvenirFindMany).not.toHaveBeenCalled()
   })
 
   it('queries the 5 most recent scene logs ordered by turnNumber desc, selecting only turnNumber and turnSummary', async () => {
@@ -87,19 +91,36 @@ describe('generateScene — N1 recent-turns loading', () => {
     })
   })
 
-  it('passes the loaded recent turns through to buildSystemPrompt', async () => {
+  it('passes the loaded recent turns and souvenirs through to buildSystemPrompt', async () => {
     hasOpenRouterKey.mockReturnValue(true)
     const recentTurns = [
       { turnNumber: 3, turnSummary: 'Turn 3 happened.' },
       { turnNumber: 2, turnSummary: null },
       { turnNumber: 1, turnSummary: 'Turn 1 happened.' },
     ]
+    const souvenirs = [
+      { id: 'sv1', userId: 'user1', title: 'The Trader Fell', createdAt: new Date() },
+    ]
     sceneLogFindMany.mockResolvedValue(recentTurns)
+    souvenirFindMany.mockResolvedValue(souvenirs)
     callOpenRouter.mockResolvedValue({ success: true, content: JSON.stringify(validAiPayload) })
 
     await generateScene({ character, locale: 'en', sessionId: 's1' })
 
-    expect(buildSystemPrompt).toHaveBeenCalledWith(character, 'en', [], recentTurns)
+    expect(buildSystemPrompt).toHaveBeenCalledWith(character, 'en', [], recentTurns, souvenirs)
+  })
+
+  it('queries the 3 most recent Souvenirs for the character owner, ordered by createdAt desc', async () => {
+    hasOpenRouterKey.mockReturnValue(true)
+    callOpenRouter.mockResolvedValue({ success: true, content: JSON.stringify(validAiPayload) })
+
+    await generateScene({ character, locale: 'en', sessionId: 's1' })
+
+    expect(souvenirFindMany).toHaveBeenCalledWith({
+      where: { userId: 'user1' },
+      orderBy: { createdAt: 'desc' },
+      take: 3,
+    })
   })
 
   it('falls back to the stub when the AI response is missing turnSummary (Zod rejection)', async () => {

--- a/apps/backend/src/ai/game-master.service.ts
+++ b/apps/backend/src/ai/game-master.service.ts
@@ -6,7 +6,7 @@ import { buildStubScene } from './scene-stub'
 import { type AiScenePayload, validateAiScene } from './scene-validator'
 import { buildSystemPrompt, type RecentTurnSummary } from './system-prompt'
 
-import type { MemoryChunkModel } from '../generated/prisma/models'
+import type { MemoryChunkModel, SouvenirModel } from '../generated/prisma/models'
 import type { Character, Locale } from '@grimoire/shared'
 
 export interface GameMasterInput {
@@ -49,6 +49,19 @@ async function loadRecentTurns(sessionId: string): Promise<RecentTurnSummary[]> 
   })
 }
 
+/**
+ * Loads the N3 inter-run memory context: the 3 most recent named Souvenirs
+ * for this user (across all their sessions/characters, per #115 — Souvenirs
+ * are cross-run and permanent, never scoped to the current session).
+ */
+async function loadRecentSouvenirs(userId: string): Promise<SouvenirModel[]> {
+  return prisma.souvenir.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+    take: 3,
+  })
+}
+
 export interface GameMasterResult {
   scene: AiScenePayload
   /** How the scene was produced — useful for debugging and the front badge. */
@@ -76,15 +89,22 @@ export async function generateScene(input: GameMasterInput): Promise<GameMasterR
     return { scene: buildStubScene(input.character, input.locale), source: 'stub' }
   }
 
-  const [memoryChunks, recentTurns] = await Promise.all([
+  const [memoryChunks, recentTurns, souvenirs] = await Promise.all([
     loadMemoryChunks(input.sessionId),
     loadRecentTurns(input.sessionId),
+    loadRecentSouvenirs(input.character.userId),
   ])
 
   const result = await callOpenRouter([
     {
       role: 'system',
-      content: buildSystemPrompt(input.character, input.locale, memoryChunks, recentTurns),
+      content: buildSystemPrompt(
+        input.character,
+        input.locale,
+        memoryChunks,
+        recentTurns,
+        souvenirs
+      ),
     },
     { role: 'user', content: buildUserPrompt(input) },
   ])

--- a/apps/backend/src/ai/scene-validator.test.ts
+++ b/apps/backend/src/ai/scene-validator.test.ts
@@ -59,3 +59,65 @@ describe('validateAiScene — turnSummary (N1)', () => {
     expect(result.error).toBeDefined()
   })
 })
+
+describe('aiSceneSchema — souvenir_candidate (N3, #115)', () => {
+  it('accepts a payload with no souvenir_candidate at all (most turns)', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Yarel keeps walking.',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a valid souvenir_candidate', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'The trader falls silent forever.',
+      souvenir_candidate: {
+        title_suggestion: 'The Trader Who Never Lied',
+        body: 'Yarel watched the old trader take his last breath by the dry well, and swore to carry his warning to the next town.',
+        type: 'npc-death',
+      },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a souvenir_candidate with an invalid type', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Something happened.',
+      souvenir_candidate: {
+        title_suggestion: 'A valid title here',
+        body: 'A body long enough to pass the minimum character requirement for this schema.',
+        type: 'not-a-real-type',
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a souvenir_candidate missing title_suggestion', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Something happened.',
+      souvenir_candidate: {
+        body: 'A body long enough to pass the minimum character requirement for this schema.',
+        type: 'moral-choice',
+      },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a souvenir_candidate with an empty body', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Something happened.',
+      souvenir_candidate: { title_suggestion: 'A valid title', body: '', type: 'moral-choice' },
+    })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/backend/src/ai/scene-validator.ts
+++ b/apps/backend/src/ai/scene-validator.ts
@@ -50,8 +50,8 @@ export const aiSceneSchema = z.object({
    * the recent-turns prompt section injected between N2 chunks.
    */
   turnSummary: z.string().min(1).max(200),
-  /** Optional named-Souvenir candidate for this turn (N3 memory, #115). */
-  souvenir_candidate: aiSouvenirCandidateSchema.optional(),
+  /** Optional named-Souvenir candidate for this turn (N3 memory, #115). Some models emit `null` instead of omitting the field. */
+  souvenir_candidate: aiSouvenirCandidateSchema.nullish().transform((v) => v ?? undefined),
 })
 
 export type AiScenePayload = z.infer<typeof aiSceneSchema>

--- a/apps/backend/src/ai/scene-validator.ts
+++ b/apps/backend/src/ai/scene-validator.ts
@@ -22,6 +22,23 @@ export const persistedChoiceSchema = aiChoiceSchema.extend({
 
 export const persistedChoicesSchema = z.array(persistedChoiceSchema)
 
+/**
+ * Zod schema for the optional per-turn Souvenir candidate (N3 memory, #115).
+ * The AI proposes this only when a Souvenir-worthy moment just happened —
+ * most turns omit it entirely. `type` is an explicit hint from the AI since
+ * it can't be reliably inferred server-side from prose alone; the backend
+ * still re-validates it against the enum and applies every other rule (cap,
+ * pinned-fact match, dedup, length bounds) in `souvenir.service.ts` before
+ * ever persisting anything.
+ */
+export const aiSouvenirCandidateSchema = z.object({
+  title_suggestion: z.string().min(1).max(200),
+  body: z.string().min(1).max(1000),
+  type: z.enum(['npc-death', 'moral-choice', 'secret-discovery', 'boss-victory', 'strong-promise']),
+})
+
+export type AiSouvenirCandidate = z.infer<typeof aiSouvenirCandidateSchema>
+
 export const aiSceneSchema = z.object({
   narrative: z.string().min(1).max(4000),
   sceneType: z.enum(['exploration', 'combat', 'dialog', 'event', 'shop', 'rest']),
@@ -33,6 +50,8 @@ export const aiSceneSchema = z.object({
    * the recent-turns prompt section injected between N2 chunks.
    */
   turnSummary: z.string().min(1).max(200),
+  /** Optional named-Souvenir candidate for this turn (N3 memory, #115). */
+  souvenir_candidate: aiSouvenirCandidateSchema.optional(),
 })
 
 export type AiScenePayload = z.infer<typeof aiSceneSchema>

--- a/apps/backend/src/ai/system-prompt.test.ts
+++ b/apps/backend/src/ai/system-prompt.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { buildSystemPrompt, type RecentTurnSummary } from './system-prompt'
 
-import type { MemoryChunkModel } from '../generated/prisma/models'
+import type { MemoryChunkModel, SouvenirModel } from '../generated/prisma/models'
 
 const character = {
   id: 'char1',
@@ -29,6 +29,21 @@ function chunk(overrides: Partial<MemoryChunkModel>): MemoryChunkModel {
     npcsEvolution: [],
     turnRangeStart: 1,
     turnRangeEnd: 8,
+    createdAt: new Date(),
+    ...overrides,
+  }
+}
+
+function souvenir(overrides: Partial<SouvenirModel>): SouvenirModel {
+  return {
+    id: 'sv1',
+    userId: 'user1',
+    characterId: 'char1',
+    sessionId: 's1',
+    title: 'The Trader Who Never Lied',
+    body: 'Yarel watched the old trader take his last breath by the dry well.',
+    type: 'npc-death',
+    sharedWithAveugle: false,
     createdAt: new Date(),
     ...overrides,
   }
@@ -144,5 +159,33 @@ describe('buildSystemPrompt — N1 recent-turns injection', () => {
 
     expect(prompt.indexOf('Story so far')).toBeGreaterThanOrEqual(0)
     expect(prompt.indexOf('Recent turns')).toBeGreaterThan(prompt.indexOf('Story so far'))
+  })
+})
+
+describe('buildSystemPrompt — N3 Souvenirs injection (#115)', () => {
+  it('injects no Souvenirs section when the list is empty', () => {
+    const prompt = buildSystemPrompt(character, 'en', [], [], [])
+
+    expect(prompt).not.toContain('named Souvenirs')
+  })
+
+  it('injects each Souvenir title and body', () => {
+    const souvenirs = [
+      souvenir({ id: 'sv1', title: 'The Trader Who Never Lied', body: 'He died at dusk.' }),
+      souvenir({ id: 'sv2', title: 'The Vow at the Well', body: 'She swore to return.' }),
+    ]
+
+    const prompt = buildSystemPrompt(character, 'en', [], [], souvenirs)
+
+    expect(prompt).toContain("player's named Souvenirs from past runs")
+    expect(prompt).toContain('"The Trader Who Never Lied" — He died at dusk.')
+    expect(prompt).toContain('"The Vow at the Well" — She swore to return.')
+  })
+
+  it('documents the optional souvenir_candidate field in the JSON output instructions', () => {
+    const prompt = buildSystemPrompt(character, 'en')
+
+    expect(prompt).toContain('"souvenir_candidate"?')
+    expect(prompt).toContain('npc-death')
   })
 })

--- a/apps/backend/src/ai/system-prompt.ts
+++ b/apps/backend/src/ai/system-prompt.ts
@@ -1,4 +1,4 @@
-import type { MemoryChunkModel } from '../generated/prisma/models'
+import type { MemoryChunkModel, SouvenirModel } from '../generated/prisma/models'
 import type { Character, Locale } from '@grimoire/shared'
 
 /** Human-readable language name for the locale, injected into the prompt. */
@@ -63,6 +63,25 @@ function buildRecentTurnsSection(recentTurns: RecentTurnSummary[]): string[] {
 }
 
 /**
+ * Builds the N3 memory section: the caller passes at most the 3 most recent
+ * named Souvenirs (cross-run, per #115 — narrower than the canon's 5-max
+ * since these are a passive mention, not the Aveugle's relevance-ranked pick).
+ * Souvenirs are immutable once created; this prompt never asks the AI to
+ * alter or contradict them, only to be aware of them.
+ */
+function buildSouvenirsSection(souvenirs: SouvenirModel[]): string[] {
+  if (souvenirs.length === 0) return []
+
+  const lines = souvenirs.map((souvenir) => `- "${souvenir.title}" — ${souvenir.body}`)
+
+  return [
+    '',
+    "The player's named Souvenirs from past runs (permanent, never contradict them):",
+    ...lines,
+  ]
+}
+
+/**
  * Builds the Game Master system prompt.
  * The AI writes narration and choice labels only; the backend owns all rules,
  * dice, stats, and canon consistency. Canon brand terms are NOT re-translated —
@@ -72,7 +91,8 @@ export function buildSystemPrompt(
   character: Character,
   locale: Locale,
   memoryChunks: MemoryChunkModel[] = [],
-  recentTurns: RecentTurnSummary[] = []
+  recentTurns: RecentTurnSummary[] = [],
+  souvenirs: SouvenirModel[] = []
 ): string {
   const languageName = LOCALE_NAME[locale]
 
@@ -91,6 +111,7 @@ export function buildSystemPrompt(
     `Player character: ${character.name} — people "${character.people}", vocation "${character.vocation}".`,
     ...buildMemorySection(memoryChunks),
     ...buildRecentTurnsSection(recentTurns),
+    ...buildSouvenirsSection(souvenirs),
     '',
     'Respond with a single JSON object and nothing else, matching exactly:',
     '{',
@@ -98,11 +119,18 @@ export function buildSystemPrompt(
     '  "sceneType": "exploration" | "combat" | "dialog" | "event" | "shop" | "rest",',
     '  "location": string,',
     '  "choices": [{ "text": string, "type": "action"|"dialog"|"combat"|"flee"|"use_item"|"skill", "riskLevel"?: "safe"|"low"|"medium"|"high"|"deadly" }],',
-    '  "turnSummary": string',
+    '  "turnSummary": string,',
+    '  "souvenir_candidate"?: { "title_suggestion": string, "body": string, "type": "npc-death"|"moral-choice"|"secret-discovery"|"boss-victory"|"strong-promise" }',
     '}',
     '',
     'turnSummary: a short factual sentence (max 200 characters) condensing what just',
     'happened THIS turn — not styled narration, a compact fact usable for continuity',
     '(e.g. "The player fled the oasis after discovering the merchant NPC was lying").',
+    '',
+    'souvenir_candidate: OPTIONAL, omit on most turns. Only include it when something',
+    'truly Souvenir-worthy just happened THIS turn: a named NPC died, a major moral',
+    'choice was made, a secret was discovered, a boss was defeated, or a strong promise',
+    'was sworn. title_suggestion: 4-15 words, evocative. body: 30-70 tokens, third person,',
+    'describing the moment concretely (not restating narrative style).',
   ].join('\n')
 }

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -34,9 +34,17 @@ const gameLimiter = rateLimit({
   legacyHeaders: false,
 })
 
+// Rate-limit the authenticated read endpoints against abuse (no AI cost here).
+const apiLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+})
+
 // Routes
 app.use('/api/game', gameLimiter, requireAuth, gameRouter)
-app.use('/api/souvenirs', requireAuth, souvenirRouter)
+app.use('/api/souvenirs', apiLimiter, requireAuth, souvenirRouter)
 
 // Health check
 app.get('/api/health', (_req, res) => {

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -5,6 +5,7 @@ import rateLimit from 'express-rate-limit'
 import { env } from './config/env'
 import { requireAuth } from './middleware/auth.middleware'
 import { gameRouter } from './routes/game.routes'
+import { souvenirRouter } from './routes/souvenir.routes'
 
 const app: Express = express()
 const PORT = env.port
@@ -35,6 +36,7 @@ const gameLimiter = rateLimit({
 
 // Routes
 app.use('/api/game', gameLimiter, requireAuth, gameRouter)
+app.use('/api/souvenirs', requireAuth, souvenirRouter)
 
 // Health check
 app.get('/api/health', (_req, res) => {

--- a/apps/backend/src/routes/souvenir.routes.ts
+++ b/apps/backend/src/routes/souvenir.routes.ts
@@ -1,0 +1,35 @@
+import { type Request, type Response, Router } from 'express'
+
+import { prisma } from '../lib/prisma'
+
+import type { ApiResponse, Souvenir, SouvenirType } from '@grimoire/shared'
+
+export const souvenirRouter: Router = Router()
+
+/**
+ * GET /api/souvenirs
+ * Lists the authenticated user's named Souvenirs (N3 memory, #115), most
+ * recent first. Cross-run and permanent — scoped to `req.auth.userId` only,
+ * never to a session or character (a Souvenir outlives both). Read-only:
+ * Souvenirs are immutable once persisted by `souvenir.service.ts`.
+ */
+souvenirRouter.get('/', async (req: Request, res: Response<ApiResponse<Souvenir[]>>) => {
+  const rows = await prisma.souvenir.findMany({
+    where: { userId: req.auth!.userId },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  const data: Souvenir[] = rows.map((row) => ({
+    id: row.id,
+    userId: row.userId,
+    characterId: row.characterId,
+    sessionId: row.sessionId,
+    title: row.title,
+    body: row.body,
+    type: row.type as SouvenirType,
+    sharedWithAveugle: row.sharedWithAveugle,
+    createdAt: row.createdAt.toISOString(),
+  }))
+
+  res.json({ success: true, data })
+})

--- a/apps/backend/src/services/session.service.ts
+++ b/apps/backend/src/services/session.service.ts
@@ -17,6 +17,7 @@ import { prisma } from '../lib/prisma'
 
 import { compressScene } from './memory.service'
 import { assembleScene } from './scene-assembler'
+import { validateAndPersistSouvenirCandidate } from './souvenir.service'
 
 import type { Character as DbCharacter, GameSession } from '../generated/prisma/client'
 
@@ -364,6 +365,21 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
         )
       } catch (err) {
         console.warn(`[Memory] failed to load turns for session ${session.id}:`, err)
+      }
+    })()
+  }
+
+  if (gm.scene.souvenir_candidate) {
+    void (async () => {
+      try {
+        await validateAndPersistSouvenirCandidate(
+          session.id,
+          character.userId,
+          character.id,
+          gm.scene.souvenir_candidate!
+        )
+      } catch (err) {
+        console.warn(`[Souvenir] failed to persist candidate for session ${session.id}:`, err)
       }
     })()
   }

--- a/apps/backend/src/services/souvenir.service.test.ts
+++ b/apps/backend/src/services/souvenir.service.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const souvenirCount = vi.fn()
+const souvenirFindMany = vi.fn()
+const souvenirCreate = vi.fn()
+const souvenirDeleteMany = vi.fn()
+const memoryChunkFindMany = vi.fn()
+vi.mock('../lib/prisma', () => ({
+  prisma: {
+    souvenir: {
+      count: souvenirCount,
+      findMany: souvenirFindMany,
+      create: souvenirCreate,
+      deleteMany: souvenirDeleteMany,
+    },
+    memoryChunk: { findMany: memoryChunkFindMany },
+  },
+}))
+
+const { levenshteinDistance, validateAndPersistSouvenirCandidate, purgeInactiveSouvenirs } =
+  await import('./souvenir.service')
+
+const validCandidate = {
+  title_suggestion: 'The Trader Who Never Lied',
+  body: 'Yarel watched the old trader take his last breath by the dry well, and swore to carry his warning to the next town before the sun rose again.',
+  type: 'npc-death' as const,
+}
+
+const pinnedFacts = ['NPC died: the Trader']
+
+describe('levenshteinDistance', () => {
+  it('returns 0 for identical strings', () => {
+    expect(levenshteinDistance('The Trader', 'The Trader')).toBe(0)
+  })
+
+  it('is case-insensitive', () => {
+    expect(levenshteinDistance('The Trader', 'the trader')).toBe(0)
+  })
+
+  it('returns the edit distance for different strings', () => {
+    expect(levenshteinDistance('kitten', 'sitting')).toBe(3)
+  })
+
+  it('returns the length of the other string when one is empty', () => {
+    expect(levenshteinDistance('', 'abcde')).toBe(5)
+  })
+})
+
+describe('validateAndPersistSouvenirCandidate', () => {
+  beforeEach(() => {
+    souvenirCount.mockReset().mockResolvedValue(0)
+    souvenirFindMany.mockReset().mockResolvedValue([])
+    souvenirCreate.mockReset().mockResolvedValue({})
+    memoryChunkFindMany.mockReset().mockResolvedValue([{ keyFactsPinned: pinnedFacts }])
+  })
+
+  it('persists a valid candidate that matches a pinned fact', async () => {
+    await validateAndPersistSouvenirCandidate('s1', 'user1', 'char1', validCandidate)
+
+    expect(souvenirCreate).toHaveBeenCalledWith({
+      data: {
+        userId: 'user1',
+        characterId: 'char1',
+        sessionId: 's1',
+        title: validCandidate.title_suggestion,
+        body: validCandidate.body,
+        type: validCandidate.type,
+      },
+    })
+  })
+
+  it('discards silently when the title is too short (fewer than 4 words)', async () => {
+    await validateAndPersistSouvenirCandidate('s1', 'user1', 'char1', {
+      ...validCandidate,
+      title_suggestion: 'Two Words',
+    })
+
+    expect(souvenirCreate).not.toHaveBeenCalled()
+  })
+
+  it('discards silently when the title is too long (more than 15 words)', async () => {
+    const longTitle = Array.from({ length: 16 }, (_, i) => `word${i}`).join(' ')
+
+    await validateAndPersistSouvenirCandidate('s1', 'user1', 'char1', {
+      ...validCandidate,
+      title_suggestion: longTitle,
+    })
+
+    expect(souvenirCreate).not.toHaveBeenCalled()
+  })
+
+  it('discards silently when the body is too short', async () => {
+    await validateAndPersistSouvenirCandidate('s1', 'user1', 'char1', {
+      ...validCandidate,
+      body: 'Too short a body for this.',
+    })
+
+    expect(souvenirCreate).not.toHaveBeenCalled()
+  })
+
+  it('discards silently when the body is too long (more than 90 words)', async () => {
+    const longBody = Array.from({ length: 91 }, (_, i) => `word${i}`).join(' ')
+
+    await validateAndPersistSouvenirCandidate('s1', 'user1', 'char1', {
+      ...validCandidate,
+      body: longBody,
+    })
+
+    expect(souvenirCreate).not.toHaveBeenCalled()
+  })
+
+  it('discards silently when the session already has 3 Souvenirs (cap)', async () => {
+    souvenirCount.mockResolvedValue(3)
+
+    await validateAndPersistSouvenirCandidate('s1', 'user1', 'char1', validCandidate)
+
+    expect(souvenirCreate).not.toHaveBeenCalled()
+  })
+
+  it('persists when the session has fewer than 3 Souvenirs', async () => {
+    souvenirCount.mockResolvedValue(2)
+
+    await validateAndPersistSouvenirCandidate('s1', 'user1', 'char1', validCandidate)
+
+    expect(souvenirCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it('discards silently when the candidate matches no pinned fact', async () => {
+    memoryChunkFindMany.mockResolvedValue([
+      { keyFactsPinned: ['Quest started: locate missing cargo shipment'] },
+    ])
+
+    await validateAndPersistSouvenirCandidate('s1', 'user1', 'char1', validCandidate)
+
+    expect(souvenirCreate).not.toHaveBeenCalled()
+  })
+
+  it('discards silently when there are no pinned facts at all', async () => {
+    memoryChunkFindMany.mockResolvedValue([])
+
+    await validateAndPersistSouvenirCandidate('s1', 'user1', 'char1', validCandidate)
+
+    expect(souvenirCreate).not.toHaveBeenCalled()
+  })
+
+  it('discards silently when the title is a near-duplicate of an existing Souvenir (Levenshtein < 5)', async () => {
+    souvenirFindMany.mockResolvedValue([{ title: 'The Trader Who Never Lies' }])
+
+    await validateAndPersistSouvenirCandidate('s1', 'user1', 'char1', validCandidate)
+
+    expect(souvenirCreate).not.toHaveBeenCalled()
+  })
+
+  it('persists when the title is sufficiently different from existing Souvenirs', async () => {
+    souvenirFindMany.mockResolvedValue([{ title: 'An Entirely Unrelated Memory Title' }])
+
+    await validateAndPersistSouvenirCandidate('s1', 'user1', 'char1', validCandidate)
+
+    expect(souvenirCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it('never throws when the database errors unexpectedly', async () => {
+    souvenirCount.mockRejectedValue(new Error('DB down'))
+
+    await expect(
+      validateAndPersistSouvenirCandidate('s1', 'user1', 'char1', validCandidate)
+    ).resolves.toBeUndefined()
+
+    expect(souvenirCreate).not.toHaveBeenCalled()
+  })
+
+  it('never throws when create() itself fails', async () => {
+    souvenirCreate.mockRejectedValue(new Error('unique constraint violation'))
+
+    await expect(
+      validateAndPersistSouvenirCandidate('s1', 'user1', 'char1', validCandidate)
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe('purgeInactiveSouvenirs', () => {
+  beforeEach(() => {
+    souvenirFindMany.mockReset()
+    souvenirDeleteMany.mockReset().mockResolvedValue({ count: 0 })
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+
+  it('does nothing for a user with 20 or fewer Souvenirs', async () => {
+    souvenirFindMany.mockResolvedValue(
+      Array.from({ length: 20 }, (_, i) => ({ id: `sv${i}`, createdAt: new Date(0) }))
+    )
+
+    await purgeInactiveSouvenirs(['user1'])
+
+    expect(souvenirFindMany).toHaveBeenCalledWith({
+      where: { userId: 'user1' },
+      orderBy: { createdAt: 'desc' },
+    })
+    expect(souvenirDeleteMany).not.toHaveBeenCalled()
+  })
+
+  it('never throws when the database errors unexpectedly', async () => {
+    souvenirFindMany.mockRejectedValue(new Error('DB down'))
+
+    await expect(purgeInactiveSouvenirs(['user1'])).resolves.toBeUndefined()
+    expect(souvenirDeleteMany).not.toHaveBeenCalled()
+  })
+
+  it('skips a user whose most recent Souvenir is within the 6-month inactivity window', async () => {
+    souvenirFindMany.mockResolvedValue(
+      Array.from({ length: 25 }, (_, i) => ({ id: `sv${i}`, createdAt: new Date() }))
+    )
+
+    await purgeInactiveSouvenirs(['user1'])
+
+    expect(souvenirFindMany).toHaveBeenCalledTimes(1)
+    expect(souvenirDeleteMany).not.toHaveBeenCalled()
+  })
+
+  it('deletes the oldest Souvenirs beyond the retention count for an inactive user over the cap', async () => {
+    const oldDate = new Date(Date.now() - 1000 * 60 * 60 * 24 * 30 * 7) // 7 months ago
+    souvenirFindMany.mockResolvedValue(
+      Array.from({ length: 25 }, (_, i) => ({ id: `sv${i}`, createdAt: oldDate }))
+    )
+
+    await purgeInactiveSouvenirs(['user1'])
+
+    expect(souvenirDeleteMany).toHaveBeenCalledWith({
+      where: { id: { in: Array.from({ length: 5 }, (_, i) => `sv${i + 20}`) } },
+    })
+  })
+
+  it('never throws when deleteMany itself fails', async () => {
+    const oldDate = new Date(Date.now() - 1000 * 60 * 60 * 24 * 30 * 7)
+    souvenirFindMany.mockResolvedValue(
+      Array.from({ length: 25 }, (_, i) => ({ id: `sv${i}`, createdAt: oldDate }))
+    )
+    souvenirDeleteMany.mockRejectedValue(new Error('DB down'))
+
+    await expect(purgeInactiveSouvenirs(['user1'])).resolves.toBeUndefined()
+  })
+})

--- a/apps/backend/src/services/souvenir.service.ts
+++ b/apps/backend/src/services/souvenir.service.ts
@@ -1,0 +1,185 @@
+import { prisma } from '../lib/prisma'
+
+import type { AiSouvenirCandidate } from '../ai/scene-validator'
+
+const MAX_SOUVENIRS_PER_SESSION = 3
+const TITLE_MIN_WORDS = 4
+const TITLE_MAX_WORDS = 15
+// Approximated via word count (no tokenizer dependency) — 1.3 words/token per
+// the canon budget, so 30-70 tokens ≈ 23-90 words. Kept simple per spec.
+const BODY_MIN_WORDS = 23
+const BODY_MAX_WORDS = 90
+const DEDUP_LEVENSHTEIN_THRESHOLD = 5
+/** Purge threshold for free-tier accounts (6 months of inactivity, canon 16-MEMORY.md §8). */
+const PURGE_INACTIVITY_MS = 1000 * 60 * 60 * 24 * 30 * 6
+/** Souvenirs retained per free-tier user after a purge (canon 14-META-WORLD.md §8). */
+const PURGE_RETENTION_COUNT = 20
+
+function countWords(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length
+}
+
+/**
+ * Classic edit-distance (insert/delete/substitute) between two strings,
+ * case-insensitive — used for cross-run Souvenir title dedup. No dependency:
+ * small enough to keep local (canon threshold is < 5, titles are short).
+ */
+export function levenshteinDistance(a: string, b: string): number {
+  const s = a.toLowerCase()
+  const t = b.toLowerCase()
+  const rows = s.length + 1
+  const cols = t.length + 1
+  const matrix: number[][] = Array.from({ length: rows }, () => new Array<number>(cols).fill(0))
+
+  for (let i = 0; i < rows; i++) matrix[i][0] = i
+  for (let j = 0; j < cols; j++) matrix[0][j] = j
+
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      const cost = s[i - 1] === t[j - 1] ? 0 : 1
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1, // deletion
+        matrix[i][j - 1] + 1, // insertion
+        matrix[i - 1][j - 1] + cost // substitution
+      )
+    }
+  }
+
+  return matrix[rows - 1][cols - 1]
+}
+
+/** Lowercased keyword tokens (3+ chars) used for the pinned-fact overlap heuristic. */
+function keywordsOf(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^a-zà-ÿ0-9']+/i)
+      .filter((word) => word.length >= 3)
+  )
+}
+
+/**
+ * Heuristic match between the candidate's content and the session's pinned
+ * facts (`MemoryChunk.keyFactsPinned`): true if any pinned fact shares at
+ * least one keyword with the candidate's title or body. Deliberately simple
+ * substring/keyword overlap, not semantic matching (see #115 spec — pgvector
+ * explicitly rejected for Souvenirs).
+ */
+function matchesPinnedFacts(candidate: AiSouvenirCandidate, pinnedFacts: string[]): boolean {
+  if (pinnedFacts.length === 0) return false
+
+  const candidateWords = new Set([
+    ...keywordsOf(candidate.title_suggestion),
+    ...keywordsOf(candidate.body),
+  ])
+
+  return pinnedFacts.some((fact) => {
+    const factWords = keywordsOf(fact)
+    for (const word of factWords) {
+      if (candidateWords.has(word)) return true
+    }
+    return false
+  })
+}
+
+/**
+ * Validates a per-turn Souvenir candidate against every canon rule (16-MEMORY
+ * §6, 14-META-WORLD §2) and persists it as an immutable `Souvenir` row on
+ * success. Fire-and-forget-safe: never throws, silently discards on any
+ * validation failure, and logs a warning only on unexpected errors (DB down,
+ * etc). Must never block or crash `resolveTurn`.
+ */
+export async function validateAndPersistSouvenirCandidate(
+  sessionId: string,
+  userId: string,
+  characterId: string,
+  candidate: AiSouvenirCandidate
+): Promise<void> {
+  try {
+    const titleWords = countWords(candidate.title_suggestion)
+    if (titleWords < TITLE_MIN_WORDS || titleWords > TITLE_MAX_WORDS) {
+      return
+    }
+
+    const bodyWords = countWords(candidate.body)
+    if (bodyWords < BODY_MIN_WORDS || bodyWords > BODY_MAX_WORDS) {
+      return
+    }
+
+    const sessionSouvenirCount = await prisma.souvenir.count({ where: { sessionId } })
+    if (sessionSouvenirCount >= MAX_SOUVENIRS_PER_SESSION) {
+      return
+    }
+
+    const memoryChunks = await prisma.memoryChunk.findMany({
+      where: { sessionId },
+      select: { keyFactsPinned: true },
+    })
+    const pinnedFacts = memoryChunks.flatMap((chunk) =>
+      Array.isArray(chunk.keyFactsPinned) ? (chunk.keyFactsPinned as string[]) : []
+    )
+    if (!matchesPinnedFacts(candidate, pinnedFacts)) {
+      return
+    }
+
+    const existingSouvenirs = await prisma.souvenir.findMany({
+      where: { userId },
+      select: { title: true },
+    })
+    const isDuplicate = existingSouvenirs.some(
+      (existing) =>
+        levenshteinDistance(existing.title, candidate.title_suggestion) <
+        DEDUP_LEVENSHTEIN_THRESHOLD
+    )
+    if (isDuplicate) {
+      return
+    }
+
+    await prisma.souvenir.create({
+      data: {
+        userId,
+        characterId,
+        sessionId,
+        title: candidate.title_suggestion,
+        body: candidate.body,
+        type: candidate.type,
+      },
+    })
+  } catch (err) {
+    console.warn(`[Souvenir] validation/persist failed for session ${sessionId}:`, err)
+  }
+}
+
+/**
+ * Best-effort purge for free-tier users: caps each user's retained Souvenirs
+ * to 20 after 6 months of inactivity (canon 14-META-WORLD.md §8, 16-MEMORY.md
+ * §8). Anonymous tier is cookie-based (no DB rows to purge) and Premium is
+ * never purged — both are out of scope for this function's callers to filter.
+ * Not yet wired to a scheduler: this codebase has no cron/job infrastructure
+ * today, so this stays a plain exported function until one exists.
+ */
+export async function purgeInactiveSouvenirs(freeTierUserIds: string[]): Promise<void> {
+  const cutoff = new Date(Date.now() - PURGE_INACTIVITY_MS)
+
+  for (const userId of freeTierUserIds) {
+    try {
+      const souvenirs = await prisma.souvenir.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'desc' },
+      })
+      if (souvenirs.length <= PURGE_RETENTION_COUNT) {
+        continue
+      }
+
+      const mostRecentActivity = souvenirs[0].createdAt
+      if (mostRecentActivity > cutoff) {
+        continue
+      }
+
+      const toDelete = souvenirs.slice(PURGE_RETENTION_COUNT).map((s) => s.id)
+      await prisma.souvenir.deleteMany({ where: { id: { in: toDelete } } })
+    } catch (err) {
+      console.warn(`[Souvenir] purge failed for user ${userId}:`, err)
+    }
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,7 @@ export * from "./types/inventory.types";
 export * from "./types/combat.types";
 export * from "./types/session.types";
 export * from "./types/api.types";
+export * from "./types/souvenir.types";
 
 // Constants
 export * from "./constants/localized";

--- a/packages/shared/src/types/souvenir.types.ts
+++ b/packages/shared/src/types/souvenir.types.ts
@@ -1,0 +1,19 @@
+/** Trigger category for a named Souvenir. @see 14-META-WORLD.md §9 */
+export type SouvenirType =
+  | "npc-death"
+  | "moral-choice"
+  | "secret-discovery"
+  | "boss-victory"
+  | "strong-promise";
+
+export interface Souvenir {
+  id: string;
+  userId: string;
+  characterId: string;
+  sessionId: string;
+  title: string;
+  body: string;
+  type: SouvenirType;
+  sharedWithAveugle: boolean;
+  createdAt: string;
+}


### PR DESCRIPTION
## Résumé

- Souvenirs nommés (N3 mémoire inter-run) : modèle Prisma `Souvenir`, validation Zod du candidate IA, service de détection/persistance/dédup/cap, injection des 3 plus récents dans le prompt système, endpoint galerie, purge 6 mois d'inactivité.
- fix(#137) inclus : `souvenir_candidate` utilisait `.optional()` (rejette `null`), alors que le LLM renvoie systématiquement `"souvenir_candidate": null` au lieu d'omettre la clé. Cela faisait échouer la validation Zod de la scène entière et provoquait un fallback stub systématique (le jeu semblait "toujours bloqué"/texte identique). Passé à `.nullish().transform((v) => v ?? undefined)`.

Closes #115
Closes #137

## Test plan

- [x] `pnpm type-check --filter @grimoire/backend`
- [x] `pnpm test --filter @grimoire/backend`
- [x] Vérifié en live via le Browser pane sur `/velkhar/session/1` : badge `AI GAME MASTER` (plus `STUB FALLBACK`), narration variée à chaque tour, aucune erreur de validation Zod dans les logs backend.