### PR TITLE
feat(#116): chronique de fin de run

### DIFF
--- a/apps/backend/prisma/migrations/20260714113001_add_chronicle/migration.sql
+++ b/apps/backend/prisma/migrations/20260714113001_add_chronicle/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "Chronicle" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "characterId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "endReason" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "bodyMarkdown" TEXT NOT NULL,
+    "mood" TEXT NOT NULL,
+    "keyMoments" JSONB NOT NULL,
+    "tagline" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Chronicle_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Chronicle" ADD CONSTRAINT "Chronicle_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   createdAt  DateTime    @default(now())
   characters Character[]
   souvenirs  Souvenir[]
+  chronicles Chronicle[]
 }
 
 model Character {
@@ -146,6 +147,35 @@ model Souvenir {
 
   /// Placeholder for the future Aveugle Souvenir-for-lore exchange (#133). Unused for now.
   sharedWithAveugle Boolean @default(false)
+
+  createdAt DateTime @default(now())
+}
+
+/// End-of-run literary synthesis (#116). One-time, generated when a
+/// GameSession ends (death | inn | abandon). Linked to `User` only (no
+/// cascade relation to Session/Character, which must be free to disappear
+/// while the Chronicle survives them, mirroring `Souvenir`). `characterId`
+/// and `sessionId` are kept as plain strings for provenance/display only.
+/// No slug/public-URL field yet — public sharing is a deferred, separate ticket.
+model Chronicle {
+  id     String @id @default(uuid())
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  characterId String
+  sessionId   String
+
+  /// Why the run ended (death | inn | abandon), copied from GameSession.endReason.
+  endReason String
+
+  title        String
+  bodyMarkdown String
+  /// ChronicleMood (@grimoire/shared) stored as a plain string, matching
+  /// Souvenir.type's convention — no Prisma enum in this schema.
+  mood         String
+  /// ChronicleKeyMoment[] sérialisé ({label, scene_ref}[]).
+  keyMoments   Json
+  tagline      String
 
   createdAt DateTime @default(now())
 }

--- a/apps/backend/src/ai/chronicle-validator.test.ts
+++ b/apps/backend/src/ai/chronicle-validator.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+
+import { chronicleOutputSchema, validateChronicleOutput } from './chronicle-validator'
+
+const validPayload = {
+  title: 'The Last Crossing of Yarel',
+  body_markdown: 'A long literary chronicle body describing the run.',
+  mood: 'epic' as const,
+  key_moments: [{ label: 'Yarel crosses the salt flats', scene_ref: 3 }],
+  tagline: 'The salt remembers her name',
+}
+
+describe('chronicleOutputSchema', () => {
+  it('accepts a valid payload', () => {
+    const result = chronicleOutputSchema.safeParse(validPayload)
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a title longer than 80 characters', () => {
+    const result = chronicleOutputSchema.safeParse({ ...validPayload, title: 'a'.repeat(81) })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an empty title', () => {
+    const result = chronicleOutputSchema.safeParse({ ...validPayload, title: '' })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an empty body_markdown', () => {
+    const result = chronicleOutputSchema.safeParse({ ...validPayload, body_markdown: '' })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a mood outside the fixed enum', () => {
+    const result = chronicleOutputSchema.safeParse({ ...validPayload, mood: 'joyful' })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a key_moments entry missing scene_ref', () => {
+    const result = chronicleOutputSchema.safeParse({
+      ...validPayload,
+      key_moments: [{ label: 'Yarel crosses the salt flats' }],
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts an empty key_moments array', () => {
+    const result = chronicleOutputSchema.safeParse({ ...validPayload, key_moments: [] })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a tagline shorter than 15 characters', () => {
+    const result = chronicleOutputSchema.safeParse({ ...validPayload, tagline: 'Too short' })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a tagline longer than 30 characters', () => {
+    const result = chronicleOutputSchema.safeParse({ ...validPayload, tagline: 'a'.repeat(31) })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a payload carrying an illustration_prompt (out of scope for #116)', () => {
+    // illustration_prompt is simply ignored (not an error) since Zod strips unknown
+    // keys by default — this test documents that the field is never surfaced in `data`.
+    const result = chronicleOutputSchema.safeParse({
+      ...validPayload,
+      illustration_prompt: 'a painterly wide shot of the salt flats at dusk',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.success && 'illustration_prompt' in result.data).toBe(false)
+  })
+})
+
+describe('validateChronicleOutput', () => {
+  it('returns success with parsed data for a valid payload', () => {
+    const result = validateChronicleOutput(validPayload)
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual(validPayload)
+  })
+
+  it('returns failure with an error message for an invalid payload', () => {
+    const result = validateChronicleOutput({ title: 'Too short a payload' })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeTruthy()
+    expect(result.data).toBeUndefined()
+  })
+
+  it('returns failure for a non-object payload', () => {
+    const result = validateChronicleOutput('not an object')
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/backend/src/ai/chronicle-validator.ts
+++ b/apps/backend/src/ai/chronicle-validator.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+
+/**
+ * Zod schema for the raw end-of-run Chronicle payload the AI produces
+ * (17-RUN-CHRONICLE.md §1). `illustration_prompt` is intentionally omitted:
+ * illustration generation is out of scope for #116 (deferred ticket).
+ */
+export const chronicleOutputSchema = z.object({
+  title: z.string().min(1).max(80),
+  body_markdown: z.string().min(1),
+  mood: z.enum(['tragic', 'epic', 'melancholic', 'serene', 'absurd']),
+  key_moments: z.array(
+    z.object({
+      label: z.string().min(1),
+      scene_ref: z.number().int(),
+    })
+  ),
+  tagline: z.string().min(15).max(30),
+})
+
+export type ChronicleOutput = z.infer<typeof chronicleOutputSchema>
+
+export interface ChronicleValidationResult {
+  success: boolean
+  data?: ChronicleOutput
+  error?: string
+}
+
+/** Parses and validates raw AI Chronicle output; malformed output is rejected, never passed through. */
+export function validateChronicleOutput(raw: unknown): ChronicleValidationResult {
+  const parsed = chronicleOutputSchema.safeParse(raw)
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues.map((i) => i.message).join('; ') }
+  }
+  return { success: true, data: parsed.data }
+}

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -4,6 +4,7 @@ import rateLimit from 'express-rate-limit'
 
 import { env } from './config/env'
 import { requireAuth } from './middleware/auth.middleware'
+import { chronicleRouter } from './routes/chronicle.routes'
 import { gameRouter } from './routes/game.routes'
 import { souvenirRouter } from './routes/souvenir.routes'
 
@@ -45,6 +46,7 @@ const apiLimiter = rateLimit({
 // Routes
 app.use('/api/game', gameLimiter, requireAuth, gameRouter)
 app.use('/api/souvenirs', apiLimiter, requireAuth, souvenirRouter)
+app.use('/api/chronicles', apiLimiter, requireAuth, chronicleRouter)
 
 // Health check
 app.get('/api/health', (_req, res) => {

--- a/apps/backend/src/routes/chronicle.routes.ts
+++ b/apps/backend/src/routes/chronicle.routes.ts
@@ -1,0 +1,51 @@
+import { type Request, type Response, Router } from 'express'
+
+import { prisma } from '../lib/prisma'
+
+import type {
+  ApiResponse,
+  Chronicle,
+  ChronicleEndReason,
+  ChronicleKeyMoment,
+  ChronicleMood,
+} from '@grimoire/shared'
+
+export const chronicleRouter: Router = Router()
+
+/**
+ * GET /api/chronicles/session/:sessionId
+ * Fetches the Chronicle generated for a given session (end-of-run screen).
+ * Scoped to `req.auth.userId` — a user can only read their own Chronicles.
+ * 404 if the session hasn't ended yet, was too short for a Chronicle, or
+ * generation failed (no Chronicle persisted in that case).
+ */
+chronicleRouter.get(
+  '/session/:sessionId',
+  async (req: Request<{ sessionId: string }>, res: Response<ApiResponse<Chronicle>>) => {
+    const { sessionId } = req.params
+
+    const row = await prisma.chronicle.findFirst({
+      where: { sessionId, userId: req.auth!.userId },
+    })
+    if (!row) {
+      res.status(404).json({ success: false, error: 'Chronicle not found' })
+      return
+    }
+
+    const data: Chronicle = {
+      id: row.id,
+      userId: row.userId,
+      characterId: row.characterId,
+      sessionId: row.sessionId,
+      endReason: row.endReason as ChronicleEndReason,
+      title: row.title,
+      bodyMarkdown: row.bodyMarkdown,
+      mood: row.mood as ChronicleMood,
+      keyMoments: row.keyMoments as unknown as ChronicleKeyMoment[],
+      tagline: row.tagline,
+      createdAt: row.createdAt.toISOString(),
+    }
+
+    res.json({ success: true, data })
+  }
+)

--- a/apps/backend/src/routes/game-action.schema.ts
+++ b/apps/backend/src/routes/game-action.schema.ts
@@ -22,3 +22,10 @@ export const createSessionSchema = z.object({
 })
 
 export type CreateSessionRequest = z.infer<typeof createSessionSchema>
+
+/** Request to voluntarily end a session (inn choice or explicit abandon). */
+export const endSessionSchema = z.object({
+  sessionId: z.string().min(1),
+})
+
+export type EndSessionRequest = z.infer<typeof endSessionSchema>

--- a/apps/backend/src/routes/game.routes.ts
+++ b/apps/backend/src/routes/game.routes.ts
@@ -2,18 +2,25 @@ import { type Request, type Response, Router } from 'express'
 
 import { prisma } from '../lib/prisma'
 import {
+  abandonSession,
   buildOpeningScene,
+  endSessionAtInn,
   getOrCreateSession,
   INVALID_CHOICE,
   resolveChosenChoice,
   resolveTurn,
 } from '../services/session.service'
 
-import { createSessionSchema, gameActionSchema } from './game-action.schema'
+import { createSessionSchema, endSessionSchema, gameActionSchema } from './game-action.schema'
 
-import type { ApiResponse, SceneResponse } from '@grimoire/shared'
+import type { ApiResponse, SceneResponse, SessionEndReason } from '@grimoire/shared'
 
 export const gameRouter: Router = Router()
+
+interface EndSessionResponse {
+  status: 'ended'
+  endReason: SessionEndReason
+}
 
 /**
  * POST /api/game/session
@@ -88,3 +95,57 @@ gameRouter.post('/action', async (req: Request, res: Response<ApiResponse<SceneR
 
   res.json({ success: true, data: response })
 })
+
+/**
+ * POST /api/game/session/end-inn
+ * Voluntary end-of-run: the player clicks "Ton aventure se termine ici" while
+ * facing L'Aveugle at the inn. Ends the session and triggers the Chronicle.
+ */
+gameRouter.post(
+  '/session/end-inn',
+  async (req: Request, res: Response<ApiResponse<EndSessionResponse>>) => {
+    const parsed = endSessionSchema.safeParse(req.body)
+    if (!parsed.success) {
+      res.status(400).json({
+        success: false,
+        error: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      })
+      return
+    }
+
+    const session = await endSessionAtInn(parsed.data.sessionId, req.auth!.userId)
+    if (!session) {
+      res.status(404).json({ success: false, error: 'Active session not found' })
+      return
+    }
+
+    res.json({ success: true, data: { status: 'ended', endReason: 'inn' } })
+  }
+)
+
+/**
+ * POST /api/game/session/abandon
+ * Explicit "Abandonner ce perso" click. Ends the session and triggers the
+ * Chronicle. The 30-day-inactivity path is a separate job, not this route.
+ */
+gameRouter.post(
+  '/session/abandon',
+  async (req: Request, res: Response<ApiResponse<EndSessionResponse>>) => {
+    const parsed = endSessionSchema.safeParse(req.body)
+    if (!parsed.success) {
+      res.status(400).json({
+        success: false,
+        error: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      })
+      return
+    }
+
+    const session = await abandonSession(parsed.data.sessionId, req.auth!.userId)
+    if (!session) {
+      res.status(404).json({ success: false, error: 'Active session not found' })
+      return
+    }
+
+    res.json({ success: true, data: { status: 'ended', endReason: 'abandon' } })
+  }
+)

--- a/apps/backend/src/services/chronicle.service.test.ts
+++ b/apps/backend/src/services/chronicle.service.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callOpenRouter = vi.fn()
+vi.mock('../ai/openrouter.provider', () => ({ callOpenRouter }))
+
+const gameSessionFindUnique = vi.fn()
+const memoryChunkFindMany = vi.fn()
+const souvenirFindMany = vi.fn()
+const chronicleCreate = vi.fn()
+const sceneLogDeleteMany = vi.fn()
+vi.mock('../lib/prisma', () => ({
+  prisma: {
+    gameSession: { findUnique: gameSessionFindUnique },
+    memoryChunk: { findMany: memoryChunkFindMany },
+    souvenir: { findMany: souvenirFindMany },
+    chronicle: { create: chronicleCreate },
+    sceneLog: { deleteMany: sceneLogDeleteMany },
+  },
+}))
+
+const { generateChronicle } = await import('./chronicle.service')
+
+const character = {
+  id: 'char1',
+  userId: 'user1',
+  name: 'Yarel of the Salt Roads',
+  people: 'sahelin',
+  vocation: 'salt-walker',
+}
+
+const baseSession = {
+  id: 's1',
+  turnNumber: 12,
+  endReason: 'inn',
+  character,
+}
+
+const validOutput = {
+  title: 'The Last Crossing of Yarel',
+  body_markdown: 'A long literary chronicle body.',
+  mood: 'epic',
+  key_moments: [{ label: 'Yarel crosses the salt flats', scene_ref: 3 }],
+  tagline: 'The salt remembers her name',
+}
+
+describe('generateChronicle', () => {
+  beforeEach(() => {
+    callOpenRouter.mockReset()
+    gameSessionFindUnique.mockReset().mockResolvedValue(baseSession)
+    memoryChunkFindMany.mockReset().mockResolvedValue([
+      {
+        summary: 'Yarel crossed the salt flats.',
+        keyFactsPinned: ['Artifact obtained: shrine relic'],
+      },
+      { summary: 'Yarel met a wandering trader.', keyFactsPinned: ['NPC died: the Trader'] },
+    ])
+    souvenirFindMany
+      .mockReset()
+      .mockResolvedValue([{ title: 'The Trader Who Never Lied', body: 'A tale.' }])
+    chronicleCreate.mockReset().mockResolvedValue({})
+    sceneLogDeleteMany.mockReset().mockResolvedValue({ count: 0 })
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+
+  it('returns generated:false without calling the AI when the session has no endReason', async () => {
+    gameSessionFindUnique.mockResolvedValue({ ...baseSession, endReason: null })
+
+    const result = await generateChronicle('s1')
+
+    expect(result).toEqual({ generated: false })
+    expect(callOpenRouter).not.toHaveBeenCalled()
+  })
+
+  it('returns generated:false when the session does not exist', async () => {
+    gameSessionFindUnique.mockResolvedValue(null)
+
+    const result = await generateChronicle('s1')
+
+    expect(result).toEqual({ generated: false })
+    expect(callOpenRouter).not.toHaveBeenCalled()
+  })
+
+  it('skips AI generation and returns tooShort when the run has fewer than 5 turns', async () => {
+    gameSessionFindUnique.mockResolvedValue({ ...baseSession, turnNumber: 4 })
+
+    const result = await generateChronicle('s1')
+
+    expect(result).toEqual({ generated: false, tooShort: true })
+    expect(callOpenRouter).not.toHaveBeenCalled()
+    expect(chronicleCreate).not.toHaveBeenCalled()
+  })
+
+  it('generates and persists a Chronicle on success, then purges the session SceneLog', async () => {
+    callOpenRouter.mockResolvedValue({ success: true, content: JSON.stringify(validOutput) })
+
+    const result = await generateChronicle('s1')
+
+    expect(result).toEqual({ generated: true })
+    expect(chronicleCreate).toHaveBeenCalledWith({
+      data: {
+        userId: 'user1',
+        characterId: 'char1',
+        sessionId: 's1',
+        endReason: 'inn',
+        title: validOutput.title,
+        bodyMarkdown: validOutput.body_markdown,
+        mood: validOutput.mood,
+        keyMoments: validOutput.key_moments,
+        tagline: validOutput.tagline,
+      },
+    })
+    expect(sceneLogDeleteMany).toHaveBeenCalledWith({ where: { sessionId: 's1' } })
+  })
+
+  it('passes an explicit model option through to callOpenRouter', async () => {
+    callOpenRouter.mockResolvedValue({ success: true, content: JSON.stringify(validOutput) })
+
+    await generateChronicle('s1', { model: 'premium/model' })
+
+    expect(callOpenRouter).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ model: 'premium/model' })
+    )
+  })
+
+  it('never persists and never purges when the AI call fails', async () => {
+    callOpenRouter.mockResolvedValue({ success: false, error: 'timeout' })
+
+    const result = await generateChronicle('s1')
+
+    expect(result).toEqual({ generated: false })
+    expect(chronicleCreate).not.toHaveBeenCalled()
+    expect(sceneLogDeleteMany).not.toHaveBeenCalled()
+  })
+
+  it('never persists and never purges when the AI returns non-JSON', async () => {
+    callOpenRouter.mockResolvedValue({ success: true, content: 'not json' })
+
+    const result = await generateChronicle('s1')
+
+    expect(result).toEqual({ generated: false })
+    expect(chronicleCreate).not.toHaveBeenCalled()
+    expect(sceneLogDeleteMany).not.toHaveBeenCalled()
+  })
+
+  it('never persists and never purges when the AI JSON fails Zod validation', async () => {
+    callOpenRouter.mockResolvedValue({
+      success: true,
+      content: JSON.stringify({ title: 'Too short a payload' }),
+    })
+
+    const result = await generateChronicle('s1')
+
+    expect(result).toEqual({ generated: false })
+    expect(chronicleCreate).not.toHaveBeenCalled()
+    expect(sceneLogDeleteMany).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates pinned facts across memory chunks', async () => {
+    memoryChunkFindMany.mockResolvedValue([
+      { summary: 'A', keyFactsPinned: ['Artifact obtained: shrine relic'] },
+      { summary: 'B', keyFactsPinned: ['Artifact obtained: shrine relic', 'NPC died: the Trader'] },
+    ])
+    callOpenRouter.mockResolvedValue({ success: true, content: JSON.stringify(validOutput) })
+
+    await generateChronicle('s1')
+
+    const [messages] = callOpenRouter.mock.calls[0] as [{ content: string }[]]
+    const prompt = messages[0].content
+    const occurrences = prompt.split('Artifact obtained: shrine relic').length - 1
+    expect(occurrences).toBe(1)
+  })
+})

--- a/apps/backend/src/services/chronicle.service.ts
+++ b/apps/backend/src/services/chronicle.service.ts
@@ -1,0 +1,211 @@
+import { getPeople, getVocation } from '@grimoire/shared'
+
+import { type ChronicleOutput, validateChronicleOutput } from '../ai/chronicle-validator'
+import { callOpenRouter } from '../ai/openrouter.provider'
+import { env } from '../config/env'
+import { prisma } from '../lib/prisma'
+
+import type { ChronicleEndReason } from '@grimoire/shared'
+
+const CHRONICLE_TIMEOUT_MS = 8000
+/** Below this many turns there isn't enough narrative material for a Chronicle (17-RUN-CHRONICLE.md §7). */
+const MIN_TURNS_FOR_CHRONICLE = 5
+
+export interface GenerateChronicleOptions {
+  /** AI model override for the Chronicle text. Defaults to the free-tier model. Premium-tier branching is a future ticket. */
+  model?: string
+}
+
+export interface GenerateChronicleResult {
+  /** True when a Chronicle was generated and persisted. */
+  generated: boolean
+  /** Set when `generated` is false and the run was too short (< 5 turns) to have a Chronicle at all. */
+  tooShort?: boolean
+}
+
+interface ChronicleContext {
+  sessionId: string
+  userId: string
+  characterId: string
+  characterName: string
+  peopleLabel: string
+  vocationLabel: string
+  endReason: ChronicleEndReason
+  turnCount: number
+  memorySummaries: string[]
+  pinnedFacts: string[]
+  souvenirs: { title: string; body: string }[]
+}
+
+/** Builds the exact canon Chronicle prompt (docs/private/raw/17-RUN-CHRONICLE.md §1-3). */
+function buildChroniclePrompt(context: ChronicleContext): string {
+  const {
+    characterName,
+    peopleLabel,
+    vocationLabel,
+    endReason,
+    memorySummaries,
+    pinnedFacts,
+    souvenirs,
+  } = context
+
+  const endReasonLabel: Record<ChronicleEndReason, string> = {
+    death: 'Mort en cours de run',
+    inn: 'Choix de fin volontaire à l’auberge, face à L’Aveugle',
+    abandon: 'Abandon du personnage (inactivité ou clic explicite)',
+  }
+
+  return [
+    'Tu écris la Chronique de fin de run — un récit littéraire de 800 à 1200 mots qui transforme la partie vécue en histoire.',
+    '',
+    '[IDENTITÉ]',
+    `Nom : ${characterName}`,
+    `Peuple : ${peopleLabel}`,
+    `Vocation : ${vocationLabel}`,
+    `Cause de fin : ${endReasonLabel[endReason]}`,
+    '',
+    '[RÉSUMÉS DU RUN (mémoire N2)]',
+    memorySummaries.length > 0 ? memorySummaries.join('\n') : '(aucun résumé disponible)',
+    '',
+    '[FAITS ÉPINGLÉS]',
+    pinnedFacts.length > 0 ? pinnedFacts.join('\n') : '(aucun fait épinglé)',
+    '',
+    '[SOUVENIRS NOMMÉS DU RUN]',
+    souvenirs.length > 0
+      ? souvenirs.map((s) => `- ${s.title} : ${s.body}`).join('\n')
+      : '(aucun Souvenir nommé)',
+    '',
+    '[STRUCTURE]',
+    '3 actes implicites, jamais nommés dans le texte : Ouverture (~200-300 mots, le perso, son origine, sa quête initiale) ; Complications (~400-600 mots, rencontres marquantes, Souvenirs intégrés au récit, choix difficiles) ; Climax & fin (~200-300 mots, le moment de bascule, la cause de fin, l’écho qui reste).',
+    '',
+    '[VOIX]',
+    'Narrateur uniquement, sec, sensoriel, présent, à la 3e personne. Jamais "je", jamais L’Aveugle qui parle.',
+    '',
+    '[À MENTIONNER OBLIGATOIREMENT]',
+    '- Le nom du personnage, plusieurs fois',
+    '- La vocation, au moins une fois',
+    '- Le peuple, au moins un ancrage culturel',
+    '- 2-3 Souvenirs nommés intégrés au récit (jamais listés)',
+    '- 1-2 PNJ marquants par leur nom',
+    '- La cause de fin, décrite jamais énoncée bêtement',
+    '',
+    '[INTERDITS]',
+    '- Résumé "rapport de partie" ("Le joueur a tué X")',
+    '- Stats numériques',
+    '- Emojis',
+    '- Méta-commentaire ("En 3 actes, le joueur...")',
+    '- Adresse au lecteur ("Imaginez...")',
+    '',
+    '[INSTRUCTION]',
+    'Génère STRICTEMENT en JSON :',
+    '{',
+    '  "title": "string, max 80 caractères, style chapitre de roman, jamais générique",',
+    '  "body_markdown": "string, 800-1200 mots, markdown léger (pas de titres ##, italique autorisé)",',
+    '  "mood": "tragic | epic | melancholic | serene | absurd",',
+    '  "key_moments": [{"label": "5-8 mots", "scene_ref": 0}],',
+    '  "tagline": "string, 15-30 caractères, pour partage social"',
+    '}',
+  ].join('\n')
+}
+
+async function tryGenerate(prompt: string, model: string): Promise<ChronicleOutput | null> {
+  const result = await callOpenRouter([{ role: 'user', content: prompt }], {
+    model,
+    timeoutMs: CHRONICLE_TIMEOUT_MS,
+  })
+
+  if (!result.success || !result.content) {
+    return null
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(result.content)
+  } catch {
+    return null
+  }
+
+  const validated = validateChronicleOutput(parsed)
+  return validated.success && validated.data ? validated.data : null
+}
+
+/**
+ * Generates and persists the end-of-run Chronicle (17-RUN-CHRONICLE.md).
+ * Below `MIN_TURNS_FOR_CHRONICLE` turns, no AI call is made — the run had too
+ * little narrative material (canon §7). On AI failure or invalid output, no
+ * Chronicle is persisted and the caller must not purge the session's `SceneLog`.
+ * The AI model is an optional parameter (not hardcoded) so a future premium-tier
+ * ticket can pass a stronger model without changing this function's shape.
+ */
+export async function generateChronicle(
+  sessionId: string,
+  options?: GenerateChronicleOptions
+): Promise<GenerateChronicleResult> {
+  const session = await prisma.gameSession.findUnique({
+    where: { id: sessionId },
+    include: { character: true },
+  })
+  if (!session || !session.endReason) {
+    return { generated: false }
+  }
+
+  if (session.turnNumber < MIN_TURNS_FOR_CHRONICLE) {
+    return { generated: false, tooShort: true }
+  }
+
+  const { character } = session
+  const people = getPeople(character.people)
+  const vocation = getVocation(character.vocation)
+
+  const [memoryChunks, souvenirs] = await Promise.all([
+    prisma.memoryChunk.findMany({ where: { sessionId }, orderBy: { turnRangeEnd: 'asc' } }),
+    prisma.souvenir.findMany({ where: { sessionId }, orderBy: { createdAt: 'asc' } }),
+  ])
+
+  const context: ChronicleContext = {
+    sessionId,
+    userId: character.userId,
+    characterId: character.id,
+    characterName: character.name,
+    peopleLabel: people?.name.fr ?? character.people,
+    vocationLabel: vocation?.name.fr ?? character.vocation,
+    endReason: session.endReason as ChronicleEndReason,
+    turnCount: session.turnNumber,
+    memorySummaries: memoryChunks.map((chunk) => chunk.summary),
+    pinnedFacts: [
+      ...new Set(
+        memoryChunks.flatMap((chunk) =>
+          Array.isArray(chunk.keyFactsPinned) ? (chunk.keyFactsPinned as string[]) : []
+        )
+      ),
+    ],
+    souvenirs: souvenirs.map((s) => ({ title: s.title, body: s.body })),
+  }
+
+  const prompt = buildChroniclePrompt(context)
+  const model = options?.model ?? env.openRouter.model
+
+  const output = await tryGenerate(prompt, model)
+  if (!output) {
+    console.warn(`[Chronicle] generation failed for session ${sessionId}, no Chronicle persisted`)
+    return { generated: false }
+  }
+
+  await prisma.chronicle.create({
+    data: {
+      userId: context.userId,
+      characterId: context.characterId,
+      sessionId,
+      endReason: context.endReason,
+      title: output.title,
+      bodyMarkdown: output.body_markdown,
+      mood: output.mood,
+      keyMoments: output.key_moments,
+      tagline: output.tagline,
+    },
+  })
+
+  await prisma.sceneLog.deleteMany({ where: { sessionId } })
+
+  return { generated: true }
+}

--- a/apps/backend/src/services/session.service.ts
+++ b/apps/backend/src/services/session.service.ts
@@ -15,6 +15,7 @@ import { persistedChoicesSchema } from '../ai/scene-validator'
 import { resolveChoice } from '../game-rules/consequences'
 import { prisma } from '../lib/prisma'
 
+import { generateChronicle } from './chronicle.service'
 import { compressScene } from './memory.service'
 import { assembleScene } from './scene-assembler'
 import { validateAndPersistSouvenirCandidate } from './souvenir.service'
@@ -384,6 +385,16 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
     })()
   }
 
+  if (resolution.gameOver) {
+    void (async () => {
+      try {
+        await generateChronicle(session.id)
+      } catch (err) {
+        console.warn(`[Chronicle] failed to generate for session ${session.id}:`, err)
+      }
+    })()
+  }
+
   return {
     scene,
     updatedStats: toStatsRecord(resolution.updatedSurvival),
@@ -392,6 +403,63 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
     diceRoll: resolution.diceRoll,
     source: gm.source,
   }
+}
+
+/**
+ * Ends an active session with the given reason (`inn` or `abandon`) and
+ * fires the Chronicle generation, mirroring the `death` path in `resolveTurn`.
+ * Returns null if the session doesn't exist, isn't the caller's, or has
+ * already ended — the route decides how to surface that.
+ */
+async function endSession(
+  sessionId: string,
+  userId: string,
+  endReason: Exclude<SessionEndReason, 'death'>
+): Promise<GameSession | null> {
+  const session = await prisma.gameSession.findFirst({
+    where: { id: sessionId, status: 'active', character: { userId } },
+  })
+  if (!session) {
+    return null
+  }
+
+  const updated = await prisma.gameSession.update({
+    where: { id: session.id },
+    data: { status: 'ended', endReason },
+  })
+
+  void (async () => {
+    try {
+      await generateChronicle(session.id)
+    } catch (err) {
+      console.warn(`[Chronicle] failed to generate for session ${session.id}:`, err)
+    }
+  })()
+
+  return updated
+}
+
+/**
+ * Ends a session via the player's voluntary choice at the inn, facing
+ * L'Aveugle ("Ton aventure se termine ici").
+ */
+export async function endSessionAtInn(
+  sessionId: string,
+  userId: string
+): Promise<GameSession | null> {
+  return endSession(sessionId, userId, 'inn')
+}
+
+/**
+ * Ends a session via an explicit "Abandonner ce perso" click. The 30-day
+ * inactivity path is a separate job, not wired here (mirrors the Souvenir
+ * purge job's approach: a plain exported function, no cron infra yet).
+ */
+export async function abandonSession(
+  sessionId: string,
+  userId: string
+): Promise<GameSession | null> {
+  return endSession(sessionId, userId, 'abandon')
 }
 
 /** Assembles the shared `Character` shape the Game Master prompt expects. */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,7 @@ export * from "./types/combat.types";
 export * from "./types/session.types";
 export * from "./types/api.types";
 export * from "./types/souvenir.types";
+export * from "./types/chronicle.types";
 
 // Constants
 export * from "./constants/localized";

--- a/packages/shared/src/types/chronicle.types.ts
+++ b/packages/shared/src/types/chronicle.types.ts
@@ -1,0 +1,29 @@
+/** Dominant tone of a Chronicle. @see 17-RUN-CHRONICLE.md §2 */
+export type ChronicleMood =
+  | "tragic"
+  | "epic"
+  | "melancholic"
+  | "serene"
+  | "absurd";
+
+export interface ChronicleKeyMoment {
+  label: string;
+  sceneRef: number;
+}
+
+/** Why a GameSession ended, mirrors GameSession.endReason. */
+export type ChronicleEndReason = "death" | "inn" | "abandon";
+
+export interface Chronicle {
+  id: string;
+  userId: string;
+  characterId: string;
+  sessionId: string;
+  endReason: ChronicleEndReason;
+  title: string;
+  bodyMarkdown: string;
+  mood: ChronicleMood;
+  keyMoments: ChronicleKeyMoment[];
+  tagline: string;
+  createdAt: string;
+}


### PR DESCRIPTION
Synthèse littéraire IA (800-1200 mots) générée une seule fois en fin de run, à partir des résumés N2 (MemoryChunk), des Souvenirs N3, des faits épinglés et de l'identité du personnage.

- `Chronicle` (Prisma) : titre, corps markdown, mood, key_moments, tagline
- `chronicle-validator.ts` : schéma Zod strict, `illustration_prompt` volontairement exclu (hors scope)
- `chronicle.service.ts` : `generateChronicle()` — skip-rule (<5 tours), timeout 8s, purge du `SceneLog` uniquement après persistance réussie, modèle IA passé en paramètre (branchement premium différé)
- Wiring des 3 triggers de fin de run : mort (`resolveTurn`), auberge (`POST /session/end-inn`), abandon (`POST /session/abandon`)
- `GET /api/chronicles/session/:sessionId` — lecture scopée à l'utilisateur

## Hors scope (tickets séparés)

- Branchement modèle premium pour le texte
- Partage public / illustration
- Job d'abandon après 30 jours d'inactivité
- Endpoint galerie/liste des Chroniques (#130)
- UI frontend (écran de fin de run)

## Tests

- chronicle-validator.test.ts (13 tests) : validation Zod du payload IA
- chronicle.service.test.ts (9 tests) : skip-rule, succès + persistance + purge, échecs IA/JSON/Zod sans crash ni persistance, dédup des faits épinglés
- pnpm type-check / pnpm lint / pnpm test : tous verts (102 tests backend)

Closes #116