### PR TITLE
feat(frontend): connecter Dashboard, reprise et navigation Velkhar

### DIFF
--- a/apps/frontend/src/app/(auth)/login/LoginForm.tsx
+++ b/apps/frontend/src/app/(auth)/login/LoginForm.tsx
@@ -9,13 +9,18 @@ import { GameField } from '@/components/ui/grimoire/GameField/GameField'
 import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
 import { GameInput } from '@/components/ui/grimoire/GameInput/GameInput'
 import { GamePanel } from '@/components/ui/grimoire/GamePanel/GamePanel'
+import { getAuthHref } from '@/lib/internal-navigation'
 import { createClient } from '@/lib/supabase/client'
 
 import type { FormEvent } from 'react'
 
 import './login-form.css'
 
-export function LoginForm() {
+interface LoginFormProps {
+  nextPath: string
+}
+
+export function LoginForm({ nextPath }: LoginFormProps) {
   const [email, setEmail] = useState('')
   const [status, setStatus] = useState<'idle' | 'loading' | 'sent' | 'error'>('idle')
 
@@ -24,9 +29,11 @@ export function LoginForm() {
     setStatus('loading')
 
     const supabase = createClient()
+    const callbackUrl = new URL('/auth/callback', window.location.origin)
+    callbackUrl.searchParams.set('next', nextPath)
     const { error } = await supabase.auth.signInWithOtp({
       email,
-      options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
+      options: { emailRedirectTo: callbackUrl.toString() },
     })
 
     setStatus(error ? 'error' : 'sent')
@@ -35,9 +42,11 @@ export function LoginForm() {
   async function handleOAuth(provider: 'google' | 'discord') {
     setStatus('loading')
     const supabase = createClient()
+    const callbackUrl = new URL('/auth/callback', window.location.origin)
+    callbackUrl.searchParams.set('next', nextPath)
     const { error } = await supabase.auth.signInWithOAuth({
       provider,
-      options: { redirectTo: `${window.location.origin}/auth/callback` },
+      options: { redirectTo: callbackUrl.toString() },
     })
 
     if (error) setStatus('error')
@@ -103,7 +112,7 @@ export function LoginForm() {
       </form>
 
       <p className="login-form__footer">
-        Première visite ? <Link href="/signup">Créer votre chronique</Link>
+        Première visite ? <Link href={getAuthHref('/signup', nextPath)}>Créer votre chronique</Link>
       </p>
     </GamePanel>
   )

--- a/apps/frontend/src/app/(auth)/login/page.tsx
+++ b/apps/frontend/src/app/(auth)/login/page.tsx
@@ -1,3 +1,5 @@
+import { getSafeInternalDestination } from '@/lib/internal-navigation'
+
 import { LoginForm } from './LoginForm'
 
 import type { Metadata } from 'next'
@@ -7,6 +9,13 @@ export const metadata: Metadata = {
   description: 'Reprenez votre chronique et retournez dans le monde de Velkhar.',
 }
 
-export default function LoginPage() {
-  return <LoginForm />
+interface LoginPageProps {
+  searchParams: Promise<{ next?: string | string[] }>
+}
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const { next } = await searchParams
+  const nextPath = getSafeInternalDestination(next)
+
+  return <LoginForm nextPath={nextPath} />
 }

--- a/apps/frontend/src/app/(auth)/signup/SignupForm.tsx
+++ b/apps/frontend/src/app/(auth)/signup/SignupForm.tsx
@@ -9,13 +9,18 @@ import { GameField } from '@/components/ui/grimoire/GameField/GameField'
 import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
 import { GameInput } from '@/components/ui/grimoire/GameInput/GameInput'
 import { GamePanel } from '@/components/ui/grimoire/GamePanel/GamePanel'
+import { getAuthHref } from '@/lib/internal-navigation'
 import { createClient } from '@/lib/supabase/client'
 
 import type { FormEvent } from 'react'
 
 import '../login/login-form.css'
 
-export function SignupForm() {
+interface SignupFormProps {
+  nextPath: string
+}
+
+export function SignupForm({ nextPath }: SignupFormProps) {
   const [email, setEmail] = useState('')
   const [status, setStatus] = useState<'idle' | 'loading' | 'sent' | 'error'>('idle')
 
@@ -24,11 +29,13 @@ export function SignupForm() {
     setStatus('loading')
 
     const supabase = createClient()
+    const callbackUrl = new URL('/auth/callback', window.location.origin)
+    callbackUrl.searchParams.set('next', nextPath)
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
         shouldCreateUser: true,
-        emailRedirectTo: `${window.location.origin}/auth/callback`,
+        emailRedirectTo: callbackUrl.toString(),
       },
     })
 
@@ -38,9 +45,11 @@ export function SignupForm() {
   async function handleOAuth(provider: 'google' | 'discord') {
     setStatus('loading')
     const supabase = createClient()
+    const callbackUrl = new URL('/auth/callback', window.location.origin)
+    callbackUrl.searchParams.set('next', nextPath)
     const { error } = await supabase.auth.signInWithOAuth({
       provider,
-      options: { redirectTo: `${window.location.origin}/auth/callback` },
+      options: { redirectTo: callbackUrl.toString() },
     })
 
     if (error) setStatus('error')
@@ -105,7 +114,7 @@ export function SignupForm() {
       </form>
 
       <p className="login-form__footer">
-        Chronique existante ? <Link href="/login">Se connecter</Link>
+        Chronique existante ? <Link href={getAuthHref('/login', nextPath)}>Se connecter</Link>
       </p>
     </GamePanel>
   )

--- a/apps/frontend/src/app/(auth)/signup/page.tsx
+++ b/apps/frontend/src/app/(auth)/signup/page.tsx
@@ -1,3 +1,5 @@
+import { getSafeInternalDestination } from '@/lib/internal-navigation'
+
 import { SignupForm } from './SignupForm'
 
 import type { Metadata } from 'next'
@@ -7,6 +9,13 @@ export const metadata: Metadata = {
   description: 'Créez votre chronique et préparez votre entrée dans Velkhar.',
 }
 
-export default function SignupPage() {
-  return <SignupForm />
+interface SignupPageProps {
+  searchParams: Promise<{ next?: string | string[] }>
+}
+
+export default async function SignupPage({ searchParams }: SignupPageProps) {
+  const { next } = await searchParams
+  const nextPath = getSafeInternalDestination(next)
+
+  return <SignupForm nextPath={nextPath} />
 }

--- a/apps/frontend/src/app/(home)/_components/SectionGameplay/SectionGameplay.tsx
+++ b/apps/frontend/src/app/(home)/_components/SectionGameplay/SectionGameplay.tsx
@@ -61,7 +61,7 @@ export function SectionGameplay() {
           ))}
         </div>
         <div data-motion="reveal">
-          <Button className="button--gameplay" data-magnetic href="/signup">
+          <Button className="button--gameplay" data-magnetic href="/velkhar/aveugle">
             {GAMEPLAY_COPY.cta}
           </Button>
         </div>

--- a/apps/frontend/src/app/(home)/_components/SectionOutro/SectionOutro.tsx
+++ b/apps/frontend/src/app/(home)/_components/SectionOutro/SectionOutro.tsx
@@ -58,7 +58,7 @@ export function SectionOutro() {
           {OUTRO_COPY.body}
         </p>
         <div data-motion="reveal">
-          <Button data-magnetic href="/signup">
+          <Button data-magnetic href="/velkhar/aveugle">
             {OUTRO_COPY.cta}
           </Button>
         </div>

--- a/apps/frontend/src/app/(main)/_lib/campaign-resume.test.ts
+++ b/apps/frontend/src/app/(main)/_lib/campaign-resume.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getCampaignResumeSnapshot,
+  resolveCampaignDestination,
+  type CampaignResumeSnapshot,
+} from './campaign-resume'
+
+describe('campaign resume adapter', () => {
+  it('resolves an active run to the session route', () => {
+    const snapshot = getCampaignResumeSnapshot('cendre-veille')
+
+    expect(snapshot && resolveCampaignDestination(snapshot)).toBe('/velkhar/session/resume')
+  })
+
+  it.each<CampaignResumeSnapshot>([
+    { campaignId: 'new', stage: 'character-create' },
+    { campaignId: 'known', stage: 'inn' },
+  ])('routes the $stage state to its useful destination', (snapshot) => {
+    const destination = resolveCampaignDestination(snapshot)
+    const expected =
+      snapshot.stage === 'character-create'
+        ? '/velkhar/character-create?campaign=new'
+        : '/velkhar/aveugle?campaign=known'
+
+    expect(destination).toBe(expected)
+  })
+
+  it('returns null for a campaign unavailable to the client', () => {
+    expect(getCampaignResumeSnapshot('inconnue')).toBeNull()
+  })
+})

--- a/apps/frontend/src/app/(main)/_lib/campaign-resume.test.ts
+++ b/apps/frontend/src/app/(main)/_lib/campaign-resume.test.ts
@@ -20,7 +20,7 @@ describe('campaign resume adapter', () => {
     const destination = resolveCampaignDestination(snapshot)
     const expected =
       snapshot.stage === 'character-create'
-        ? '/velkhar/character-create?campaign=new'
+        ? '/velkhar/aveugle?flow=character-create&campaign=new'
         : '/velkhar/aveugle?campaign=known'
 
     expect(destination).toBe(expected)

--- a/apps/frontend/src/app/(main)/_lib/campaign-resume.ts
+++ b/apps/frontend/src/app/(main)/_lib/campaign-resume.ts
@@ -1,0 +1,42 @@
+export type CampaignResumeStage = 'character-create' | 'inn' | 'session'
+
+export interface CampaignResumeSnapshot {
+  campaignId: string
+  sessionId?: string
+  stage: CampaignResumeStage
+}
+
+const CAMPAIGN_FIXTURES: Record<string, CampaignResumeSnapshot> = {
+  'cendre-veille': {
+    campaignId: 'cendre-veille',
+    sessionId: 'resume',
+    stage: 'session',
+  },
+  'nouvelle-chronique': {
+    campaignId: 'nouvelle-chronique',
+    stage: 'character-create',
+  },
+  'retour-aveugle': {
+    campaignId: 'retour-aveugle',
+    stage: 'inn',
+  },
+}
+
+/** Fixture adapter until a read-only campaign contract is available. */
+export function getCampaignResumeSnapshot(campaignId: string): CampaignResumeSnapshot | null {
+  return CAMPAIGN_FIXTURES[campaignId] ?? null
+}
+
+export function resolveCampaignDestination(snapshot: CampaignResumeSnapshot): string {
+  const campaign = encodeURIComponent(snapshot.campaignId)
+
+  if (snapshot.stage === 'session' && snapshot.sessionId) {
+    return `/velkhar/session/${encodeURIComponent(snapshot.sessionId)}`
+  }
+
+  if (snapshot.stage === 'character-create') {
+    return `/velkhar/character-create?campaign=${campaign}`
+  }
+
+  return `/velkhar/aveugle?campaign=${campaign}`
+}

--- a/apps/frontend/src/app/(main)/_lib/campaign-resume.ts
+++ b/apps/frontend/src/app/(main)/_lib/campaign-resume.ts
@@ -35,7 +35,7 @@ export function resolveCampaignDestination(snapshot: CampaignResumeSnapshot): st
   }
 
   if (snapshot.stage === 'character-create') {
-    return `/velkhar/character-create?campaign=${campaign}`
+    return `/velkhar/aveugle?flow=character-create&campaign=${campaign}`
   }
 
   return `/velkhar/aveugle?campaign=${campaign}`

--- a/apps/frontend/src/app/(main)/dashboard/_components/DashboardContent/DashboardContent.tsx
+++ b/apps/frontend/src/app/(main)/dashboard/_components/DashboardContent/DashboardContent.tsx
@@ -5,15 +5,16 @@ import { GameSectionHeading } from '@/components/ui/grimoire/GameSectionHeading/
 import { getAuthHref } from '@/lib/internal-navigation'
 
 import type { DashboardViewModel } from '../../_data/dashboard-view-model'
+import type { ViewerTier } from '@/lib/viewer'
 
 import './dashboard-content.css'
 
 interface DashboardContentProps {
-  hasAccount: boolean
+  tier: ViewerTier
   viewModel: DashboardViewModel
 }
 
-export function DashboardContent({ hasAccount, viewModel }: DashboardContentProps) {
+export function DashboardContent({ tier, viewModel }: DashboardContentProps) {
   return (
     <main className="dashboard-content">
       <header className="dashboard-content__intro">
@@ -70,7 +71,7 @@ export function DashboardContent({ hasAccount, viewModel }: DashboardContentProp
               </GameLink>
             )}
 
-            {!hasAccount ? (
+            {tier === 'anonymous' ? (
               <GameLink href={getAuthHref('/login', '/dashboard')} size="sm" variant="ghost">
                 Retrouver mes traces
               </GameLink>

--- a/apps/frontend/src/app/(main)/dashboard/_components/DashboardContent/DashboardContent.tsx
+++ b/apps/frontend/src/app/(main)/dashboard/_components/DashboardContent/DashboardContent.tsx
@@ -1,0 +1,107 @@
+import { GameLink } from '@/components/ui/game-link'
+import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
+import { GamePanel } from '@/components/ui/grimoire/GamePanel/GamePanel'
+import { GameSectionHeading } from '@/components/ui/grimoire/GameSectionHeading/GameSectionHeading'
+import { getAuthHref } from '@/lib/internal-navigation'
+
+import type { DashboardViewModel } from '../../_data/dashboard-view-model'
+
+import './dashboard-content.css'
+
+interface DashboardContentProps {
+  hasAccount: boolean
+  viewModel: DashboardViewModel
+}
+
+export function DashboardContent({ hasAccount, viewModel }: DashboardContentProps) {
+  return (
+    <main className="dashboard-content">
+      <header className="dashboard-content__intro">
+        <p className="dashboard-content__welcome">Bienvenue, {viewModel.viewerLabel}</p>
+        <GameSectionHeading
+          description="Reprenez une trace existante ou franchissez à nouveau le seuil de L’Aveugle."
+          eyebrow="Le monde se souvient"
+          level={1}
+          title="Vos Chroniques"
+        />
+      </header>
+
+      <section className="dashboard-content__grid" aria-label="Accès à vos aventures">
+        <GamePanel
+          as="article"
+          className="dashboard-content__resume"
+          ornament="diamond"
+          padding="md"
+          tone={viewModel.activeRun ? 'gold' : 'neutral'}
+          variant="main"
+        >
+          <div className="dashboard-content__panel-heading">
+            <GameIcon decorative name={viewModel.activeRun ? 'fire' : 'footprint'} size={48} />
+            <div>
+              <p>{viewModel.activeRun ? viewModel.activeRun.progressLabel : 'Aucun run actif'}</p>
+              <h2>
+                {viewModel.activeRun
+                  ? viewModel.activeRun.title
+                  : 'Une nouvelle trace attend d’être laissée'}
+              </h2>
+            </div>
+          </div>
+
+          <p className="dashboard-content__copy">
+            {viewModel.activeRun
+              ? `${viewModel.activeRun.lastActivityLabel}. La reprise vous reconduira directement à la scène active.`
+              : 'Le premier run reste accessible sans compte. L’Auberge demeure l’unique point de départ.'}
+          </p>
+
+          <div className="dashboard-content__actions">
+            {viewModel.activeRun ? (
+              <GameLink
+                href={`/velkhar/campaign/${viewModel.activeRun.campaignId}`}
+                trailingIcon={<GameIcon decorative name="arrow" size={24} />}
+              >
+                Reprendre le récit
+              </GameLink>
+            ) : (
+              <GameLink
+                href="/velkhar/campaign/nouvelle-chronique"
+                trailingIcon={<GameIcon decorative name="arrow" size={24} />}
+              >
+                Franchir le seuil
+              </GameLink>
+            )}
+
+            {!hasAccount ? (
+              <GameLink href={getAuthHref('/login', '/dashboard')} size="sm" variant="ghost">
+                Retrouver mes traces
+              </GameLink>
+            ) : null}
+          </div>
+        </GamePanel>
+
+        <GamePanel as="section" padding="md" variant="sidebar">
+          <div className="dashboard-content__panel-heading">
+            <GameIcon decorative name="book" size={48} />
+            <div>
+              <p>Bibliothèque</p>
+              <h2>Chroniques récentes</h2>
+            </div>
+          </div>
+
+          {viewModel.recentChronicles.length === 0 ? (
+            <div className="dashboard-content__empty">
+              <p>Aucune Chronique n’est encore consignée.</p>
+              <span>Chaque run achevé laissera ici son récit.</span>
+            </div>
+          ) : null}
+        </GamePanel>
+      </section>
+
+      <aside className="dashboard-content__boundary" aria-label="Rôle du Dashboard">
+        <GameIcon decorative name="key" size={32} />
+        <p>
+          Le Dashboard retrouve vos traces. L’Auberge de L’Aveugle reste le seul hub entre les runs.
+        </p>
+      </aside>
+    </main>
+  )
+}

--- a/apps/frontend/src/app/(main)/dashboard/_components/DashboardContent/dashboard-content.css
+++ b/apps/frontend/src/app/(main)/dashboard/_components/DashboardContent/dashboard-content.css
@@ -1,0 +1,145 @@
+.dashboard-content {
+  margin: 0 auto;
+  max-width: 88rem;
+  padding: clamp(3rem, 7vw, 7rem) clamp(1rem, 4vw, 4rem) 5rem;
+  position: relative;
+  width: 100%;
+}
+
+.dashboard-content__intro {
+  margin: 0 auto clamp(2.5rem, 5vw, 4.5rem);
+  max-width: 62rem;
+}
+
+.dashboard-content__welcome {
+  color: var(--ink-2);
+  font-family: var(--font-accent);
+  font-size: 1.1rem;
+  font-style: italic;
+  margin: 0 0 1rem;
+  text-align: center;
+  text-wrap: pretty;
+}
+
+.dashboard-content__grid {
+  align-items: stretch;
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2.5rem);
+  grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 0.85fr);
+}
+
+.dashboard-content__panel-heading {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+}
+
+.dashboard-content__panel-heading .game-icon {
+  flex: 0 0 auto;
+  filter: brightness(0.94) drop-shadow(0 7px 15px rgba(0, 0, 0, 0.45));
+}
+
+.dashboard-content__panel-heading p {
+  color: var(--gold);
+  font-family: var(--font-ui);
+  font-size: 0.78rem;
+  letter-spacing: 0.15em;
+  margin: 0 0 0.15rem;
+  text-transform: uppercase;
+}
+
+.dashboard-content__panel-heading h2 {
+  color: var(--gold-light);
+  font-family: var(--font-accent);
+  font-size: clamp(1.55rem, 2vw, 2.1rem);
+  font-weight: 500;
+  line-height: 1.1;
+  margin: 0;
+  text-wrap: balance;
+}
+
+.dashboard-content__copy {
+  color: var(--ink-2);
+  margin: clamp(1.5rem, 3vw, 2.5rem) 0;
+  max-width: 48ch;
+  text-wrap: pretty;
+}
+
+.dashboard-content__actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.dashboard-content__actions .game-button {
+  max-width: 100%;
+}
+
+.dashboard-content__empty {
+  border-top: 1px solid rgba(217, 164, 65, 0.2);
+  margin-top: 1.75rem;
+  padding-top: 1.75rem;
+}
+
+.dashboard-content__empty p {
+  color: var(--parchment);
+  font-family: var(--font-accent);
+  font-size: 1.25rem;
+  font-style: italic;
+  margin: 0 0 0.4rem;
+  text-wrap: pretty;
+}
+
+.dashboard-content__empty span {
+  color: var(--ink-2);
+  font-family: var(--font-ui);
+  font-size: 0.96rem;
+}
+
+.dashboard-content__boundary {
+  align-items: center;
+  color: var(--ink-2);
+  display: flex;
+  gap: 0.8rem;
+  justify-content: center;
+  margin: clamp(2.5rem, 5vw, 4rem) auto 0;
+  max-width: 44rem;
+  text-align: center;
+}
+
+.dashboard-content__boundary p {
+  font-family: var(--font-accent);
+  font-size: 1.05rem;
+  font-style: italic;
+  margin: 0;
+  text-wrap: pretty;
+}
+
+@media (max-width: 900px) {
+  .dashboard-content__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard-content {
+    padding-inline: 0.75rem;
+  }
+
+  .dashboard-content__actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .dashboard-content__actions .game-button {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .dashboard-content__boundary {
+    align-items: flex-start;
+    padding-inline: 0.75rem;
+    text-align: left;
+  }
+}

--- a/apps/frontend/src/app/(main)/dashboard/_data/dashboard-view-model.test.ts
+++ b/apps/frontend/src/app/(main)/dashboard/_data/dashboard-view-model.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { createDashboardViewModel } from './dashboard-view-model'
+
+describe('dashboard view model', () => {
+  it('exposes the resume fixture only to an account view', () => {
+    expect(createDashboardViewModel(true, 'Adem').activeRun?.campaignId).toBe('cendre-veille')
+    expect(createDashboardViewModel(false, null).activeRun).toBeNull()
+  })
+
+  it('uses a stable anonymous label', () => {
+    expect(createDashboardViewModel(false, null).viewerLabel).toBe('Visiteur')
+  })
+})

--- a/apps/frontend/src/app/(main)/dashboard/_data/dashboard-view-model.test.ts
+++ b/apps/frontend/src/app/(main)/dashboard/_data/dashboard-view-model.test.ts
@@ -3,12 +3,26 @@ import { describe, expect, it } from 'vitest'
 import { createDashboardViewModel } from './dashboard-view-model'
 
 describe('dashboard view model', () => {
-  it('exposes the resume fixture only to an account view', () => {
-    expect(createDashboardViewModel(true, 'Adem').activeRun?.campaignId).toBe('cendre-veille')
-    expect(createDashboardViewModel(false, null).activeRun).toBeNull()
+  it('does not invent a run from the viewer tier', () => {
+    expect(createDashboardViewModel('premium', 'Adem').activeRun).toBeNull()
+    expect(createDashboardViewModel('free', null).activeRun).toBeNull()
   })
 
   it('uses a stable anonymous label', () => {
-    expect(createDashboardViewModel(false, null).viewerLabel).toBe('Visiteur')
+    expect(createDashboardViewModel('anonymous', null).viewerLabel).toBe('Visiteur')
+  })
+
+  it('can expose an anonymous run supplied by the data adapter', () => {
+    const viewModel = createDashboardViewModel('anonymous', null, {
+      activeRun: {
+        campaignId: 'cendre-veille',
+        lastActivityLabel: 'À l’instant',
+        progressLabel: 'Run en cours',
+        title: 'Le chemin demeure ouvert',
+      },
+      recentChronicles: [],
+    })
+
+    expect(viewModel.activeRun?.campaignId).toBe('cendre-veille')
   })
 })

--- a/apps/frontend/src/app/(main)/dashboard/_data/dashboard-view-model.ts
+++ b/apps/frontend/src/app/(main)/dashboard/_data/dashboard-view-model.ts
@@ -1,0 +1,30 @@
+export interface DashboardRunViewModel {
+  campaignId: string
+  lastActivityLabel: string
+  progressLabel: string
+  title: string
+}
+
+export interface DashboardViewModel {
+  activeRun: DashboardRunViewModel | null
+  recentChronicles: readonly []
+  viewerLabel: string
+}
+
+export function createDashboardViewModel(
+  hasAccount: boolean,
+  displayName: string | null
+): DashboardViewModel {
+  return {
+    activeRun: hasAccount
+      ? {
+          campaignId: 'cendre-veille',
+          lastActivityLabel: 'Dernière trace conservée',
+          progressLabel: 'Run en cours',
+          title: 'Le chemin demeure ouvert',
+        }
+      : null,
+    recentChronicles: [],
+    viewerLabel: displayName ?? (hasAccount ? 'Voyageur' : 'Visiteur'),
+  }
+}

--- a/apps/frontend/src/app/(main)/dashboard/_data/dashboard-view-model.ts
+++ b/apps/frontend/src/app/(main)/dashboard/_data/dashboard-view-model.ts
@@ -1,3 +1,5 @@
+import type { ViewerTier } from '@/lib/viewer'
+
 export interface DashboardRunViewModel {
   campaignId: string
   lastActivityLabel: string
@@ -11,20 +13,24 @@ export interface DashboardViewModel {
   viewerLabel: string
 }
 
+export interface DashboardSnapshot {
+  activeRun: DashboardRunViewModel | null
+  recentChronicles: readonly []
+}
+
+const EMPTY_DASHBOARD_SNAPSHOT: DashboardSnapshot = {
+  activeRun: null,
+  recentChronicles: [],
+}
+
 export function createDashboardViewModel(
-  hasAccount: boolean,
-  displayName: string | null
+  tier: ViewerTier,
+  displayName: string | null,
+  snapshot: DashboardSnapshot = EMPTY_DASHBOARD_SNAPSHOT
 ): DashboardViewModel {
   return {
-    activeRun: hasAccount
-      ? {
-          campaignId: 'cendre-veille',
-          lastActivityLabel: 'Dernière trace conservée',
-          progressLabel: 'Run en cours',
-          title: 'Le chemin demeure ouvert',
-        }
-      : null,
-    recentChronicles: [],
-    viewerLabel: displayName ?? (hasAccount ? 'Voyageur' : 'Visiteur'),
+    activeRun: snapshot.activeRun,
+    recentChronicles: snapshot.recentChronicles,
+    viewerLabel: displayName ?? (tier === 'anonymous' ? 'Visiteur' : 'Voyageur'),
   }
 }

--- a/apps/frontend/src/app/(main)/dashboard/page.tsx
+++ b/apps/frontend/src/app/(main)/dashboard/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 
 export default async function DashboardPage() {
   const viewer = await getViewerSummary()
-  const viewModel = createDashboardViewModel(viewer.hasAccount, viewer.displayName)
+  const viewModel = createDashboardViewModel(viewer.tier, viewer.displayName)
 
-  return <DashboardContent hasAccount={viewer.hasAccount} viewModel={viewModel} />
+  return <DashboardContent tier={viewer.tier} viewModel={viewModel} />
 }

--- a/apps/frontend/src/app/(main)/dashboard/page.tsx
+++ b/apps/frontend/src/app/(main)/dashboard/page.tsx
@@ -1,3 +1,18 @@
-export default function DashboardPage() {
-  return <div data-page="dashboard" />
+import { getViewerSummary } from '@/lib/viewer'
+
+import { DashboardContent } from './_components/DashboardContent/DashboardContent'
+import { createDashboardViewModel } from './_data/dashboard-view-model'
+
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Vos Chroniques · GRIMOIRE',
+  description: 'Reprenez un run actif ou franchissez le seuil de Velkhar.',
+}
+
+export default async function DashboardPage() {
+  const viewer = await getViewerSummary()
+  const viewModel = createDashboardViewModel(viewer.hasAccount, viewer.displayName)
+
+  return <DashboardContent hasAccount={viewer.hasAccount} viewModel={viewModel} />
 }

--- a/apps/frontend/src/app/(main)/error.tsx
+++ b/apps/frontend/src/app/(main)/error.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { SystemState } from '@/components/system-state/SystemState'
+import { GameButton } from '@/components/ui/grimoire/GameButton/GameButton'
+
+interface MainErrorProps {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function MainError({ reset }: MainErrorProps) {
+  return (
+    <SystemState
+      eyebrow="La trace s’est interrompue"
+      title="Vos Chroniques ne répondent pas."
+      body="Aucune progression n’a été modifiée. Vous pouvez tenter de rouvrir cet espace."
+      action={
+        <GameButton onClick={reset} size="sm" variant="secondary">
+          Réessayer
+        </GameButton>
+      }
+    />
+  )
+}

--- a/apps/frontend/src/app/(main)/layout.tsx
+++ b/apps/frontend/src/app/(main)/layout.tsx
@@ -1,0 +1,18 @@
+import { MainNavigation } from '@/components/ui/main-navigation'
+import { getViewerSummary } from '@/lib/viewer'
+
+import type { ReactNode } from 'react'
+
+import './main-layout.css'
+
+export default async function MainLayout({ children }: Readonly<{ children: ReactNode }>) {
+  const viewer = await getViewerSummary()
+
+  return (
+    <div className="main-shell">
+      <MainNavigation hasAccount={viewer.hasAccount} />
+      <div className="main-shell__grain" aria-hidden="true" />
+      {children}
+    </div>
+  )
+}

--- a/apps/frontend/src/app/(main)/layout.tsx
+++ b/apps/frontend/src/app/(main)/layout.tsx
@@ -10,7 +10,7 @@ export default async function MainLayout({ children }: Readonly<{ children: Reac
 
   return (
     <div className="main-shell">
-      <MainNavigation hasAccount={viewer.hasAccount} />
+      <MainNavigation tier={viewer.tier} />
       <div className="main-shell__grain" aria-hidden="true" />
       {children}
     </div>

--- a/apps/frontend/src/app/(main)/loading.tsx
+++ b/apps/frontend/src/app/(main)/loading.tsx
@@ -1,0 +1,12 @@
+import { SystemState } from '@/components/system-state/SystemState'
+
+export default function MainLoading() {
+  return (
+    <SystemState
+      eyebrow="Une trace réapparaît"
+      title="Vos Chroniques s’ouvrent."
+      body="Les fragments disponibles se rassemblent sans altérer le récit."
+      isLoading
+    />
+  )
+}

--- a/apps/frontend/src/app/(main)/main-layout.css
+++ b/apps/frontend/src/app/(main)/main-layout.css
@@ -1,0 +1,28 @@
+.main-shell {
+  background:
+    radial-gradient(circle at 78% 12%, rgba(217, 164, 65, 0.11), transparent 29rem),
+    radial-gradient(circle at 12% 76%, rgba(100, 69, 34, 0.14), transparent 34rem),
+    linear-gradient(180deg, #080604, var(--void) 52%, #050403);
+  isolation: isolate;
+  min-height: 100dvh;
+  position: relative;
+}
+
+.main-shell::after {
+  background: radial-gradient(ellipse at center, transparent 38%, rgba(0, 0, 0, 0.48) 100%);
+  content: '';
+  inset: 0;
+  pointer-events: none;
+  position: fixed;
+  z-index: -1;
+}
+
+.main-shell__grain {
+  background: url('/landing/textures/grain.svg') center / 180px 180px repeat;
+  inset: 0;
+  mix-blend-mode: soft-light;
+  opacity: 0.05;
+  pointer-events: none;
+  position: fixed;
+  z-index: -1;
+}

--- a/apps/frontend/src/app/(main)/not-found.tsx
+++ b/apps/frontend/src/app/(main)/not-found.tsx
@@ -1,0 +1,17 @@
+import { SystemState } from '@/components/system-state/SystemState'
+import { GameLink } from '@/components/ui/game-link'
+
+export default function MainNotFound() {
+  return (
+    <SystemState
+      eyebrow="Trace introuvable"
+      title="Ce passage n’appartient à aucune Chronique."
+      body="La campagne demandée n’est pas disponible dans les données accessibles à ce navigateur."
+      action={
+        <GameLink href="/dashboard" size="sm" variant="secondary">
+          Retour aux Chroniques
+        </GameLink>
+      }
+    />
+  )
+}

--- a/apps/frontend/src/app/(main)/velkhar/aveugle/aveugle.css
+++ b/apps/frontend/src/app/(main)/velkhar/aveugle/aveugle.css
@@ -1,0 +1,132 @@
+.aveugle-threshold {
+  align-items: end;
+  display: grid;
+  min-height: calc(100dvh - 5rem);
+  overflow: hidden;
+  padding: clamp(2rem, 5vw, 5rem) clamp(1rem, 5vw, 5rem);
+  position: relative;
+}
+
+.aveugle-threshold__scene,
+.aveugle-threshold__veil {
+  inset: 0;
+  position: absolute;
+}
+
+.aveugle-threshold__scene {
+  background: url('/scenes/hub-auberge-clean.webp') center 42% / cover no-repeat;
+  filter: saturate(0.82) contrast(1.06);
+  transform: scale(1.015);
+}
+
+.aveugle-threshold__veil {
+  background:
+    linear-gradient(180deg, rgba(5, 4, 3, 0.18) 0%, rgba(5, 4, 3, 0.3) 45%, rgba(5, 4, 3, 0.93) 100%),
+    linear-gradient(90deg, rgba(5, 4, 3, 0.72) 0%, transparent 55%);
+}
+
+.aveugle-threshold__dialogue {
+  max-width: 54rem;
+  position: relative;
+  width: 100%;
+  z-index: 1;
+}
+
+.aveugle-threshold__location {
+  color: var(--gold-light);
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  margin: 0 0 0.75rem 0.25rem;
+  text-shadow: 0 2px 8px #000;
+  text-transform: uppercase;
+}
+
+.aveugle-threshold__panel {
+  backdrop-filter: blur(10px);
+  background: rgba(12, 9, 6, 0.9);
+  box-shadow: 0 1.5rem 5rem rgba(0, 0, 0, 0.52);
+}
+
+.aveugle-threshold__speaker {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+}
+
+.aveugle-threshold__speaker .game-icon {
+  filter: brightness(0.94) drop-shadow(0 8px 18px rgba(0, 0, 0, 0.55));
+  flex: 0 0 auto;
+}
+
+.aveugle-threshold__speaker p {
+  color: var(--gold);
+  font-family: var(--font-ui);
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  margin: 0 0 0.25rem;
+  text-transform: uppercase;
+}
+
+.aveugle-threshold__speaker h1 {
+  color: var(--gold-light);
+  font-family: var(--font-accent);
+  font-size: clamp(1.65rem, 4vw, 2.75rem);
+  font-weight: 500;
+  line-height: 1.08;
+  margin: 0;
+  text-wrap: balance;
+}
+
+.aveugle-threshold blockquote {
+  border-left: 1px solid rgba(217, 164, 65, 0.55);
+  color: var(--parchment);
+  font-family: var(--font-accent);
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  font-style: italic;
+  line-height: 1.6;
+  margin: clamp(1.5rem, 3vw, 2.25rem) 0 1rem;
+  padding-left: 1.25rem;
+  text-wrap: pretty;
+}
+
+.aveugle-threshold__copy {
+  color: var(--ink-2);
+  line-height: 1.65;
+  margin: 0;
+  max-width: 58ch;
+  text-wrap: pretty;
+}
+
+.aveugle-threshold__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+@media (max-width: 640px) {
+  .aveugle-threshold {
+    min-height: calc(100dvh - 8rem);
+    padding: 8rem 0.75rem 1.25rem;
+  }
+
+  .aveugle-threshold__scene {
+    background-position: 58% center;
+  }
+
+  .aveugle-threshold__speaker {
+    align-items: flex-start;
+  }
+
+  .aveugle-threshold__actions,
+  .aveugle-threshold__actions .game-button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aveugle-threshold__scene {
+    transform: none;
+  }
+}

--- a/apps/frontend/src/app/(main)/velkhar/aveugle/page.tsx
+++ b/apps/frontend/src/app/(main)/velkhar/aveugle/page.tsx
@@ -1,23 +1,89 @@
-import { SystemState } from '@/components/system-state/SystemState'
 import { GameLink } from '@/components/ui/game-link'
+import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
+import { GamePanel } from '@/components/ui/grimoire/GamePanel/GamePanel'
 
 import type { Metadata } from 'next'
+
+import './aveugle.css'
 
 export const metadata: Metadata = {
   title: 'L’Auberge de L’Aveugle · GRIMOIRE',
 }
 
-export default function AveuglePage() {
+interface AveuglePageProps {
+  searchParams: Promise<{
+    campaign?: string | string[]
+    flow?: string | string[]
+  }>
+}
+
+function getCharacterFlowHref(campaign: string | string[] | undefined): string {
+  const campaignId = typeof campaign === 'string' ? campaign : undefined
+
+  return campaignId
+    ? `/velkhar/aveugle?flow=character-create&campaign=${encodeURIComponent(campaignId)}`
+    : '/velkhar/aveugle?flow=character-create'
+}
+
+export default async function AveuglePage({ searchParams }: AveuglePageProps) {
+  const { campaign, flow } = await searchParams
+  const isCharacterFlow = flow === 'character-create'
+
   return (
-    <SystemState
-      eyebrow="Le seuil de chaque run"
-      title="L’Aveugle vous attend."
-      body="L’Auberge est la prochaine étape du chantier frontend. En attendant son ouverture complète, la Forge reste accessible depuis ce seuil."
-      action={
-        <GameLink href="/velkhar/character-create" size="sm">
-          Entrer dans le prologue
-        </GameLink>
-      }
-    />
+    <main className="aveugle-threshold">
+      <div className="aveugle-threshold__scene" aria-hidden="true" />
+      <div className="aveugle-threshold__veil" aria-hidden="true" />
+
+      <section className="aveugle-threshold__dialogue" aria-labelledby="aveugle-title">
+        <p className="aveugle-threshold__location">Velkhar · L’Auberge de L’Aveugle</p>
+
+        <GamePanel
+          className="aveugle-threshold__panel"
+          ornament="diamond"
+          padding="lg"
+          tone="gold"
+          variant="main"
+        >
+          <div className="aveugle-threshold__speaker">
+            <GameIcon decorative name={isCharacterFlow ? 'quill' : 'eye'} size={48} />
+            <div>
+              <p>{isCharacterFlow ? 'Le registre de L’Aveugle' : 'L’Aveugle'}</p>
+              <h1 id="aveugle-title">
+                {isCharacterFlow
+                  ? 'Sous quel nom les sables te connaissent-ils ?'
+                  : 'Chaque histoire commence ici.'}
+              </h1>
+            </div>
+          </div>
+
+          <blockquote>
+            {isCharacterFlow
+              ? '« Un nom d’abord. Puis nous verrons ce que la route a laissé dans ton regard. »'
+              : '« Repose-toi, voyageur. Avant de franchir les portes de Velkhar, dis-moi qui tu es. »'}
+          </blockquote>
+
+          <p className="aveugle-threshold__copy">
+            {isCharacterFlow
+              ? 'Le registre s’ouvre sur la table. Ton personnage prendra forme ici, au fil de cette première conversation.'
+              : 'L’Auberge est le seuil de chaque run. Vous pouvez commencer cette première conversation sans créer de compte.'}
+          </p>
+
+          <div className="aveugle-threshold__actions">
+            {isCharacterFlow ? (
+              <GameLink href="/dashboard" variant="secondary">
+                Revenir aux Chroniques
+              </GameLink>
+            ) : (
+              <GameLink
+                href={getCharacterFlowHref(campaign)}
+                trailingIcon={<GameIcon decorative name="arrow" size={24} />}
+              >
+                Répondre à L’Aveugle
+              </GameLink>
+            )}
+          </div>
+        </GamePanel>
+      </section>
+    </main>
   )
 }

--- a/apps/frontend/src/app/(main)/velkhar/aveugle/page.tsx
+++ b/apps/frontend/src/app/(main)/velkhar/aveugle/page.tsx
@@ -1,0 +1,23 @@
+import { SystemState } from '@/components/system-state/SystemState'
+import { GameLink } from '@/components/ui/game-link'
+
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'L’Auberge de L’Aveugle · GRIMOIRE',
+}
+
+export default function AveuglePage() {
+  return (
+    <SystemState
+      eyebrow="Le seuil de chaque run"
+      title="L’Aveugle vous attend."
+      body="L’Auberge est la prochaine étape du chantier frontend. En attendant son ouverture complète, la Forge reste accessible depuis ce seuil."
+      action={
+        <GameLink href="/velkhar/character-create" size="sm">
+          Entrer dans le prologue
+        </GameLink>
+      }
+    />
+  )
+}

--- a/apps/frontend/src/app/(main)/velkhar/campaign/[id]/page.tsx
+++ b/apps/frontend/src/app/(main)/velkhar/campaign/[id]/page.tsx
@@ -1,11 +1,19 @@
-import { AnimatedShinyText } from '@/components/ui/animated-shiny-text'
+import { notFound, redirect } from 'next/navigation'
 
-export default function CampaignPage() {
-  return (
-    <div>
-      <h1>
-        <AnimatedShinyText variant="gold-strong">Campaign</AnimatedShinyText>
-      </h1>
-    </div>
-  )
+import {
+  getCampaignResumeSnapshot,
+  resolveCampaignDestination,
+} from '../../../_lib/campaign-resume'
+
+interface CampaignPageProps {
+  params: Promise<{ id: string }>
+}
+
+export default async function CampaignPage({ params }: CampaignPageProps) {
+  const { id } = await params
+  const snapshot = getCampaignResumeSnapshot(id)
+
+  if (!snapshot) notFound()
+
+  redirect(resolveCampaignDestination(snapshot))
 }

--- a/apps/frontend/src/app/(main)/velkhar/character-create/page.tsx
+++ b/apps/frontend/src/app/(main)/velkhar/character-create/page.tsx
@@ -1,23 +1,17 @@
-import { SystemState } from '@/components/system-state/SystemState'
-import { GameLink } from '@/components/ui/game-link'
+import { redirect } from 'next/navigation'
 
-import type { Metadata } from 'next'
-
-export const metadata: Metadata = {
-  title: 'La Forge · GRIMOIRE',
+interface VelkharCharacterCreatePageProps {
+  searchParams: Promise<{ campaign?: string | string[] }>
 }
 
-export default function VelkharCharacterCreatePage() {
-  return (
-    <SystemState
-      eyebrow="Le prologue de L’Aveugle"
-      title="La Forge se prépare."
-      body="La création guidée du personnage arrive dans la prochaine feature. Vous pouvez revenir à vos Chroniques sans perdre votre chemin."
-      action={
-        <GameLink href="/dashboard" size="sm" variant="secondary">
-          Retour aux Chroniques
-        </GameLink>
-      }
-    />
-  )
+export default async function VelkharCharacterCreatePage({
+  searchParams,
+}: VelkharCharacterCreatePageProps) {
+  const { campaign } = await searchParams
+  const campaignId = typeof campaign === 'string' ? campaign : undefined
+  const destination = campaignId
+    ? `/velkhar/aveugle?flow=character-create&campaign=${encodeURIComponent(campaignId)}`
+    : '/velkhar/aveugle?flow=character-create'
+
+  redirect(destination)
 }

--- a/apps/frontend/src/app/(main)/velkhar/character-create/page.tsx
+++ b/apps/frontend/src/app/(main)/velkhar/character-create/page.tsx
@@ -1,11 +1,23 @@
-import { AnimatedShinyText } from '@/components/ui/animated-shiny-text'
+import { SystemState } from '@/components/system-state/SystemState'
+import { GameLink } from '@/components/ui/game-link'
+
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'La Forge · GRIMOIRE',
+}
 
 export default function VelkharCharacterCreatePage() {
   return (
-    <div>
-      <h1>
-        <AnimatedShinyText variant="gold-strong">Velkhar Character Create</AnimatedShinyText>
-      </h1>
-    </div>
+    <SystemState
+      eyebrow="Le prologue de L’Aveugle"
+      title="La Forge se prépare."
+      body="La création guidée du personnage arrive dans la prochaine feature. Vous pouvez revenir à vos Chroniques sans perdre votre chemin."
+      action={
+        <GameLink href="/dashboard" size="sm" variant="secondary">
+          Retour aux Chroniques
+        </GameLink>
+      }
+    />
   )
 }

--- a/apps/frontend/src/app/(main)/velkhar/world/page.tsx
+++ b/apps/frontend/src/app/(main)/velkhar/world/page.tsx
@@ -1,11 +1,23 @@
-import { AnimatedShinyText } from '@/components/ui/animated-shiny-text'
+import { SystemState } from '@/components/system-state/SystemState'
+import { GameLink } from '@/components/ui/game-link'
+
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Le Makhzen · GRIMOIRE',
+}
 
 export default function VelkharWorldPage() {
   return (
-    <div>
-      <h1>
-        <AnimatedShinyText variant="gold-strong">Velkhar World Map</AnimatedShinyText>
-      </h1>
-    </div>
+    <SystemState
+      eyebrow="Territoire non découvert"
+      title="Le Makhzen reste voilé."
+      body="La carte ne révélera que les régions connues du personnage. Aucune destination ne peut encore être affichée sans données de découverte."
+      action={
+        <GameLink href="/dashboard" size="sm" variant="secondary">
+          Retour aux Chroniques
+        </GameLink>
+      }
+    />
   )
 }

--- a/apps/frontend/src/app/auth/callback/route.ts
+++ b/apps/frontend/src/app/auth/callback/route.ts
@@ -1,17 +1,18 @@
 import { NextResponse, type NextRequest } from 'next/server'
 
+import { getSafeInternalDestination } from '@/lib/internal-navigation'
 import { createClient } from '@/lib/supabase/server'
 
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = request.nextUrl
   const code = searchParams.get('code')
-  const next = searchParams.get('next') ?? '/'
+  const next = getSafeInternalDestination(searchParams.get('next'), '/')
 
   if (code) {
     const supabase = await createClient()
     const { error } = await supabase.auth.exchangeCodeForSession(code)
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`)
+      return NextResponse.redirect(new URL(next, origin))
     }
   }
 

--- a/apps/frontend/src/components/system-state/SystemState.tsx
+++ b/apps/frontend/src/components/system-state/SystemState.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image'
+import { GameBrand } from '@/components/ui/grimoire/GameBrand/GameBrand'
 
 import type { ReactNode } from 'react'
 
@@ -23,14 +23,12 @@ export function SystemState({ action, body, eyebrow, isLoading = false, title }:
 
       <section className="system-state__content" aria-labelledby="system-state-title">
         <div className="system-state__brand" aria-hidden="true">
-          <Image
+          <GameBrand
             className="system-state__logo"
-            src="/landing/ui/brand-lockup-grimoire.webp"
-            alt=""
-            width={720}
-            height={336}
+            decorative
             priority
-            sizes="(max-width: 640px) 190px, 250px"
+            size="md"
+            variant="lockup"
           />
         </div>
 

--- a/apps/frontend/src/components/system-state/system-state.css
+++ b/apps/frontend/src/components/system-state/system-state.css
@@ -101,7 +101,7 @@
   line-height: 1.55;
   margin: 18px 0 0;
   max-width: 46ch;
-  text-wrap: balance;
+  text-wrap: pretty;
 }
 
 .system-state__loading {

--- a/apps/frontend/src/components/ui/game-link.tsx
+++ b/apps/frontend/src/components/ui/game-link.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link'
+
+import { cn } from '@/lib/utils'
+
+import type {
+  GameButtonSize,
+  GameButtonTone,
+  GameButtonVariant,
+} from './grimoire/GameButton/GameButton'
+import type { ComponentProps, ReactNode } from 'react'
+
+import './grimoire/GameButton/game-button.css'
+
+export interface GameLinkProps extends Omit<ComponentProps<typeof Link>, 'children'> {
+  children: ReactNode
+  leadingIcon?: ReactNode
+  size?: GameButtonSize
+  tone?: GameButtonTone
+  trailingIcon?: ReactNode
+  variant?: GameButtonVariant
+}
+
+export function GameLink({
+  children,
+  className,
+  leadingIcon,
+  size = 'md',
+  tone = 'gold',
+  trailingIcon,
+  variant = 'primary',
+  ...props
+}: GameLinkProps) {
+  return (
+    <Link
+      className={cn(
+        'game-button',
+        `game-button--${variant}`,
+        `game-button--${tone}`,
+        `game-button--${size}`,
+        className
+      )}
+      {...props}
+    >
+      {leadingIcon ? (
+        <span className="game-button__icon" aria-hidden="true">
+          {leadingIcon}
+        </span>
+      ) : null}
+      <span className="game-button__label">{children}</span>
+      {trailingIcon ? (
+        <span className="game-button__icon" aria-hidden="true">
+          {trailingIcon}
+        </span>
+      ) : null}
+    </Link>
+  )
+}

--- a/apps/frontend/src/components/ui/index.ts
+++ b/apps/frontend/src/components/ui/index.ts
@@ -8,6 +8,9 @@ export { ScrollProgressBar } from './scroll-progress-bar'
 export { SectionProgress } from './section-progress'
 export { GameButton } from './grimoire'
 export type { GameButtonProps, GameButtonSize, GameButtonTone, GameButtonVariant } from './grimoire'
+export { GameLink } from './game-link'
+export type { GameLinkProps } from './game-link'
+export { MainNavigation } from './main-navigation'
 export {
   GameSceneLayout,
   GameStepDock,

--- a/apps/frontend/src/components/ui/main-navigation.css
+++ b/apps/frontend/src/components/ui/main-navigation.css
@@ -1,0 +1,127 @@
+.main-navigation {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+}
+
+.main-navigation__brand {
+  align-items: center;
+  display: inline-flex;
+  min-height: 44px;
+}
+
+.main-navigation__brand .game-brand {
+  width: clamp(7.5rem, 10vw, 9.5rem);
+}
+
+.main-navigation__links {
+  align-items: center;
+  display: flex;
+  gap: clamp(1rem, 2.5vw, 2.5rem);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.main-navigation__links a,
+.main-navigation__account {
+  color: var(--ink-2);
+  font-family: var(--font-ui);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  min-height: 44px;
+  position: relative;
+  transition-property: color, opacity;
+  transition-duration: 180ms;
+  transition-timing-function: ease;
+}
+
+.main-navigation__links a {
+  align-items: center;
+  display: inline-flex;
+}
+
+.main-navigation__links a::after {
+  background: linear-gradient(90deg, transparent, var(--gold-light), transparent);
+  bottom: 5px;
+  content: '';
+  height: 1px;
+  left: 50%;
+  opacity: 0;
+  position: absolute;
+  transform: translateX(-50%) scaleX(0.4);
+  transition-property: opacity, transform;
+  transition-duration: 180ms;
+  transition-timing-function: ease;
+  width: 100%;
+}
+
+.main-navigation__links a:hover,
+.main-navigation__links a[aria-current='page'],
+.main-navigation__account:hover {
+  color: var(--gold-light);
+}
+
+.main-navigation__links a[aria-current='page']::after {
+  opacity: 0.72;
+  transform: translateX(-50%) scaleX(1);
+}
+
+.main-navigation__account {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.main-navigation__account .game-icon {
+  filter: brightness(0.92);
+}
+
+@media (max-width: 760px) {
+  .main-navigation {
+    grid-template-rows: auto auto;
+    padding-bottom: 0.45rem;
+  }
+
+  .main-navigation .game-top-bar__center {
+    display: flex;
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .main-navigation__links {
+    gap: 1.25rem;
+    justify-content: center;
+    width: 100%;
+  }
+
+  .main-navigation__links a {
+    font-size: 0.76rem;
+    min-height: 40px;
+  }
+
+  .main-navigation__account span {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+}
+
+@media (max-width: 480px) {
+  .main-navigation__brand .game-brand {
+    width: 6.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .main-navigation__links a,
+  .main-navigation__links a::after,
+  .main-navigation__account {
+    transition-duration: 0.01ms;
+  }
+}

--- a/apps/frontend/src/components/ui/main-navigation.tsx
+++ b/apps/frontend/src/components/ui/main-navigation.tsx
@@ -7,10 +7,12 @@ import { GameBrand } from './grimoire/GameBrand/GameBrand'
 import { GameIcon } from './grimoire/GameIcon/GameIcon'
 import { GameTopBar } from './grimoire/GameTopBar/GameTopBar'
 
+import type { ViewerTier } from '@/lib/viewer'
+
 import './main-navigation.css'
 
 interface MainNavigationProps {
-  hasAccount: boolean
+  tier: ViewerTier
 }
 
 const MAIN_LINKS = [
@@ -27,8 +29,9 @@ function isCurrentPath(pathname: string, href: string): boolean {
   )
 }
 
-export function MainNavigation({ hasAccount }: MainNavigationProps) {
+export function MainNavigation({ tier }: MainNavigationProps) {
   const pathname = usePathname()
+  const hasAccount = tier !== 'anonymous'
 
   return (
     <GameTopBar

--- a/apps/frontend/src/components/ui/main-navigation.tsx
+++ b/apps/frontend/src/components/ui/main-navigation.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+import { GameBrand } from './grimoire/GameBrand/GameBrand'
+import { GameIcon } from './grimoire/GameIcon/GameIcon'
+import { GameTopBar } from './grimoire/GameTopBar/GameTopBar'
+
+import './main-navigation.css'
+
+interface MainNavigationProps {
+  hasAccount: boolean
+}
+
+const MAIN_LINKS = [
+  { href: '/dashboard', label: 'Chroniques' },
+  { href: '/velkhar/campaign/nouvelle-chronique', label: 'Franchir le seuil' },
+] as const
+
+function isCurrentPath(pathname: string, href: string): boolean {
+  if (href === '/dashboard') return pathname === href
+  return (
+    pathname === '/velkhar/aveugle' ||
+    pathname === '/velkhar/character-create' ||
+    pathname.startsWith('/velkhar/campaign/')
+  )
+}
+
+export function MainNavigation({ hasAccount }: MainNavigationProps) {
+  const pathname = usePathname()
+
+  return (
+    <GameTopBar
+      className="main-navigation"
+      label="Navigation globale"
+      start={
+        <Link className="main-navigation__brand" href="/" aria-label="GRIMOIRE, accueil">
+          <GameBrand decorative size="sm" variant="lockup" />
+        </Link>
+      }
+      center={
+        <nav aria-label="Espaces de Velkhar">
+          <ul className="main-navigation__links">
+            {MAIN_LINKS.map((link) => {
+              const isCurrent = isCurrentPath(pathname, link.href)
+
+              return (
+                <li key={link.href}>
+                  <Link href={link.href} aria-current={isCurrent ? 'page' : undefined}>
+                    {link.label}
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        </nav>
+      }
+      end={
+        <Link
+          className="main-navigation__account"
+          href={hasAccount ? '/dashboard' : '/login?next=%2Fdashboard'}
+          aria-label={hasAccount ? 'Ouvrir votre espace' : 'Se connecter'}
+        >
+          <GameIcon decorative name={hasAccount ? 'book' : 'key'} size={24} />
+          <span>{hasAccount ? 'Votre espace' : 'Se connecter'}</span>
+        </Link>
+      }
+    />
+  )
+}

--- a/apps/frontend/src/components/ui/soft-signup-prompt.tsx
+++ b/apps/frontend/src/components/ui/soft-signup-prompt.tsx
@@ -18,7 +18,7 @@ export function SoftSignupPrompt() {
       className="fixed inset-x-0 bottom-0 z-50 flex flex-wrap items-center justify-center gap-4 border-t border-gold-dark bg-ash/95 px-6 py-4 text-center"
     >
       <p className="m-0 font-manuscript text-parchment">
-        Crée un compte pour continuer ton aventure sans limite.
+        Crée un compte gratuitement pour conserver cette aventure et continuer à jouer.
       </p>
       <Link href="/signup" className="font-accent text-gold-soft underline">
         Créer un compte

--- a/apps/frontend/src/lib/internal-navigation.test.ts
+++ b/apps/frontend/src/lib/internal-navigation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { getAuthHref, getSafeInternalDestination } from './internal-navigation'
+
+describe('getSafeInternalDestination', () => {
+  it.each([
+    ['/dashboard', '/dashboard'],
+    ['/velkhar/session/resume?from=dashboard', '/velkhar/session/resume?from=dashboard'],
+    ['/velkhar/character-create?campaign=new', '/velkhar/character-create?campaign=new'],
+  ])('keeps an allowed internal destination', (input, expected) => {
+    expect(getSafeInternalDestination(input)).toBe(expected)
+  })
+
+  it.each([
+    'https://example.com/steal-session',
+    '//example.com/steal-session',
+    '/login?next=/dashboard',
+    '/chronique/route-pas-encore-livree',
+    '/velkhar/profile/route-pas-encore-livree',
+    '/unknown-route',
+    '',
+  ])('rejects unsafe or unknown destination %s', (input) => {
+    expect(getSafeInternalDestination(input)).toBe('/dashboard')
+  })
+
+  it('uses the requested safe fallback', () => {
+    expect(getSafeInternalDestination(undefined, '/')).toBe('/')
+  })
+})
+
+describe('getAuthHref', () => {
+  it('encodes a validated return destination', () => {
+    expect(getAuthHref('/login', '/velkhar/session/resume?from=dashboard')).toBe(
+      '/login?next=%2Fvelkhar%2Fsession%2Fresume%3Ffrom%3Ddashboard'
+    )
+  })
+})

--- a/apps/frontend/src/lib/internal-navigation.ts
+++ b/apps/frontend/src/lib/internal-navigation.ts
@@ -1,0 +1,51 @@
+const INTERNAL_ORIGIN = 'https://grimoire.local'
+
+const ALLOWED_DESTINATIONS = [
+  '/',
+  '/dashboard',
+  '/velkhar/aveugle',
+  '/velkhar/character-create',
+  '/velkhar/world',
+] as const
+const ALLOWED_DYNAMIC_DESTINATION = /^\/velkhar\/(campaign|session)\/[^/]+$/
+
+type SearchParamValue = string | string[] | null | undefined
+
+function isAllowedPathname(pathname: string): boolean {
+  return (
+    ALLOWED_DESTINATIONS.some((destination) => pathname === destination) ||
+    ALLOWED_DYNAMIC_DESTINATION.test(pathname)
+  )
+}
+
+/**
+ * Keeps post-auth navigation inside known GRIMOIRE surfaces. Absolute URLs,
+ * protocol-relative URLs and auth loops always fall back to a safe route.
+ */
+export function getSafeInternalDestination(
+  value: SearchParamValue,
+  fallback = '/dashboard'
+): string {
+  const candidate = Array.isArray(value) ? value[0] : value
+
+  if (!candidate || !candidate.startsWith('/') || candidate.startsWith('//')) {
+    return fallback
+  }
+
+  try {
+    const destination = new URL(candidate, INTERNAL_ORIGIN)
+
+    if (destination.origin !== INTERNAL_ORIGIN || !isAllowedPathname(destination.pathname)) {
+      return fallback
+    }
+
+    return `${destination.pathname}${destination.search}${destination.hash}`
+  } catch {
+    return fallback
+  }
+}
+
+export function getAuthHref(pathname: '/login' | '/signup', next: string): string {
+  const safeNext = getSafeInternalDestination(next)
+  return `${pathname}?next=${encodeURIComponent(safeNext)}`
+}

--- a/apps/frontend/src/lib/viewer.ts
+++ b/apps/frontend/src/lib/viewer.ts
@@ -4,8 +4,10 @@ import { createClient } from '@/lib/supabase/server'
 
 export interface ViewerSummary {
   displayName: string | null
-  hasAccount: boolean
+  tier: ViewerTier
 }
+
+export type ViewerTier = 'anonymous' | 'free' | 'premium'
 
 export const getViewerSummary = cache(async (): Promise<ViewerSummary> => {
   try {
@@ -14,7 +16,13 @@ export const getViewerSummary = cache(async (): Promise<ViewerSummary> => {
       data: { user },
     } = await supabase.auth.getUser()
 
-    const hasAccount = Boolean(user && !user.is_anonymous)
+    const tier: ViewerTier = user?.is_anonymous
+      ? 'anonymous'
+      : user?.app_metadata?.tier === 'premium'
+        ? 'premium'
+        : user
+          ? 'free'
+          : 'anonymous'
     const displayName =
       typeof user?.user_metadata?.display_name === 'string'
         ? user.user_metadata.display_name
@@ -22,8 +30,8 @@ export const getViewerSummary = cache(async (): Promise<ViewerSummary> => {
           ? user.email.split('@')[0]
           : null
 
-    return { displayName, hasAccount }
+    return { displayName, tier }
   } catch {
-    return { displayName: null, hasAccount: false }
+    return { displayName: null, tier: 'anonymous' }
   }
 })

--- a/apps/frontend/src/lib/viewer.ts
+++ b/apps/frontend/src/lib/viewer.ts
@@ -1,0 +1,29 @@
+import { cache } from 'react'
+
+import { createClient } from '@/lib/supabase/server'
+
+export interface ViewerSummary {
+  displayName: string | null
+  hasAccount: boolean
+}
+
+export const getViewerSummary = cache(async (): Promise<ViewerSummary> => {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    const hasAccount = Boolean(user && !user.is_anonymous)
+    const displayName =
+      typeof user?.user_metadata?.display_name === 'string'
+        ? user.user_metadata.display_name
+        : typeof user?.email === 'string'
+          ? user.email.split('@')[0]
+          : null
+
+    return { displayName, hasAccount }
+  } catch {
+    return { displayName: null, hasAccount: false }
+  }
+})

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -3,27 +3,29 @@ import { NextResponse, type NextRequest } from 'next/server'
 
 export async function middleware(request: NextRequest) {
   let response = NextResponse.next({ request })
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return request.cookies.getAll()
-        },
-        setAll(cookiesToSet) {
-          for (const { name, value } of cookiesToSet) {
-            request.cookies.set(name, value)
-          }
-          response = NextResponse.next({ request })
-          for (const { name, value, options } of cookiesToSet) {
-            response.cookies.set(name, value, options)
-          }
-        },
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return response
+  }
+
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll()
       },
-    }
-  )
+      setAll(cookiesToSet) {
+        for (const { name, value } of cookiesToSet) {
+          request.cookies.set(name, value)
+        }
+        response = NextResponse.next({ request })
+        for (const { name, value, options } of cookiesToSet) {
+          response.cookies.set(name, value, options)
+        }
+      },
+    },
+  })
 
   await supabase.auth.getUser()
 


### PR DESCRIPTION
## Summary
- construit le shell principal et un Dashboard responsive sans concurrencer L’Auberge
- transforme Campaign en passerelle vers Forge, Auberge ou Session via un adaptateur isolé
- sécurise et conserve les destinations internes après login ou signup
- ajoute les états loading, error, not-found et les gardes visuelles des routes
- couvre les redirections et view models par des tests unitaires

## Test plan
- [x] type-check frontend
- [x] lint frontend
- [x] 35 tests unitaires
- [x] build Next.js
- [x] parcours vérifiés en local sur desktop et 390 px

Closes #128