### PR TITLE
feat(auberge): ajouter le hub immersif de L’Aveugle

### DIFF
--- a/apps/frontend/src/app/(main)/velkhar/aveugle/aveugle.css
+++ b/apps/frontend/src/app/(main)/velkhar/aveugle/aveugle.css
@@ -45,7 +45,7 @@ body:has(.aveugle-threshold) .main-navigation {
 .aveugle-threshold__location {
   color: var(--gold-light);
   font-family: var(--font-game-ui);
-  font-size: var(--text-game-label);
+  font-size: clamp(1rem, 1.35vw, 1.2rem);
   letter-spacing: 0.18em;
   margin: 0 0 0.75rem 0.25rem;
   text-shadow: 0 2px 8px #000;
@@ -81,22 +81,15 @@ body:has(.aveugle-threshold) .main-navigation {
   flex: 0 0 auto;
 }
 
-.aveugle-threshold__speaker p {
-  color: var(--gold);
-  font-family: var(--font-game-ui);
-  font-size: var(--text-game-label);
-  letter-spacing: 0.16em;
-  margin: 0 0 0.25rem;
-  text-transform: uppercase;
-}
-
 .aveugle-threshold__speaker h1 {
   color: var(--gold-light);
   font-family: var(--font-game-heading);
-  font-size: var(--text-game-title);
+  font-size: clamp(1.6rem, 2.5vw, 2.25rem);
   font-weight: 500;
-  line-height: 1.08;
+  letter-spacing: 0.08em;
+  line-height: 1.15;
   margin: 0;
+  text-transform: uppercase;
   text-wrap: balance;
 }
 
@@ -104,20 +97,13 @@ body:has(.aveugle-threshold) .main-navigation {
   border-left: 1px solid rgba(217, 164, 65, 0.55);
   color: var(--parchment);
   font-family: var(--font-game-heading);
-  font-size: var(--text-game-quote);
+  font-size: clamp(1.55rem, 2.5vw, 2.15rem);
   font-style: italic;
-  line-height: 1.6;
-  margin: clamp(1.5rem, 3vw, 2.25rem) 0 1rem;
+  line-height: 1.45;
+  margin: clamp(1.75rem, 3vw, 2.5rem) 0 0;
+  max-width: 36ch;
+  padding-bottom: 0.12em;
   padding-left: 1.25rem;
-  text-wrap: pretty;
-}
-
-.aveugle-threshold__copy {
-  color: var(--ink-2);
-  font-size: var(--text-game-body);
-  line-height: 1.65;
-  margin: 0;
-  max-width: 58ch;
   text-wrap: pretty;
 }
 
@@ -125,7 +111,7 @@ body:has(.aveugle-threshold) .main-navigation {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  margin-top: clamp(1.5rem, 3vw, 2.25rem);
+  margin-top: clamp(2rem, 3.5vw, 3rem);
 }
 
 @media (min-width: 641px) and (max-width: 900px) {
@@ -172,10 +158,6 @@ body:has(.aveugle-threshold) .main-navigation {
   .aveugle-threshold blockquote {
     line-height: 1.5;
     margin-top: 1.35rem;
-  }
-
-  .aveugle-threshold__copy {
-    line-height: 1.55;
   }
 
   .aveugle-threshold__actions {
@@ -237,10 +219,6 @@ body:has(.aveugle-threshold) .main-navigation {
   .aveugle-threshold blockquote {
     line-height: 1.5;
     margin-top: 1.25rem;
-  }
-
-  .aveugle-threshold__copy {
-    line-height: 1.55;
   }
 
   .aveugle-threshold__actions,

--- a/apps/frontend/src/app/(main)/velkhar/aveugle/page.tsx
+++ b/apps/frontend/src/app/(main)/velkhar/aveugle/page.tsx
@@ -1,7 +1,4 @@
-import { GameLink } from '@/components/ui/game-link'
-import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
-import { GamePanel } from '@/components/ui/grimoire/GamePanel/GamePanel'
-import { VelkharMotionShell } from '@/components/ui/velkhar-motion-shell'
+import { AveugleHub } from '@/components/aveugle-hub/AveugleHub'
 
 import type { Metadata } from 'next'
 
@@ -16,111 +13,21 @@ interface AveuglePageProps {
     campaign?: string | string[]
     character?: string | string[]
     flow?: string | string[]
+    return?: string | string[]
     transition?: string | string[]
   }>
 }
 
-function getCharacterFlowHref(campaign: string | string[] | undefined): string {
-  const campaignId = typeof campaign === 'string' ? campaign : undefined
-
-  return campaignId
-    ? `/velkhar/aveugle?flow=character-create&campaign=${encodeURIComponent(campaignId)}`
-    : '/velkhar/aveugle?flow=character-create'
-}
-
-function getCharacterCreateHref(campaign: string | string[] | undefined): string {
-  const campaignId = typeof campaign === 'string' ? campaign : undefined
-
-  return campaignId
-    ? `/velkhar/character-create?campaign=${encodeURIComponent(campaignId)}`
-    : '/velkhar/character-create'
-}
-
 export default async function AveuglePage({ searchParams }: AveuglePageProps) {
-  const { campaign, character, flow, transition } = await searchParams
-  const isCharacterFlow = flow === 'character-create'
-  const isCharacterReady = character === 'ready'
+  const { campaign, character, flow, return: returnState, transition } = await searchParams
 
   return (
-    <VelkharMotionShell animateEntrance={transition === 'home'} className="aveugle-threshold">
-      <div className="aveugle-threshold__scene" data-velkhar-scene aria-hidden="true" />
-      <div className="aveugle-threshold__veil" aria-hidden="true" />
-
-      <section className="aveugle-threshold__dialogue" aria-labelledby="aveugle-title">
-        <p className="aveugle-threshold__location" data-velkhar-enter>
-          Velkhar · L’Auberge de L’Aveugle
-        </p>
-        <div className="aveugle-threshold__portrait" data-velkhar-enter aria-hidden="true" />
-
-        <GamePanel
-          className="aveugle-threshold__panel"
-          data-velkhar-frame
-          padding="none"
-          tone="gold"
-          variant="aveugle-dialogue"
-        >
-          <div className="aveugle-threshold__speaker" data-velkhar-enter>
-            <GameIcon
-              decorative
-              name={isCharacterReady ? 'scroll' : isCharacterFlow ? 'quill' : 'eye'}
-              size={48}
-            />
-            <div>
-              <p>
-                {isCharacterFlow || isCharacterReady ? 'Le registre de L’Aveugle' : 'L’Aveugle'}
-              </p>
-              <h1 id="aveugle-title">
-                {isCharacterReady
-                  ? 'Le registre porte désormais ton nom.'
-                  : isCharacterFlow
-                    ? 'Sous quel nom les sables te connaissent-ils ?'
-                    : 'Chaque histoire commence ici.'}
-              </h1>
-            </div>
-          </div>
-
-          <blockquote data-velkhar-enter>
-            {isCharacterReady
-              ? '« Bien. Les sables sauront qui marche sur eux. Lorsque tu seras prêt, la porte s’ouvrira. »'
-              : isCharacterFlow
-                ? '« Un nom d’abord. Puis nous verrons ce que la route a laissé dans ton regard. »'
-                : '« Repose-toi, voyageur. Avant de franchir les portes de Velkhar, dis-moi qui tu es. »'}
-          </blockquote>
-
-          <p className="aveugle-threshold__copy" data-velkhar-enter>
-            {isCharacterReady
-              ? 'Ton personnage est revenu auprès de L’Aveugle. La prochaine action peut maintenant ouvrir le run.'
-              : isCharacterFlow
-                ? 'Le registre s’ouvre sur la table. Ton personnage prendra forme ici, au fil de cette première conversation.'
-                : 'L’Auberge est le seuil de chaque run. Vous pouvez commencer cette première conversation sans créer de compte.'}
-          </p>
-
-          <div className="aveugle-threshold__actions" data-velkhar-enter>
-            {isCharacterReady ? (
-              <GameLink
-                href="/velkhar/session/new"
-                trailingIcon={<GameIcon decorative name="arrow" size={24} />}
-              >
-                Franchir la porte
-              </GameLink>
-            ) : isCharacterFlow ? (
-              <GameLink
-                href={getCharacterCreateHref(campaign)}
-                trailingIcon={<GameIcon decorative name="arrow" size={24} />}
-              >
-                Ouvrir le registre
-              </GameLink>
-            ) : (
-              <GameLink
-                href={getCharacterFlowHref(campaign)}
-                trailingIcon={<GameIcon decorative name="arrow" size={24} />}
-              >
-                Répondre à L’Aveugle
-              </GameLink>
-            )}
-          </div>
-        </GamePanel>
-      </section>
-    </VelkharMotionShell>
+    <AveugleHub
+      campaignId={typeof campaign === 'string' ? campaign : undefined}
+      characterReadyHint={character === 'ready'}
+      isCharacterFlow={flow === 'character-create'}
+      isRunReturn={returnState === 'chronicle' || returnState === 'run'}
+      transitionFromHome={transition === 'home'}
+    />
   )
 }

--- a/apps/frontend/src/components/aveugle-hub/AubergeDock.tsx
+++ b/apps/frontend/src/components/aveugle-hub/AubergeDock.tsx
@@ -1,0 +1,392 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
+import { DialogueChoice } from '@/components/ui/grimoire/DialogueChoice/DialogueChoice'
+import { DialogueChoiceGroup } from '@/components/ui/grimoire/DialogueChoiceGroup/DialogueChoiceGroup'
+import { GameButton } from '@/components/ui/grimoire/GameButton/GameButton'
+import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
+import { GamePanel } from '@/components/ui/grimoire/GamePanel/GamePanel'
+import { NarrativeComposer } from '@/components/ui/grimoire/NarrativeComposer/NarrativeComposer'
+import { gsap, useGSAP } from '@/lib/gsap-init'
+
+import { AVEUGLE_MEMORIES, AVEUGLE_OMENS, AVEUGLE_TOPICS } from './_data/aveugle-hub-fixtures'
+import { addSeenId, type AubergePreparationState } from './auberge-preparation'
+
+import type { AveugleMemoryId, AveugleOmenId, AveugleTopicId } from './_data/aveugle-hub-fixtures'
+
+export type AubergePanel = 'dialogue' | 'memories' | 'omen'
+
+interface AubergeDockProps {
+  activePanel: AubergePanel
+  isActiveSession: boolean
+  onActivePanelChange: (panel: AubergePanel) => void
+  onPreparationChange: (preparation: AubergePreparationState) => void
+  openingLine: string
+  preparation: AubergePreparationState
+}
+
+const PANEL_META = {
+  dialogue: { icon: 'eye', title: 'L’Aveugle' },
+  memories: { icon: 'memory', title: 'Souvenirs' },
+  omen: { icon: 'moon', title: 'Présage' },
+} as const
+
+export function AubergeDock({
+  activePanel,
+  isActiveSession,
+  onActivePanelChange,
+  onPreparationChange,
+  openingLine,
+  preparation,
+}: AubergeDockProps) {
+  const [selectedTopicId, setSelectedTopicId] = useState<AveugleTopicId | null>(null)
+  const [selectedMemoryId, setSelectedMemoryId] = useState<AveugleMemoryId | null>(null)
+  const [customAction, setCustomAction] = useState('')
+  const [customResponse, setCustomResponse] = useState<string | null>(null)
+  const [isComposerOpen, setIsComposerOpen] = useState(false)
+  const [isTopicExpanded, setIsTopicExpanded] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const stageRef = useRef<HTMLDivElement>(null)
+  const emblemRef = useRef<HTMLDivElement>(null)
+
+  const selectedTopic = AVEUGLE_TOPICS.find((topic) => topic.id === selectedTopicId)
+  const selectedMemory = AVEUGLE_MEMORIES.find((memory) => memory.id === selectedMemoryId)
+  const selectedOmen = AVEUGLE_OMENS.find((omen) => omen.id === preparation.selectedOmenId)
+  const dialogueResponse = customResponse ?? selectedTopic?.response ?? openingLine
+  const dialogueMode =
+    selectedTopic || customResponse ? 'answer' : isComposerOpen ? 'composer' : 'topics'
+  const panelMeta = PANEL_META[activePanel]
+  const unreadTopicCount = AVEUGLE_TOPICS.filter(
+    (topic) => topic.isNew && !preparation.seenTopicIds.includes(topic.id)
+  ).length
+  const unreadMemoryCount = AVEUGLE_MEMORIES.filter(
+    (memory) => memory.isNew && !preparation.seenMemoryIds.includes(memory.id)
+  ).length
+  const contentKey = [
+    activePanel,
+    dialogueMode,
+    dialogueResponse,
+    selectedMemoryId,
+    preparation.selectedOmenId,
+  ].join(':')
+
+  useGSAP(
+    () => {
+      const stage = stageRef.current
+      const emblem = emblemRef.current
+      if (!stage || !emblem) return undefined
+
+      const media = gsap.matchMedia()
+      media.add('(prefers-reduced-motion: no-preference)', () => {
+        const timeline = gsap.timeline({ defaults: { ease: 'power3.out' } })
+        timeline
+          .fromTo(
+            emblem,
+            { autoAlpha: 0, filter: 'blur(4px)', scale: 0.25 },
+            {
+              autoAlpha: 1,
+              clearProps: 'filter,opacity,transform,visibility',
+              duration: 0.3,
+              filter: 'blur(0px)',
+              scale: 1,
+            },
+            0
+          )
+          .fromTo(
+            stage,
+            { autoAlpha: 0, y: 12 },
+            {
+              autoAlpha: 1,
+              clearProps: 'opacity,transform,visibility',
+              duration: 0.42,
+              y: 0,
+            },
+            0.06
+          )
+
+        const actions = stage.querySelectorAll<HTMLElement>('[data-dialogue-action]')
+        if (actions.length > 0) {
+          timeline.fromTo(
+            actions,
+            { autoAlpha: 0, y: 8 },
+            {
+              autoAlpha: 1,
+              clearProps: 'opacity,transform,visibility',
+              duration: 0.3,
+              stagger: 0.05,
+              y: 0,
+            },
+            0.2
+          )
+        }
+      })
+
+      return () => media.revert()
+    },
+    { dependencies: [contentKey], revertOnUpdate: true, scope: rootRef }
+  )
+
+  const updatePreparation = (next: Partial<AubergePreparationState>) => {
+    onPreparationChange({ ...preparation, ...next })
+  }
+
+  const selectTopic = (topicId: AveugleTopicId) => {
+    setCustomResponse(null)
+    setSelectedTopicId(topicId)
+    setIsTopicExpanded(false)
+    updatePreparation({ seenTopicIds: addSeenId(preparation.seenTopicIds, topicId) })
+  }
+
+  const selectMemory = (memoryId: AveugleMemoryId) => {
+    setSelectedMemoryId(memoryId)
+    updatePreparation({ seenMemoryIds: addSeenId(preparation.seenMemoryIds, memoryId) })
+  }
+
+  const selectOmen = (omenId: AveugleOmenId) => {
+    updatePreparation({ selectedOmenId: omenId })
+  }
+
+  const submitCustomAction = () => {
+    if (!customAction.trim()) return
+    setSelectedTopicId(null)
+    setCustomResponse('Garde cette pensée. La route lui donnera un sens.')
+    setIsComposerOpen(false)
+    setCustomAction('')
+  }
+
+  const returnToTopics = () => {
+    setCustomResponse(null)
+    setSelectedTopicId(null)
+    setIsComposerOpen(false)
+    setIsTopicExpanded(false)
+  }
+
+  return (
+    <div ref={rootRef} className="aveugle-hub__dock">
+      <nav className="aveugle-hub__dock-nav" aria-label="Espaces de l’auberge">
+        <GameButton
+          aria-pressed={activePanel === 'dialogue'}
+          leadingIcon={<GameIcon decorative name="dialogue" size={24} />}
+          onClick={() => onActivePanelChange('dialogue')}
+          size="sm"
+          variant="ghost"
+        >
+          Parler{unreadTopicCount > 0 ? ` · ${unreadTopicCount}` : ''}
+        </GameButton>
+        <GameButton
+          aria-pressed={activePanel === 'memories'}
+          leadingIcon={<GameIcon decorative name="memory" size={24} />}
+          onClick={() => onActivePanelChange('memories')}
+          size="sm"
+          variant="ghost"
+        >
+          Souvenirs{unreadMemoryCount > 0 ? ` · ${unreadMemoryCount}` : ''}
+        </GameButton>
+        {!isActiveSession ? (
+          <GameButton
+            aria-label={selectedOmen ? 'Présage choisi' : 'Ouvrir les présages'}
+            aria-pressed={activePanel === 'omen'}
+            leadingIcon={<GameIcon decorative name="moon" size={24} />}
+            onClick={() => onActivePanelChange('omen')}
+            size="sm"
+            variant="ghost"
+          >
+            Présage
+          </GameButton>
+        ) : null}
+      </nav>
+
+      <GamePanel
+        className="aveugle-hub__dialogue"
+        data-auberge-frame
+        padding="none"
+        variant="aveugle-dialogue"
+      >
+        <div className="aveugle-hub__dialogue-content">
+          <header>
+            <div ref={emblemRef} className="aveugle-hub__speaker-mark">
+              <GameIcon decorative name={panelMeta.icon} size={64} />
+            </div>
+            <h1>{panelMeta.title}</h1>
+          </header>
+
+          <div ref={stageRef} className="aveugle-hub__conversation-stage">
+            {activePanel === 'dialogue' ? (
+              <>
+                <blockquote aria-live="polite">« {dialogueResponse} »</blockquote>
+
+                {dialogueMode === 'topics' ? (
+                  <DialogueChoiceGroup label="Sujets à aborder avec L’Aveugle">
+                    {AVEUGLE_TOPICS.map((topic) => {
+                      const isUnread = Boolean(
+                        topic.isNew && !preparation.seenTopicIds.includes(topic.id)
+                      )
+                      return (
+                        <DialogueChoice
+                          key={topic.id}
+                          aria-label={`${topic.label}${isUnread ? ', nouveau' : ''}`}
+                          data-dialogue-action
+                          icon={<GameIcon decorative name={topic.icon} size={32} />}
+                          onClick={() => selectTopic(topic.id)}
+                        >
+                          <span className="aveugle-hub__choice-copy">
+                            <span>{topic.label}</span>
+                            {isUnread ? <small>Nouveau</small> : null}
+                          </span>
+                        </DialogueChoice>
+                      )
+                    })}
+                  </DialogueChoiceGroup>
+                ) : null}
+
+                {dialogueMode === 'topics' ? (
+                  <GameButton
+                    className="aveugle-hub__other-question"
+                    data-dialogue-action
+                    onClick={() => setIsComposerOpen(true)}
+                    size="sm"
+                    variant="ghost"
+                  >
+                    Autre question…
+                  </GameButton>
+                ) : null}
+
+                {dialogueMode === 'composer' ? (
+                  <div className="aveugle-hub__composer" data-dialogue-action>
+                    <NarrativeComposer
+                      actionDisabled={!customAction.trim()}
+                      actionLabel="Parler"
+                      onAction={submitCustomAction}
+                      onChange={(event) => setCustomAction(event.target.value)}
+                      placeholder="Pose ta question…"
+                      value={customAction}
+                    />
+                    <GameButton onClick={returnToTopics} size="sm" variant="ghost">
+                      Revenir aux sujets
+                    </GameButton>
+                  </div>
+                ) : null}
+
+                {dialogueMode === 'answer' ? (
+                  <div className="aveugle-hub__response-actions">
+                    {selectedTopic && !isTopicExpanded ? (
+                      <GameButton
+                        data-dialogue-action
+                        onClick={() => {
+                          setCustomResponse(selectedTopic.followUp)
+                          setIsTopicExpanded(true)
+                        }}
+                        size="sm"
+                        variant="secondary"
+                      >
+                        Approfondir
+                      </GameButton>
+                    ) : null}
+                    <GameButton
+                      data-dialogue-action
+                      onClick={returnToTopics}
+                      size="sm"
+                      variant="ghost"
+                    >
+                      Autres sujets
+                    </GameButton>
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+
+            {activePanel === 'memories' ? (
+              selectedMemory ? (
+                <>
+                  <blockquote aria-live="polite">« {selectedMemory.response} »</blockquote>
+                  <GameButton
+                    data-dialogue-action
+                    onClick={() => setSelectedMemoryId(null)}
+                    size="sm"
+                    variant="ghost"
+                  >
+                    Revoir les souvenirs
+                  </GameButton>
+                </>
+              ) : (
+                <>
+                  <blockquote>« Ce que tu rapportes ne dort jamais tout à fait. »</blockquote>
+                  <DialogueChoiceGroup label="Souvenirs rapportés à l’auberge">
+                    {AVEUGLE_MEMORIES.map((memory) => {
+                      const isUnread = Boolean(
+                        memory.isNew && !preparation.seenMemoryIds.includes(memory.id)
+                      )
+                      return (
+                        <DialogueChoice
+                          key={memory.id}
+                          aria-label={`${memory.title}${isUnread ? ', nouveau' : ''}`}
+                          data-dialogue-action
+                          icon={<GameIcon decorative name={memory.icon} size={32} />}
+                          onClick={() => selectMemory(memory.id)}
+                        >
+                          <span className="aveugle-hub__choice-copy">
+                            <span>{memory.title}</span>
+                            {isUnread ? <small>Nouveau</small> : null}
+                          </span>
+                        </DialogueChoice>
+                      )
+                    })}
+                  </DialogueChoiceGroup>
+                </>
+              )
+            ) : null}
+
+            {activePanel === 'omen' && !isActiveSession ? (
+              selectedOmen ? (
+                <>
+                  <blockquote aria-live="polite">« {selectedOmen.response} »</blockquote>
+                  <p className="aveugle-hub__omen-effect">{selectedOmen.effect}</p>
+                  <div className="aveugle-hub__response-actions">
+                    <GameButton
+                      data-dialogue-action
+                      onClick={() => updatePreparation({ selectedOmenId: null })}
+                      size="sm"
+                      variant="secondary"
+                    >
+                      Changer de présage
+                    </GameButton>
+                    <GameButton
+                      data-dialogue-action
+                      onClick={() => onActivePanelChange('dialogue')}
+                      size="sm"
+                      variant="ghost"
+                    >
+                      Parler à L’Aveugle
+                    </GameButton>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <blockquote>
+                    « Deux chemins se présentent. Choisis ce que tu veux savoir. »
+                  </blockquote>
+                  <DialogueChoiceGroup label="Présages du prochain run">
+                    {AVEUGLE_OMENS.map((omen) => (
+                      <DialogueChoice
+                        key={omen.id}
+                        data-dialogue-action
+                        icon={<GameIcon decorative name={omen.icon} size={32} />}
+                        onClick={() => selectOmen(omen.id)}
+                      >
+                        <span className="aveugle-hub__choice-copy aveugle-hub__choice-copy--omen">
+                          <strong>{omen.label}</strong>
+                          <small>{omen.effect}</small>
+                        </span>
+                      </DialogueChoice>
+                    ))}
+                  </DialogueChoiceGroup>
+                </>
+              )
+            ) : null}
+          </div>
+        </div>
+      </GamePanel>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/aveugle-hub/AveugleHub.test.tsx
+++ b/apps/frontend/src/components/aveugle-hub/AveugleHub.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CHARACTER_RESULT_STORAGE_KEY } from '@/components/character-create/character-create-model'
+import { ACTIVE_GAME_SESSION_COOKIE } from '@/lib/active-game-session'
+
+import { AveugleHub } from './AveugleHub'
+
+vi.mock('next/image', () => ({
+  default: ({
+    alt,
+    fill: _fill,
+    priority: _priority,
+    unoptimized: _unoptimized,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & {
+    fill?: boolean
+    priority?: boolean
+    unoptimized?: boolean
+  }) => <img alt={alt} {...props} />,
+}))
+
+const CHARACTER = {
+  version: 1,
+  name: 'Amani',
+  peopleId: 'sahelin',
+  vocationPath: 'preset',
+  vocationId: 'salt-walker',
+  freeConcept: '',
+  backstory: '',
+  historyReviewed: true,
+}
+
+describe('AveugleHub', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+    document.cookie = `${ACTIVE_GAME_SESSION_COOKIE}=; Path=/; Max-Age=0`
+  })
+
+  it('conserve le seuil narratif quand aucun personnage n’existe', async () => {
+    render(<AveugleHub campaignId="nouvelle-chronique" />)
+
+    expect(await screen.findByRole('heading', { name: 'L’Aveugle' })).toBeInTheDocument()
+    expect(screen.getByText(/Avant la route, donne-moi ton nom/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Répondre/ })).toHaveAttribute(
+      'href',
+      '/velkhar/aveugle?flow=character-create&campaign=nouvelle-chronique'
+    )
+    expect(
+      screen.queryByRole('group', { name: 'Sujets à aborder avec L’Aveugle' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('ouvre la Forge au second temps du flow sans personnage', async () => {
+    render(<AveugleHub campaignId="nouvelle-chronique" isCharacterFlow />)
+
+    expect(
+      await screen.findByRole('heading', { name: 'Le registre de L’Aveugle' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Donner mon nom/ })).toHaveAttribute(
+      'href',
+      '/velkhar/character-create?campaign=nouvelle-chronique'
+    )
+  })
+
+  it('affiche le personnage et rend les sujets du hub interactifs', async () => {
+    const user = userEvent.setup()
+    window.localStorage.setItem(CHARACTER_RESULT_STORAGE_KEY, JSON.stringify(CHARACTER))
+
+    render(<AveugleHub />)
+
+    expect(await screen.findByLabelText('Personnage : Amani')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Choisir un présage' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Les Calcinés/ }))
+    expect(screen.getByText(/Les Calcinés n’écoutent plus la Cendre/)).toBeInTheDocument()
+    expect(
+      screen.queryByRole('group', { name: 'Sujets à aborder avec L’Aveugle' })
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Approfondir' }))
+    expect(screen.getByText(/Quand la Cendre prononce ton nom/)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Autres sujets' }))
+    await user.click(screen.getByRole('button', { name: 'Autre question…' }))
+    expect(screen.getByPlaceholderText('Pose ta question…')).toBeInTheDocument()
+  })
+
+  it('prépare le prochain run avec un présage explicite', async () => {
+    const user = userEvent.setup()
+    window.localStorage.setItem(CHARACTER_RESULT_STORAGE_KEY, JSON.stringify(CHARACTER))
+
+    render(<AveugleHub />)
+
+    await user.click(await screen.findByRole('button', { name: 'Choisir un présage' }))
+    await user.click(screen.getByRole('button', { name: /Suivre la fumée/ }))
+
+    expect(screen.getByText(/rencontre cachée pourra apparaître/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Partir en run/ })).toHaveAttribute(
+      'href',
+      '/velkhar/session/new?omen=follow-smoke'
+    )
+  })
+
+  it('isole les souvenirs de la conversation principale', async () => {
+    const user = userEvent.setup()
+    window.localStorage.setItem(CHARACTER_RESULT_STORAGE_KEY, JSON.stringify(CHARACTER))
+
+    render(<AveugleHub />)
+
+    await user.click(await screen.findByRole('button', { name: /Souvenirs/ }))
+    expect(
+      screen.queryByRole('group', { name: 'Sujets à aborder avec L’Aveugle' })
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /La nuit de Vane/ }))
+    expect(screen.getByText(/Son silence voyage encore avec toi/)).toBeInTheDocument()
+  })
+
+  it('oriente une session active vers la reprise', async () => {
+    window.localStorage.setItem(CHARACTER_RESULT_STORAGE_KEY, JSON.stringify(CHARACTER))
+    document.cookie = `${ACTIVE_GAME_SESSION_COOKIE}=1; Path=/; SameSite=Lax`
+
+    render(<AveugleHub />)
+
+    expect(await screen.findByText(/Ta place est encore chaude/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Reprendre la route/ })).toHaveAttribute(
+      'href',
+      '/velkhar/session/resume'
+    )
+  })
+})

--- a/apps/frontend/src/components/aveugle-hub/AveugleHub.tsx
+++ b/apps/frontend/src/components/aveugle-hub/AveugleHub.tsx
@@ -1,0 +1,311 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  CHARACTER_RESULT_STORAGE_KEY,
+  parseStoredCharacterResult,
+  type CharacterCreateDraft,
+} from '@/components/character-create/character-create-model'
+import { GameLink } from '@/components/ui/game-link'
+import { GameButton } from '@/components/ui/grimoire/GameButton/GameButton'
+import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
+import { GameSceneLayout } from '@/components/ui/grimoire/GameSceneLayout/GameSceneLayout'
+import { LocationIdentity } from '@/components/ui/grimoire/LocationIdentity/LocationIdentity'
+import { PlayerIdentity } from '@/components/ui/grimoire/PlayerIdentity/PlayerIdentity'
+import { ResourceCounter } from '@/components/ui/grimoire/ResourceCounter/ResourceCounter'
+import { VocationEmblem } from '@/components/ui/grimoire/VocationEmblem/VocationEmblem'
+import { VelkharMotionShell } from '@/components/ui/velkhar-motion-shell'
+import { ACTIVE_GAME_SESSION_COOKIE, hasActiveGameSession } from '@/lib/active-game-session'
+import { gsap, useGSAP } from '@/lib/gsap-init'
+
+import { AVEUGLE_RESOURCES } from './_data/aveugle-hub-fixtures'
+import {
+  AUBERGE_PREPARATION_STORAGE_KEY,
+  EMPTY_AUBERGE_PREPARATION,
+  parseAubergePreparation,
+  withOmenQuery,
+  type AubergePreparationState,
+} from './auberge-preparation'
+import { AubergeDock, type AubergePanel } from './AubergeDock'
+import {
+  getFallbackHubCharacter,
+  resolveAveugleHubSnapshot,
+  type AveugleHubStage,
+} from './aveugle-hub-model'
+import { AveugleThreshold } from './AveugleThreshold'
+
+import './aveugle-hub.css'
+
+interface AveugleHubProps {
+  campaignId?: string
+  characterReadyHint?: boolean
+  isCharacterFlow?: boolean
+  isRunReturn?: boolean
+  transitionFromHome?: boolean
+}
+
+const STAGE_COPY: Record<AveugleHubStage, string> = {
+  'character-create': 'Approche. Avant la route, donne-moi ton nom.',
+  ready: 'Ton nom est inscrit. La route, elle, ne l’est pas encore.',
+  'active-session': 'Ta place est encore chaude. Reprends la route là où tu l’as laissée.',
+  'run-return': 'Tu reviens changé. La nuit de Vane t’a suivi jusqu’ici.',
+}
+
+function readActiveSessionCookie(): boolean {
+  const cookie = document.cookie
+    .split('; ')
+    .find((entry) => entry.startsWith(`${ACTIVE_GAME_SESSION_COOKIE}=`))
+  return hasActiveGameSession(cookie?.split('=')[1])
+}
+
+function readCharacter(characterReadyHint: boolean): CharacterCreateDraft | null {
+  const persisted = parseStoredCharacterResult(
+    window.localStorage.getItem(CHARACTER_RESULT_STORAGE_KEY)
+  )
+  if (persisted) return persisted
+
+  const legacy = parseStoredCharacterResult(
+    window.sessionStorage.getItem(CHARACTER_RESULT_STORAGE_KEY)
+  )
+  if (legacy) {
+    window.localStorage.setItem(CHARACTER_RESULT_STORAGE_KEY, JSON.stringify(legacy))
+    window.sessionStorage.removeItem(CHARACTER_RESULT_STORAGE_KEY)
+    return legacy
+  }
+
+  return characterReadyHint ? getFallbackHubCharacter() : null
+}
+
+export function AveugleHub({
+  campaignId,
+  characterReadyHint = false,
+  isCharacterFlow = false,
+  isRunReturn = false,
+  transitionFromHome = false,
+}: AveugleHubProps) {
+  const [hydrated, setHydrated] = useState(false)
+  const [character, setCharacter] = useState<CharacterCreateDraft | null>(null)
+  const [hasActiveSessionState, setHasActiveSessionState] = useState(false)
+  const [activePanel, setActivePanel] = useState<AubergePanel>('dialogue')
+  const [preparation, setPreparation] = useState<AubergePreparationState>(EMPTY_AUBERGE_PREPARATION)
+  const ambienceRef = useRef<HTMLDivElement>(null)
+  const fireGlowRef = useRef<HTMLDivElement>(null)
+  const departureRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    setCharacter(readCharacter(characterReadyHint))
+    setHasActiveSessionState(readActiveSessionCookie())
+    const storedPreparation = parseAubergePreparation(
+      window.localStorage.getItem(AUBERGE_PREPARATION_STORAGE_KEY)
+    )
+    const nextPreparation = isRunReturn
+      ? { ...storedPreparation, selectedOmenId: null }
+      : storedPreparation
+    setPreparation(nextPreparation)
+    if (isRunReturn) {
+      window.localStorage.setItem(AUBERGE_PREPARATION_STORAGE_KEY, JSON.stringify(nextPreparation))
+    }
+    setHydrated(true)
+  }, [characterReadyHint, isRunReturn])
+
+  const snapshot = useMemo(
+    () =>
+      resolveAveugleHubSnapshot({
+        campaignId,
+        character,
+        hasActiveSession: hasActiveSessionState,
+        isRunReturn,
+      }),
+    [campaignId, character, hasActiveSessionState, isRunReturn]
+  )
+  const openingLine = STAGE_COPY[snapshot.stage]
+  const isActiveSession = snapshot.stage === 'active-session'
+  const departureHref =
+    preparation.selectedOmenId && !isActiveSession
+      ? withOmenQuery(snapshot.primaryHref, preparation.selectedOmenId)
+      : snapshot.primaryHref
+
+  useGSAP(
+    () => {
+      const glow = fireGlowRef.current
+      if (!glow || !hydrated || !snapshot.character) return undefined
+
+      const media = gsap.matchMedia()
+      media.add('(prefers-reduced-motion: no-preference)', () => {
+        gsap.fromTo(
+          glow,
+          { opacity: 0.34, scale: 0.98 },
+          {
+            duration: 2.8,
+            ease: 'sine.inOut',
+            opacity: 0.58,
+            repeat: -1,
+            scale: 1.03,
+            yoyo: true,
+          }
+        )
+      })
+
+      return () => media.revert()
+    },
+    { dependencies: [hydrated, snapshot.character], revertOnUpdate: true }
+  )
+
+  useGSAP(
+    () => {
+      const ambience = ambienceRef.current
+      const departure = departureRef.current
+      if (!ambience || !departure || !hydrated || !snapshot.character) return undefined
+
+      const media = gsap.matchMedia()
+      media.add('(prefers-reduced-motion: no-preference)', () => {
+        const targetOpacity =
+          activePanel === 'omen' ? 0.88 : activePanel === 'memories' ? 0.5 : 0.64
+        const timeline = gsap.timeline({ defaults: { ease: 'power2.out' } })
+        timeline
+          .to(ambience, { duration: 0.5, opacity: targetOpacity, overwrite: 'auto' }, 0)
+          .fromTo(
+            departure,
+            { autoAlpha: 0, y: 8 },
+            {
+              autoAlpha: 1,
+              clearProps: 'opacity,transform,visibility',
+              duration: 0.36,
+              y: 0,
+            },
+            0.12
+          )
+      })
+
+      return () => media.revert()
+    },
+    {
+      dependencies: [activePanel, preparation.selectedOmenId, hydrated, snapshot.character],
+      revertOnUpdate: true,
+    }
+  )
+
+  const handlePreparationChange = useCallback((nextPreparation: AubergePreparationState) => {
+    setPreparation(nextPreparation)
+    window.localStorage.setItem(AUBERGE_PREPARATION_STORAGE_KEY, JSON.stringify(nextPreparation))
+  }, [])
+
+  const topBar = snapshot.character ? (
+    <div className="aveugle-hub__player-bar" data-velkhar-enter>
+      <PlayerIdentity
+        avatar={
+          <VocationEmblem
+            decorative
+            name={
+              snapshot.character.vocationId === 'shadow-blade'
+                ? 'lame-ombre'
+                : snapshot.character.vocationId === 'word-weaver'
+                  ? 'tisse-verbe'
+                  : snapshot.character.vocationId === 'watcher'
+                    ? 'veilleur'
+                    : 'marcheur-du-sel'
+            }
+            size="sm"
+          />
+        }
+        name={snapshot.character.name}
+        resources={AVEUGLE_RESOURCES.map((resource) => (
+          <ResourceCounter
+            key={resource.label}
+            compact
+            icon={<GameIcon decorative name={resource.icon} size={24} />}
+            label={resource.label}
+            value={resource.value}
+          />
+        ))}
+        subtitle={`${snapshot.character.people}, ${snapshot.character.vocation}`}
+      />
+    </div>
+  ) : null
+
+  if (!hydrated) {
+    return (
+      <main className="aveugle-hub aveugle-hub--loading" aria-busy="true">
+        <div className="aveugle-hub__scene" aria-hidden="true" />
+        <div className="aveugle-hub__skeleton aveugle-hub__skeleton--scene" />
+        <div className="aveugle-hub__skeleton aveugle-hub__skeleton--panel" />
+      </main>
+    )
+  }
+
+  if (!snapshot.character) {
+    return (
+      <AveugleThreshold
+        campaignId={campaignId}
+        isCharacterFlow={isCharacterFlow}
+        transitionFromHome={transitionFromHome}
+      />
+    )
+  }
+
+  return (
+    <VelkharMotionShell animateEntrance={transitionFromHome} className="aveugle-hub">
+      <GameSceneLayout
+        background={
+          <>
+            <div className="aveugle-hub__scene" data-velkhar-scene />
+            <div
+              ref={ambienceRef}
+              className={`aveugle-hub__ambience aveugle-hub__ambience--${activePanel}`}
+            />
+            <div ref={fireGlowRef} className="aveugle-hub__fire-glow" />
+          </>
+        }
+        bottom={
+          <div ref={departureRef} className="aveugle-hub__departure" data-velkhar-enter>
+            {isActiveSession || preparation.selectedOmenId ? (
+              <GameLink
+                href={departureHref}
+                trailingIcon={<GameIcon decorative name="arrow" size={24} />}
+                variant="radiant"
+              >
+                {snapshot.primaryLabel}
+              </GameLink>
+            ) : (
+              <GameButton
+                onClick={() => setActivePanel('omen')}
+                trailingIcon={<GameIcon decorative name="moon" size={24} />}
+                variant="radiant"
+              >
+                Choisir un présage
+              </GameButton>
+            )}
+          </div>
+        }
+        className="aveugle-hub__layout"
+        main={
+          <div className="aveugle-hub__stage" data-velkhar-enter>
+            <LocationIdentity
+              icon={<GameIcon decorative name="fire" size={32} />}
+              place="L’Auberge de L’Aveugle"
+              world="Velkhar"
+            />
+            <div className="aveugle-hub__scene-caption">
+              <p>Le feu baisse. Tissan disparaît sous la poussière.</p>
+            </div>
+          </div>
+        }
+        sidebar={
+          <div className="aveugle-hub__sidebar" data-velkhar-frame>
+            <AubergeDock
+              activePanel={activePanel}
+              isActiveSession={isActiveSession}
+              onActivePanelChange={setActivePanel}
+              onPreparationChange={handlePreparationChange}
+              openingLine={openingLine}
+              preparation={preparation}
+            />
+          </div>
+        }
+        top={topBar}
+        variant="sidebar"
+      />
+    </VelkharMotionShell>
+  )
+}

--- a/apps/frontend/src/components/aveugle-hub/AveugleThreshold.tsx
+++ b/apps/frontend/src/components/aveugle-hub/AveugleThreshold.tsx
@@ -1,0 +1,74 @@
+import { GameLink } from '@/components/ui/game-link'
+import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
+import { GamePanel } from '@/components/ui/grimoire/GamePanel/GamePanel'
+import { VelkharMotionShell } from '@/components/ui/velkhar-motion-shell'
+
+interface AveugleThresholdProps {
+  campaignId?: string
+  isCharacterFlow?: boolean
+  transitionFromHome?: boolean
+}
+
+function getCharacterFlowHref(campaignId?: string): string {
+  return campaignId
+    ? `/velkhar/aveugle?flow=character-create&campaign=${encodeURIComponent(campaignId)}`
+    : '/velkhar/aveugle?flow=character-create'
+}
+
+function getCharacterCreateHref(campaignId?: string): string {
+  return campaignId
+    ? `/velkhar/character-create?campaign=${encodeURIComponent(campaignId)}`
+    : '/velkhar/character-create'
+}
+
+export function AveugleThreshold({
+  campaignId,
+  isCharacterFlow = false,
+  transitionFromHome = false,
+}: AveugleThresholdProps) {
+  return (
+    <VelkharMotionShell animateEntrance={transitionFromHome} className="aveugle-threshold">
+      <div className="aveugle-threshold__scene" data-velkhar-scene aria-hidden="true" />
+      <div className="aveugle-threshold__veil" aria-hidden="true" />
+
+      <section className="aveugle-threshold__dialogue" aria-labelledby="aveugle-title">
+        <p className="aveugle-threshold__location" data-velkhar-enter>
+          Velkhar · L’Auberge de L’Aveugle
+        </p>
+        <div className="aveugle-threshold__portrait" data-velkhar-enter aria-hidden="true" />
+
+        <GamePanel
+          className="aveugle-threshold__panel"
+          data-velkhar-frame
+          padding="none"
+          tone="gold"
+          variant="aveugle-dialogue"
+        >
+          <div className="aveugle-threshold__speaker" data-velkhar-enter>
+            <GameIcon decorative name={isCharacterFlow ? 'quill' : 'eye'} size={48} />
+            <h1 id="aveugle-title">{isCharacterFlow ? 'Le registre de L’Aveugle' : 'L’Aveugle'}</h1>
+          </div>
+
+          <blockquote data-velkhar-enter>
+            {isCharacterFlow
+              ? '« Un nom d’abord. Le reste viendra sur la route. »'
+              : '« Approche, voyageur. Avant la route, donne-moi ton nom. »'}
+          </blockquote>
+
+          <div className="aveugle-threshold__actions" data-velkhar-enter>
+            <GameLink
+              href={
+                isCharacterFlow
+                  ? getCharacterCreateHref(campaignId)
+                  : getCharacterFlowHref(campaignId)
+              }
+              trailingIcon={<GameIcon decorative name="arrow" size={24} />}
+            >
+              {isCharacterFlow ? 'Donner mon nom' : 'Répondre'}
+            </GameLink>
+          </div>
+        </GamePanel>
+      </section>
+    </VelkharMotionShell>
+  )
+}

--- a/apps/frontend/src/components/aveugle-hub/_data/aveugle-hub-fixtures.ts
+++ b/apps/frontend/src/components/aveugle-hub/_data/aveugle-hub-fixtures.ts
@@ -1,0 +1,109 @@
+import type { GameIconName } from '@/components/ui/grimoire/GameIcon/GameIcon'
+
+export type AveugleTopicId = 'salt-guild' | 'calcines' | 'artifact'
+export type AveugleOmenId = 'follow-smoke' | 'avoid-bells'
+export type AveugleMemoryId = 'vane-night' | 'salt-oath' | 'archon-dream'
+
+export interface AveugleTopic {
+  id: AveugleTopicId
+  icon: GameIconName
+  label: string
+  response: string
+  followUp: string
+  isNew?: boolean
+}
+
+export interface AveugleMemory {
+  id: AveugleMemoryId
+  icon: GameIconName
+  title: string
+  response: string
+  isNew?: boolean
+}
+
+export interface AveugleOmen {
+  id: AveugleOmenId
+  icon: GameIconName
+  label: string
+  effect: string
+  response: string
+}
+
+export interface AveugleResource {
+  icon: GameIconName
+  label: string
+  value: number
+}
+
+/** Scripted display fixtures until the read-only Auberge contract is available. */
+export const AVEUGLE_TOPICS: AveugleTopic[] = [
+  {
+    id: 'salt-guild',
+    icon: 'dialogue',
+    label: 'La Guilde du Sel',
+    response: 'La Guilde ne possède pas les routes. Elle possède les dettes.',
+    followUp: 'Chaque faveur devient une chaîne. Choisis bien celle que tu acceptes de porter.',
+  },
+  {
+    id: 'calcines',
+    icon: 'memory',
+    label: 'Les Calcinés',
+    response: 'Les Calcinés n’écoutent plus la Cendre. Ils lui répondent.',
+    followUp: 'Quand la Cendre prononce ton nom, ne réponds jamais deux fois.',
+    isNew: true,
+  },
+  {
+    id: 'artifact',
+    icon: 'artifact',
+    label: 'Mon artefact',
+    response: 'Cette chaleur ne vient pas du feu. Cache-le aux gardes de Tissan.',
+    followUp: 'Il se souvient de la main qui l’a forgé. Cette main te cherche peut-être encore.',
+  },
+]
+
+/** Non-authoritative placeholders, isolated so an API response can replace them later. */
+export const AVEUGLE_MEMORIES: AveugleMemory[] = [
+  {
+    id: 'vane-night',
+    icon: 'moon',
+    title: 'La nuit de Vane',
+    response: 'Tu l’as épargné cette nuit-là. Son silence voyage encore avec toi.',
+    isNew: true,
+  },
+  {
+    id: 'salt-oath',
+    icon: 'scroll',
+    title: 'Le serment du Sel',
+    response: 'Le Sel n’oublie aucun serment. Même ceux que leur auteur préfère taire.',
+  },
+  {
+    id: 'archon-dream',
+    icon: 'eye',
+    title: 'Le rêve archonique',
+    response: 'Ce rêve ne venait pas de toi. Quelque chose cherchait ton regard.',
+  },
+]
+
+/** Mocked preparation modifiers until Game Session accepts an omen contract. */
+export const AVEUGLE_OMENS: AveugleOmen[] = [
+  {
+    id: 'follow-smoke',
+    icon: 'wind',
+    label: 'Suivre la fumée',
+    effect: 'Une rencontre cachée pourra apparaître pendant le prochain run.',
+    response: 'La fumée révèle parfois ce que la route voulait garder secret.',
+  },
+  {
+    id: 'avoid-bells',
+    icon: 'warning',
+    label: 'Éviter les cloches',
+    effect: 'La première menace du prochain run sera annoncée plus clairement.',
+    response: 'Les cloches préviennent les vivants. Elles appellent aussi le reste.',
+  },
+]
+
+export const AVEUGLE_RESOURCES: AveugleResource[] = [
+  { icon: 'coin', label: 'Sels', value: 125 },
+  { icon: 'memory', label: 'Souvenirs', value: 0 },
+  { icon: 'artifact', label: 'Artefacts', value: 0 },
+]

--- a/apps/frontend/src/components/aveugle-hub/auberge-preparation.test.ts
+++ b/apps/frontend/src/components/aveugle-hub/auberge-preparation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  addSeenId,
+  EMPTY_AUBERGE_PREPARATION,
+  parseAubergePreparation,
+  withOmenQuery,
+} from './auberge-preparation'
+
+describe('auberge preparation', () => {
+  it('rejette les données locales invalides', () => {
+    expect(parseAubergePreparation('{invalid')).toEqual(EMPTY_AUBERGE_PREPARATION)
+    expect(parseAubergePreparation(JSON.stringify({ version: 2 }))).toEqual(
+      EMPTY_AUBERGE_PREPARATION
+    )
+  })
+
+  it('filtre les identifiants inconnus', () => {
+    expect(
+      parseAubergePreparation(
+        JSON.stringify({
+          version: 1,
+          selectedOmenId: 'follow-smoke',
+          seenTopicIds: ['calcines', 'unknown'],
+          seenMemoryIds: ['vane-night', 'unknown'],
+        })
+      )
+    ).toEqual({
+      version: 1,
+      selectedOmenId: 'follow-smoke',
+      seenTopicIds: ['calcines'],
+      seenMemoryIds: ['vane-night'],
+    })
+  })
+
+  it('évite les doublons dans les éléments consultés', () => {
+    expect(addSeenId(['calcines'], 'calcines')).toEqual(['calcines'])
+  })
+
+  it('transmet le présage au prochain run', () => {
+    expect(withOmenQuery('/velkhar/session/new', 'avoid-bells')).toBe(
+      '/velkhar/session/new?omen=avoid-bells'
+    )
+  })
+})

--- a/apps/frontend/src/components/aveugle-hub/auberge-preparation.ts
+++ b/apps/frontend/src/components/aveugle-hub/auberge-preparation.ts
@@ -1,0 +1,63 @@
+import type { AveugleMemoryId, AveugleOmenId, AveugleTopicId } from './_data/aveugle-hub-fixtures'
+
+export const AUBERGE_PREPARATION_STORAGE_KEY = 'grimoire:auberge-preparation:v1'
+
+const OMEN_IDS: AveugleOmenId[] = ['follow-smoke', 'avoid-bells']
+const TOPIC_IDS: AveugleTopicId[] = ['salt-guild', 'calcines', 'artifact']
+const MEMORY_IDS: AveugleMemoryId[] = ['vane-night', 'salt-oath', 'archon-dream']
+
+export interface AubergePreparationState {
+  version: 1
+  selectedOmenId: AveugleOmenId | null
+  seenTopicIds: AveugleTopicId[]
+  seenMemoryIds: AveugleMemoryId[]
+}
+
+export const EMPTY_AUBERGE_PREPARATION: AubergePreparationState = {
+  version: 1,
+  selectedOmenId: null,
+  seenTopicIds: [],
+  seenMemoryIds: [],
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function filterKnownIds<T extends string>(value: unknown, knownIds: T[]): T[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is T => typeof item === 'string' && knownIds.includes(item as T))
+}
+
+export function parseAubergePreparation(raw: string | null): AubergePreparationState {
+  if (!raw) return EMPTY_AUBERGE_PREPARATION
+
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!isRecord(parsed) || parsed.version !== 1) return EMPTY_AUBERGE_PREPARATION
+
+    const selectedOmenId =
+      typeof parsed.selectedOmenId === 'string' &&
+      OMEN_IDS.includes(parsed.selectedOmenId as AveugleOmenId)
+        ? (parsed.selectedOmenId as AveugleOmenId)
+        : null
+
+    return {
+      version: 1,
+      selectedOmenId,
+      seenTopicIds: filterKnownIds(parsed.seenTopicIds, TOPIC_IDS),
+      seenMemoryIds: filterKnownIds(parsed.seenMemoryIds, MEMORY_IDS),
+    }
+  } catch {
+    return EMPTY_AUBERGE_PREPARATION
+  }
+}
+
+export function addSeenId<T extends string>(ids: T[], id: T): T[] {
+  return ids.includes(id) ? ids : [...ids, id]
+}
+
+export function withOmenQuery(path: string, omenId: AveugleOmenId): string {
+  const separator = path.includes('?') ? '&' : '?'
+  return `${path}${separator}omen=${encodeURIComponent(omenId)}`
+}

--- a/apps/frontend/src/components/aveugle-hub/aveugle-hub-model.test.ts
+++ b/apps/frontend/src/components/aveugle-hub/aveugle-hub-model.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveAveugleHubSnapshot } from './aveugle-hub-model'
+
+import type { CharacterCreateDraft } from '@/components/character-create/character-create-model'
+
+const CHARACTER: CharacterCreateDraft = {
+  version: 1,
+  name: 'Amani',
+  peopleId: 'sahelin',
+  vocationPath: 'preset',
+  vocationId: 'salt-walker',
+  freeConcept: '',
+  backstory: 'Une caravane entière a péri par sa faute.',
+  historyReviewed: true,
+}
+
+describe('aveugle hub model', () => {
+  it('oriente un nouveau joueur vers la création de personnage', () => {
+    const snapshot = resolveAveugleHubSnapshot({
+      campaignId: 'nouvelle chronique',
+      character: null,
+      hasActiveSession: false,
+      isRunReturn: false,
+    })
+
+    expect(snapshot.stage).toBe('character-create')
+    expect(snapshot.primaryHref).toBe(
+      '/velkhar/aveugle?flow=character-create&campaign=nouvelle%20chronique'
+    )
+  })
+
+  it('oriente un personnage existant vers un nouveau run', () => {
+    const snapshot = resolveAveugleHubSnapshot({
+      character: CHARACTER,
+      hasActiveSession: false,
+      isRunReturn: false,
+    })
+
+    expect(snapshot.stage).toBe('ready')
+    expect(snapshot.character).toMatchObject({
+      name: 'Amani',
+      people: 'Sahélin',
+      vocation: 'Marcheur-du-Sel',
+    })
+    expect(snapshot.primaryHref).toBe('/velkhar/session/new')
+  })
+
+  it('donne la priorité à la reprise d’une session active', () => {
+    const snapshot = resolveAveugleHubSnapshot({
+      character: CHARACTER,
+      hasActiveSession: true,
+      isRunReturn: true,
+    })
+
+    expect(snapshot.stage).toBe('active-session')
+    expect(snapshot.primaryHref).toBe('/velkhar/session/resume')
+    expect(snapshot.primaryLabel).toBe('Reprendre la route')
+  })
+
+  it('adapte le départ après un retour de run', () => {
+    const snapshot = resolveAveugleHubSnapshot({
+      character: CHARACTER,
+      hasActiveSession: false,
+      isRunReturn: true,
+    })
+
+    expect(snapshot.stage).toBe('run-return')
+    expect(snapshot.primaryLabel).toBe('Préparer un nouveau départ')
+  })
+})

--- a/apps/frontend/src/components/aveugle-hub/aveugle-hub-model.ts
+++ b/apps/frontend/src/components/aveugle-hub/aveugle-hub-model.ts
@@ -1,0 +1,100 @@
+import { getPeople, getVocation } from '@grimoire/shared'
+
+import {
+  CHARACTER_RESULT_STORAGE_KEY,
+  parseStoredCharacterResult,
+  type CharacterCreateDraft,
+} from '@/components/character-create/character-create-model'
+import { ACTIVE_GAME_SESSION_HREF } from '@/lib/active-game-session'
+
+export type AveugleHubStage = 'character-create' | 'ready' | 'active-session' | 'run-return'
+
+export interface AveugleHubCharacter {
+  name: string
+  people: string
+  vocation: string
+  vocationId: string
+}
+
+export interface AveugleHubSnapshot {
+  character: AveugleHubCharacter | null
+  primaryHref: string
+  primaryLabel: string
+  stage: AveugleHubStage
+}
+
+interface ResolveAveugleHubSnapshotInput {
+  campaignId?: string
+  character: CharacterCreateDraft | null
+  hasActiveSession: boolean
+  isRunReturn: boolean
+}
+
+const FALLBACK_CHARACTER: CharacterCreateDraft = {
+  version: 1,
+  name: 'Le Voyageur',
+  peopleId: 'sahelin',
+  vocationPath: 'preset',
+  vocationId: 'salt-walker',
+  freeConcept: '',
+  backstory: '',
+  historyReviewed: true,
+}
+
+function withCampaign(path: string, campaignId?: string): string {
+  if (!campaignId) return path
+
+  const separator = path.includes('?') ? '&' : '?'
+  return `${path}${separator}campaign=${encodeURIComponent(campaignId)}`
+}
+
+export function readStoredHubCharacter(
+  storage: Pick<Storage, 'getItem'>
+): CharacterCreateDraft | null {
+  return parseStoredCharacterResult(storage.getItem(CHARACTER_RESULT_STORAGE_KEY))
+}
+
+export function getFallbackHubCharacter(): CharacterCreateDraft {
+  return FALLBACK_CHARACTER
+}
+
+export function resolveAveugleHubSnapshot({
+  campaignId,
+  character,
+  hasActiveSession,
+  isRunReturn,
+}: ResolveAveugleHubSnapshotInput): AveugleHubSnapshot {
+  if (!character) {
+    return {
+      character: null,
+      primaryHref: withCampaign('/velkhar/aveugle?flow=character-create', campaignId),
+      primaryLabel: 'Répondre à L’Aveugle',
+      stage: 'character-create',
+    }
+  }
+
+  const people = getPeople(character.peopleId)
+  const vocation = character.vocationPath === 'preset' ? getVocation(character.vocationId) : null
+  const hubCharacter: AveugleHubCharacter = {
+    name: character.name,
+    people: people?.name.fr ?? 'Peuple inconnu',
+    vocation: vocation?.name.fr ?? (character.freeConcept || 'Concept libre'),
+    vocationId: vocation?.id ?? 'watcher',
+  }
+
+  if (hasActiveSession) {
+    return {
+      character: hubCharacter,
+      primaryHref: ACTIVE_GAME_SESSION_HREF,
+      primaryLabel: 'Reprendre la route',
+      stage: 'active-session',
+    }
+  }
+
+  return {
+    character: hubCharacter,
+    primaryHref: '/velkhar/session/new',
+    primaryLabel: isRunReturn ? 'Préparer un nouveau départ' : 'Partir en run',
+    stage: isRunReturn ? 'run-return' : 'ready',
+  }
+}

--- a/apps/frontend/src/components/aveugle-hub/aveugle-hub.css
+++ b/apps/frontend/src/components/aveugle-hub/aveugle-hub.css
@@ -1,0 +1,569 @@
+body:has(.aveugle-hub) .main-navigation {
+  display: none;
+}
+
+body:has(.aveugle-hub) {
+  overflow: hidden;
+}
+
+.aveugle-hub {
+  background: var(--void);
+  height: 100dvh;
+  min-height: 100dvh;
+  overflow: hidden;
+  position: relative;
+}
+
+.aveugle-hub__layout.game-scene-layout {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.aveugle-hub__layout.game-scene-layout::after {
+  background:
+    linear-gradient(
+      90deg,
+      rgba(5, 4, 3, 0.08) 0%,
+      rgba(5, 4, 3, 0.08) 58%,
+      rgba(5, 4, 3, 0.72) 76%
+    ),
+    linear-gradient(180deg, rgba(5, 4, 3, 0.12) 0%, transparent 44%, rgba(5, 4, 3, 0.88) 100%);
+}
+
+.aveugle-hub__scene {
+  background: url('/scenes/aveugle-cendres.webp') 42% center / cover no-repeat;
+  filter: saturate(0.84) contrast(1.08) brightness(0.88);
+  height: 100%;
+  transform: scale(1.012);
+  width: 100%;
+}
+
+.aveugle-hub__ambience,
+.aveugle-hub__fire-glow {
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+.aveugle-hub__ambience {
+  background:
+    radial-gradient(circle at 83% 32%, rgba(167, 105, 34, 0.13), transparent 30%),
+    linear-gradient(115deg, transparent 44%, rgba(22, 14, 7, 0.48) 76%);
+  opacity: 0.64;
+}
+
+.aveugle-hub__fire-glow {
+  background: radial-gradient(circle at 12% 31%, rgba(217, 128, 42, 0.22), transparent 19%);
+  mix-blend-mode: screen;
+  opacity: 0.34;
+  transform-origin: 12% 31%;
+}
+
+.aveugle-hub__layout .game-scene-layout__top {
+  padding: 0;
+}
+
+.aveugle-hub__player-bar {
+  backdrop-filter: blur(8px);
+  background: rgba(7, 6, 4, 0.86);
+  box-shadow:
+    inset 0 1px rgba(240, 212, 138, 0.18),
+    inset 0 -1px rgba(217, 164, 65, 0.32),
+    0 1rem 2.5rem rgba(0, 0, 0, 0.3);
+  min-height: 5.25rem;
+  padding: 0.55rem clamp(1rem, 3vw, 2.75rem);
+}
+
+.aveugle-hub__player-bar .player-identity {
+  height: 100%;
+}
+
+.aveugle-hub__player-bar .player-identity__copy strong {
+  font-size: clamp(1.15rem, 1.4vw, 1.4rem);
+}
+
+.aveugle-hub__player-bar .player-identity__copy span {
+  font-size: 1rem;
+}
+
+.aveugle-hub__player-bar .vocation-emblem {
+  filter: brightness(0.9) drop-shadow(0 0.35rem 0.6rem rgba(0, 0, 0, 0.5));
+}
+
+.aveugle-hub__layout.game-scene-layout--sidebar .game-scene-layout__body {
+  gap: clamp(0.75rem, 1.4vw, 1.5rem);
+  grid-template-columns: minmax(0, 2.2fr) minmax(25rem, 1fr);
+  min-height: 0;
+  overflow: hidden;
+  padding: clamp(0.75rem, 1.4vw, 1.5rem) clamp(1rem, 2vw, 2rem) 0;
+}
+
+.aveugle-hub__layout .game-scene-layout__sidebar {
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.aveugle-hub__stage {
+  align-content: space-between;
+  display: grid;
+  height: 100%;
+  padding: 0.5rem 0 2.4rem;
+}
+
+.aveugle-hub__stage .location-identity {
+  filter: drop-shadow(0 0.3rem 0.8rem rgba(0, 0, 0, 0.8));
+  font-size: clamp(1.1rem, 1.45vw, 1.35rem);
+  width: fit-content;
+}
+
+.aveugle-hub__scene-caption {
+  max-width: 28rem;
+  padding-left: 1rem;
+  position: relative;
+  text-shadow: 0 0.2rem 0.7rem rgba(0, 0, 0, 0.9);
+}
+
+.aveugle-hub__scene-caption::before {
+  background: var(--gold-dark);
+  content: '';
+  inset: 0 auto 0 0;
+  position: absolute;
+  width: 1px;
+}
+
+.aveugle-hub__scene-caption p {
+  color: var(--parchment);
+  font-family: var(--font-game-heading);
+  font-size: clamp(1.1rem, 1.35vw, 1.3rem);
+  font-style: italic;
+  line-height: 1.5;
+  margin: 0;
+  padding-bottom: 0.1em;
+}
+
+.aveugle-hub__sidebar {
+  display: grid;
+  height: 100%;
+  min-height: 0;
+}
+
+.aveugle-hub__dock {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: 100%;
+  min-height: 0;
+}
+
+.aveugle-hub__dock-nav {
+  backdrop-filter: blur(8px);
+  background: rgba(7, 6, 4, 0.78);
+  border-block: 1px solid rgba(217, 164, 65, 0.26);
+  display: grid;
+  gap: 0.25rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: 0.3rem;
+}
+
+.aveugle-hub__dock-nav .game-button {
+  font-size: 0.95rem;
+  min-height: 44px;
+  min-width: 0;
+  padding-inline: 0.45rem;
+  white-space: nowrap;
+}
+
+.aveugle-hub__dock-nav .game-button[aria-pressed='true'] {
+  background: rgba(217, 164, 65, 0.12);
+  box-shadow: inset 0 -1px var(--gold-dark);
+  color: var(--gold-light);
+}
+
+.aveugle-hub__dialogue.game-panel {
+  align-self: stretch;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.aveugle-hub__dialogue > .game-panel__content {
+  height: 100%;
+}
+
+.aveugle-hub__dialogue-content {
+  align-content: start;
+  display: grid;
+  gap: clamp(1.25rem, 2vh, 1.75rem);
+  height: 100%;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: clamp(1.75rem, 3vh, 2.7rem) clamp(1.5rem, 2.5vw, 2.5rem);
+  scrollbar-color: rgba(217, 164, 65, 0.55) transparent;
+  scrollbar-width: thin;
+}
+
+.aveugle-hub__dialogue-content > header {
+  align-items: center;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+.aveugle-hub__speaker-mark {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  transform-origin: center;
+}
+
+.aveugle-hub__speaker-mark > .game-icon {
+  filter: brightness(0.9) drop-shadow(0 0.4rem 0.8rem rgba(0, 0, 0, 0.7));
+}
+
+.aveugle-hub__dialogue-content h1 {
+  color: var(--gold-light);
+  font-family: var(--font-game-heading);
+  font-size: clamp(1.5rem, 2vw, 1.9rem);
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  line-height: 1.15;
+  margin: 0;
+  text-transform: uppercase;
+  text-wrap: balance;
+}
+
+.aveugle-hub__conversation-stage {
+  display: grid;
+  gap: clamp(1.25rem, 2.2vh, 1.75rem);
+}
+
+.aveugle-hub__choice-copy {
+  align-items: center;
+  display: flex;
+  gap: 0.6rem;
+  justify-content: space-between;
+  min-width: 0;
+  width: 100%;
+}
+
+.aveugle-hub__choice-copy small {
+  color: var(--gold-light);
+  font-family: var(--font-game-body);
+  font-size: 0.78rem;
+  font-style: normal;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.aveugle-hub__choice-copy--omen {
+  align-items: start;
+  display: grid;
+  gap: 0.25rem;
+  justify-content: stretch;
+}
+
+.aveugle-hub__choice-copy--omen small {
+  color: var(--ash-light);
+  font-size: 0.92rem;
+  letter-spacing: 0;
+  line-height: 1.35;
+  text-transform: none;
+}
+
+.aveugle-hub__omen-effect {
+  border-left: 1px solid rgba(217, 164, 65, 0.55);
+  color: var(--ash-light);
+  font-size: 1.05rem;
+  line-height: 1.5;
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.aveugle-hub__dialogue-content blockquote {
+  border-left: 1px solid var(--gold-dark);
+  color: var(--parchment);
+  font-family: var(--font-game-heading);
+  font-size: clamp(1.35rem, 1.8vw, 1.7rem);
+  font-style: italic;
+  line-height: 1.5;
+  margin: 0;
+  min-height: 4.5rem;
+  padding: 0.15rem 0 0.18rem 1.1rem;
+  text-wrap: pretty;
+}
+
+.aveugle-hub__dialogue-content .dialogue-choice {
+  font-size: clamp(1.08rem, 1.35vw, 1.22rem);
+  min-height: 56px;
+  padding-block: 0.75rem;
+}
+
+.aveugle-hub__dialogue-content .dialogue-choice__icon .game-icon {
+  height: 1.75rem;
+  width: 1.75rem;
+}
+
+.aveugle-hub__dialogue-content .narrative-composer__control {
+  font-size: clamp(1.05rem, 1.25vw, 1.18rem);
+  min-height: 7rem;
+}
+
+.aveugle-hub__other-question {
+  justify-self: start;
+  min-width: 12rem;
+}
+
+.aveugle-hub__composer {
+  display: grid;
+  gap: 1rem;
+}
+
+.aveugle-hub__composer > .game-button {
+  justify-self: start;
+}
+
+.aveugle-hub__response-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.aveugle-hub__response-actions .game-button,
+.aveugle-hub__other-question,
+.aveugle-hub__composer > .game-button {
+  font-size: 1.05rem;
+}
+
+.aveugle-hub__departure {
+  display: flex;
+  justify-content: center;
+  padding: 0.75rem 1rem 1rem;
+  position: relative;
+}
+
+.aveugle-hub__departure::before {
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(5, 4, 3, 0.86) 24%,
+    rgba(5, 4, 3, 0.86) 76%,
+    transparent
+  );
+  content: '';
+  inset: -1rem 0 0;
+  pointer-events: none;
+  position: absolute;
+  z-index: -1;
+}
+
+.aveugle-hub__departure .game-button {
+  min-width: min(32rem, calc(100vw - 2rem));
+}
+
+.aveugle-hub--loading {
+  min-height: 100dvh;
+  overflow: hidden;
+  padding: 8rem 2rem 2rem;
+}
+
+.aveugle-hub--loading .aveugle-hub__scene {
+  inset: 0;
+  position: absolute;
+}
+
+.aveugle-hub--loading::after {
+  background: rgba(5, 4, 3, 0.64);
+  content: '';
+  inset: 0;
+  position: absolute;
+}
+
+.aveugle-hub__skeleton {
+  animation: aveugle-hub-pulse 1.8s ease-in-out infinite;
+  background: rgba(240, 212, 138, 0.09);
+  border: 1px solid rgba(217, 164, 65, 0.24);
+  position: relative;
+  z-index: 1;
+}
+
+.aveugle-hub__skeleton--scene {
+  height: 4.75rem;
+  width: min(42rem, 60vw);
+}
+
+.aveugle-hub__skeleton--panel {
+  height: min(36rem, 72vh);
+  margin: 1rem 0 0 auto;
+  width: min(29rem, 34vw);
+}
+
+@keyframes aveugle-hub-pulse {
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@media (max-width: 1100px) {
+  .aveugle-hub__layout.game-scene-layout--sidebar .game-scene-layout__body {
+    grid-template-columns: minmax(0, 1.45fr) minmax(23rem, 1fr);
+  }
+
+  .aveugle-hub__dialogue-content {
+    padding-inline: 2rem;
+  }
+}
+
+@media (max-height: 760px) and (min-width: 901px) {
+  .aveugle-hub__player-bar {
+    min-height: 4.5rem;
+  }
+
+  .aveugle-hub__dialogue-content {
+    gap: 1rem;
+    padding-block: 1.55rem;
+  }
+
+  .aveugle-hub__conversation-stage {
+    gap: 1rem;
+  }
+
+  .aveugle-hub__dialogue-content blockquote {
+    font-size: 1.35rem;
+    min-height: 0;
+  }
+}
+
+@media (max-width: 900px) {
+  body:has(.aveugle-hub) {
+    overflow: auto;
+  }
+
+  .aveugle-hub {
+    height: auto;
+    overflow: visible;
+  }
+
+  .aveugle-hub__layout.game-scene-layout {
+    height: auto;
+    min-height: 100dvh;
+    overflow: visible;
+  }
+
+  .aveugle-hub__layout.game-scene-layout--sidebar .game-scene-layout__body {
+    grid-template-columns: 1fr;
+    overflow: visible;
+    padding-top: 1rem;
+  }
+
+  .aveugle-hub__stage {
+    min-height: 38dvh;
+  }
+
+  .aveugle-hub__sidebar {
+    height: auto;
+    margin-inline: auto;
+    max-width: 42rem;
+    width: 100%;
+  }
+
+  .aveugle-hub__layout .game-scene-layout__sidebar {
+    height: auto;
+    overflow: visible;
+  }
+
+  .aveugle-hub__dialogue-content {
+    height: auto;
+    max-height: none;
+    min-height: 25rem;
+    overflow: visible;
+  }
+
+  .aveugle-hub__dock {
+    height: auto;
+  }
+
+  .aveugle-hub__dialogue.game-panel {
+    height: auto;
+    overflow: visible;
+  }
+}
+
+@media (max-width: 640px) {
+  .aveugle-hub__layout .game-scene-layout__top {
+    padding-inline: 0;
+  }
+
+  .aveugle-hub__player-bar {
+    min-height: 4rem;
+    padding-inline: 0.75rem;
+  }
+
+  .aveugle-hub__layout.game-scene-layout--sidebar .game-scene-layout__body {
+    padding-inline: 0.75rem;
+  }
+
+  .aveugle-hub__stage {
+    min-height: 33dvh;
+    padding-bottom: 1rem;
+  }
+
+  .aveugle-hub__scene-caption {
+    display: none;
+  }
+
+  .aveugle-hub__dialogue-content {
+    min-height: 0;
+    padding: 2.5rem 1.6rem 2.75rem;
+  }
+
+  .aveugle-hub__dock-nav .game-button {
+    font-size: 0.82rem;
+  }
+
+  .aveugle-hub__dock-nav .game-icon {
+    display: none;
+  }
+
+  .aveugle-hub__speaker-mark > .game-icon {
+    height: 2.75rem;
+    width: 2.75rem;
+  }
+
+  .aveugle-hub__dialogue-content h1 {
+    font-size: 1.35rem;
+  }
+
+  .aveugle-hub__dialogue-content blockquote {
+    font-size: 1.3rem;
+    min-height: 0;
+  }
+
+  .aveugle-hub__departure {
+    padding-inline: 0.75rem;
+  }
+
+  .aveugle-hub__departure .game-button {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .aveugle-hub__skeleton--scene,
+  .aveugle-hub__skeleton--panel {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aveugle-hub__scene {
+    transform: none;
+  }
+
+  .aveugle-hub__skeleton {
+    animation: none;
+  }
+}

--- a/apps/frontend/src/components/character-create/CharacterCreateFlow.test.tsx
+++ b/apps/frontend/src/components/character-create/CharacterCreateFlow.test.tsx
@@ -13,6 +13,7 @@ vi.mock('next/navigation', () => ({
 
 describe('CharacterCreateFlow', () => {
   beforeEach(() => {
+    window.localStorage.clear()
     window.sessionStorage.clear()
     pushMock.mockReset()
   })
@@ -53,7 +54,7 @@ describe('CharacterCreateFlow', () => {
       )
     })
 
-    const storedResult = window.sessionStorage.getItem(CHARACTER_RESULT_STORAGE_KEY)
+    const storedResult = window.localStorage.getItem(CHARACTER_RESULT_STORAGE_KEY)
     expect(storedResult).toContain('Amani')
     expect(storedResult).not.toContain('stats')
   })

--- a/apps/frontend/src/components/character-create/CharacterCreateFlow.tsx
+++ b/apps/frontend/src/components/character-create/CharacterCreateFlow.tsx
@@ -260,7 +260,7 @@ export function CharacterCreateFlow({ campaignId }: CharacterCreateFlowProps) {
 
   const replayCreation = () => {
     window.sessionStorage.removeItem(CHARACTER_DRAFT_STORAGE_KEY)
-    window.sessionStorage.removeItem(CHARACTER_RESULT_STORAGE_KEY)
+    window.localStorage.removeItem(CHARACTER_RESULT_STORAGE_KEY)
     setDraft(EMPTY_CHARACTER_DRAFT)
     setIsDirty(false)
     moveToStep('identity')
@@ -268,7 +268,7 @@ export function CharacterCreateFlow({ campaignId }: CharacterCreateFlowProps) {
 
   const finishCreation = () => {
     const result = createCharacterResult(draft)
-    window.sessionStorage.setItem(CHARACTER_RESULT_STORAGE_KEY, JSON.stringify(result))
+    window.localStorage.setItem(CHARACTER_RESULT_STORAGE_KEY, JSON.stringify(result))
     window.sessionStorage.removeItem(CHARACTER_DRAFT_STORAGE_KEY)
     setIsDirty(false)
     router.push(buildAveugleHref(campaignId, true))

--- a/apps/frontend/src/components/character-create/character-create-model.ts
+++ b/apps/frontend/src/components/character-create/character-create-model.ts
@@ -75,6 +75,10 @@ export function parseStoredCharacterDraft(value: string | null): CharacterCreate
   }
 }
 
+export function parseStoredCharacterResult(value: string | null): CharacterCreateDraft | null {
+  return parseStoredCharacterDraft(value)
+}
+
 export function getResumeStep(draft: CharacterCreateDraft): CharacterCreateStep {
   if (!characterNameSchema.safeParse(draft.name).success) return 'identity'
   if (!draft.peopleId) return 'people'

--- a/docs/public/current-state/NEXT_ACTIONS.md
+++ b/docs/public/current-state/NEXT_ACTIONS.md
@@ -2,22 +2,28 @@
 type: actions
 visibility: public
 rag: true
-updated: 2026-07-13
+updated: 2026-07-15
 ---
 
 # Next Actions
 
 ## Immédiat
 
-1. **Finaliser + merger #111** (mémoire N2 — compression de scène) vers `develop` : implémenté et testé, reste PR + review.
+1. **Finaliser + merger #126** (Auberge de L’Aveugle) vers `develop` : valider le hub `100dvh`, les panneaux exclusifs Parler/Souvenirs/Présage et les animations GSAP, puis remplacer les fixtures de souvenirs et de présages par les contrats API lorsqu’ils seront disponibles.
+
+## EPIC frontend #123 — ordre recommandé
+
+2. [#125](https://github.com/AdamDjo/Grimoire-game/issues/125) — **Game Session pixel-perfect** avec le UI Kit.
+3. [#134](https://github.com/AdamDjo/Grimoire-game/issues/134) — **Inventaire, fiche personnage et menu de session**.
+4. [#132](https://github.com/AdamDjo/Grimoire-game/issues/132) — **Fin de run et Chronique publique**.
+5. [#135](https://github.com/AdamDjo/Grimoire-game/issues/135) — **Auth complète et conversion anonyme**.
+6. [#136](https://github.com/AdamDjo/Grimoire-game/issues/136) — **Profil, Paramètres et confidentialité**.
+7. [#130](https://github.com/AdamDjo/Grimoire-game/issues/130), [#131](https://github.com/AdamDjo/Grimoire-game/issues/131), [#127](https://github.com/AdamDjo/Grimoire-game/issues/127), puis [#129](https://github.com/AdamDjo/Grimoire-game/issues/129).
 
 ## A3 — mémoire narrative, suite (après merge #111)
 
-2. [#113](https://github.com/AdamDjo/Grimoire-game/issues/113) — **N1, fenêtre court-terme** : grill le choix Redis vs requête DB directe avant d'implémenter, puis brancher l'injection dans `system-prompt.ts`.
-3. [#114](https://github.com/AdamDjo/Grimoire-game/issues/114) — **pgvector / rappel sémantique** sur les `MemoryChunk`.
-4. [#115](https://github.com/AdamDjo/Grimoire-game/issues/115) — **Souvenirs nommés (N3)**, inter-runs.
-5. [#116](https://github.com/AdamDjo/Grimoire-game/issues/116) — **Chronique de fin de run** (inclut la purge `SceneLog` post-génération).
-6. [#117](https://github.com/AdamDjo/Grimoire-game/issues/117) — **World events (Level C)**, priorité basse (dépend du contenu design, pas du code).
+8. [#114](https://github.com/AdamDjo/Grimoire-game/issues/114) — **pgvector / rappel sémantique** sur les `MemoryChunk`.
+9. [#117](https://github.com/AdamDjo/Grimoire-game/issues/117) — **World events (Level C)**, priorité basse (dépend du contenu design, pas du code).
 
 ## Phase 1B — écrans restants
 

--- a/docs/public/current-state/PROJECT_STATUS.md
+++ b/docs/public/current-state/PROJECT_STATUS.md
@@ -3,7 +3,7 @@ type: status
 visibility: public
 rag: true
 source_of_truth: true
-updated: 2026-07-13
+updated: 2026-07-15
 ---
 
 # Project Status
@@ -11,18 +11,21 @@ updated: 2026-07-13
 ## État actuel
 
 - Projet : **GRIMOIRE — Of Ash and Salt**
-- Phase actuelle : **Phase 1B — vertical slice gamesession** (moteur backend) + chantier A3 mémoire narrative en cours
-- Branche active : `feature/111-memoire-n2-compression-scene` (worktree `-claude`)
-- Priorité active : terminer/merger #111 (N2 compression — implémenté, testé, 32/32), puis enchaîner sur le backlog A3 (#113→#117).
-- Chantier parallèle (Codex) : UI Kit Grimoire, `feature/93-ui-kit-grimoire-complet` (#93). Ne pas toucher au code du main folder.
+- Phase actuelle : **Phase 1B — parcours frontend Velkhar** (EPIC #123), après livraison du moteur backend et de la mémoire narrative principale.
+- Branche active : `feature/126-auberge-aveugle-hub`.
+- Priorité active : finaliser #126, avec deux flows distincts : seuil narratif avant création et hub immersif après création du personnage. Le hub est fixé à `100dvh` sur desktop, utilise le cadre sombre existant de l’auberge et sépare les états Parler, Souvenirs et Présage. Le présage constitue la préparation significative avant un nouveau run ; il est persisté localement et transmis à la route Session en attendant le contrat backend.
+- Ordre recommandé ensuite : #125 Game Session, puis #134 inventaire/fiche/menu.
 
 ## Livré récemment
 
 - **Phase 1A — landing** : ✅ mergée (#94).
+- **#124 — Character Create / Forge guidée** : ✅ mergée (PR #141 → `develop`). Le résultat temporaire est persisté côté frontend jusqu’au contrat API personnage.
+- **#128 — dashboard, reprise et navigation** : ✅ mergée (PR #139 → `develop`).
+- **#115 — Souvenirs nommés** et **#116 — Chronique de fin de run** : ✅ mergés (PR #138 et #140 → `develop`).
 - **EPIC #95 — vertical slice gamesession Velkhar** : ✅ mergée sur `develop` (PR #102, commit `9bb37a5`). Ferme #95→#100.
 - **#107 — auth Supabase** : ✅ livrée, en PR [#108](https://github.com/AdamDjo/Grimoire-game/pull/108) → `develop`. Tier anonyme (`signInAnonymously`), magic link + OAuth Google/Discord, JWT vérifié via JWKS dans `requireAuth`, cap 30 req anonymes → 403. Vérifiée live. Détail : [[../tech/AUTH]].
 - **#109 — moteur de session durci (A1+A2)** : ✅ mergé (PR #110 → `develop`). D20 + conséquences rapatriés côté backend, world-state persistant, `endReason` posé sur `GameSession`.
-- **#111 — mémoire narrative N2 (compression de scène)** : ✅ implémenté et testé (32/32), branche `feature/111-memoire-n2-compression-scene`. Compression fire-and-forget tous les 8 tours via Mistral Small (fallback Llama 3.3), stockage `MemoryChunk`, injection des 5 chunks récents + faits épinglés dans le prompt système. Reste à merger.
+- **#111 — mémoire narrative N2 (compression de scène)** : ✅ mergé (PR #118 → `develop`). Compression fire-and-forget tous les 8 tours via Mistral Small (fallback Llama 3.3), stockage `MemoryChunk`, injection des chunks récents + faits épinglés dans le prompt système.
 
 ## Backlog A3 — mémoire narrative (après #111)
 
@@ -43,8 +46,9 @@ Chantier découpé en sous-tickets indépendants, tous rattachés à A3 :
 
 ## Critères pour avancer dans la Phase 1B
 
-- #111 mergé sur `develop`.
-- Écrans Auberge de L'Aveugle + Character Create branchés sur le triptyque canon.
+- #126 mergé sur `develop` avec séparation seuil/hub validée.
+- #125 Game Session reconstruite avec le UI Kit.
+- Parcours Landing → seuil → Forge → hub → Session sans cul-de-sac.
 
 ## Sources liées
 


### PR DESCRIPTION
## Summary

- Préserve le flow narratif de L’Aveugle avant la création du personnage.
- Ajoute un hub distinct pour les personnages existants.
- Sépare les espaces Parler, Souvenirs et Présage dans le cadre sombre existant.
- Ajoute la préparation du prochain run par un présage persisté et transmis à la Session.
- Corrige le layout desktop en 100dvh et les faibles hauteurs.
- Renforce la lisibilité des dialogues et la réaction au retour de run.

## Test plan

- [x] TypeScript passe.
- [x] Lint frontend et monorepo passent.
- [x] 65 tests frontend passent.
- [x] Build Next.js production passe.
- [x] Testé visuellement en 1440x900 et 1844x496.
- [x] Les flows sans personnage et avec personnage restent distincts.

## Follow-up

- #142 ajoutera la cinématique de première entrée dans l’Auberge.
- Les fixtures seront remplacées par les contrats API lorsqu’ils seront disponibles.

Closes #126