### PR TITLE
feat(game-session): ajouter inventaire, fiche et menu de session

### DIFF
--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharCharacterSheet.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharCharacterSheet.tsx
@@ -1,0 +1,108 @@
+import { ATTRIBUTE_LABELS, attributeModifier, getPeople, getVocation } from '@grimoire/shared'
+
+import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
+
+import type { Character, Condition, SurvivalStats } from '@grimoire/shared'
+
+interface VelkharCharacterSheetProps {
+  character: Character
+  survival: SurvivalStats
+}
+
+const ATTRIBUTE_ORDER = ['blood', 'breath', 'ash'] as const
+
+const CONDITION_LABELS: Record<Condition, string> = {
+  fever: 'Fever',
+  poisoned: 'Poisoned',
+  wounded: 'Wounded',
+  frozen: 'Frozen',
+  stunned: 'Stunned',
+  blinded: 'Blinded',
+  marsh_sickness: 'Marsh sickness',
+  ash_corrupted: 'Ash-corrupted',
+  shaken_mind: 'Shaken mind',
+  slow_petrification: 'Slow petrification',
+}
+
+export function VelkharCharacterSheet({ character, survival }: VelkharCharacterSheetProps) {
+  const people = getPeople(character.people)
+  const vocation = getVocation(character.vocation)
+
+  return (
+    <div className="velkhar-character-sheet">
+      <header className="velkhar-character-sheet__identity">
+        <GameIcon decorative name="stranger" size={64} />
+        <div>
+          <p className="velkhar-session-window__eyebrow">Character sheet</p>
+          <h3>{character.name}</h3>
+          <p>
+            {people?.name.en ?? character.people} · {vocation?.name.en ?? character.vocation}
+          </p>
+        </div>
+      </header>
+
+      {character.backstory ? (
+        <p className="velkhar-session-window__story">{character.backstory}</p>
+      ) : null}
+
+      <section aria-labelledby="velkhar-attributes-title">
+        <h4 id="velkhar-attributes-title">Triptych</h4>
+        <dl className="velkhar-session-window__attributes">
+          {ATTRIBUTE_ORDER.map((attribute) => {
+            const value = character.stats.attributes[attribute]
+            const modifier = attributeModifier(value)
+            return (
+              <div key={attribute} data-attribute={attribute}>
+                <dt>{ATTRIBUTE_LABELS[attribute].en}</dt>
+                <dd>
+                  {value} <small>{modifier >= 0 ? `+${modifier}` : modifier}</small>
+                </dd>
+              </div>
+            )
+          })}
+        </dl>
+      </section>
+
+      <section aria-labelledby="velkhar-survival-title">
+        <h4 id="velkhar-survival-title">Survival</h4>
+        <dl className="velkhar-character-sheet__survival">
+          <div>
+            <dt>Health</dt>
+            <dd>
+              {survival.hp}/{survival.maxHp}
+            </dd>
+          </div>
+          <div>
+            <dt>Thirst</dt>
+            <dd>{survival.thirst}%</dd>
+          </div>
+          <div>
+            <dt>Hunger</dt>
+            <dd>{survival.hunger}%</dd>
+          </div>
+          <div>
+            <dt>Fatigue</dt>
+            <dd>{100 - survival.energy}%</dd>
+          </div>
+          <div data-danger={survival.calamine >= 75}>
+            <dt>Calamine</dt>
+            <dd>{survival.calamine}%</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section aria-labelledby="velkhar-conditions-title">
+        <h4 id="velkhar-conditions-title">Conditions</h4>
+        {character.stats.conditions.length > 0 ? (
+          <ul className="velkhar-character-sheet__conditions">
+            {character.stats.conditions.map((condition) => (
+              <li key={condition}>{CONDITION_LABELS[condition]}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="velkhar-session-window__muted">No active condition.</p>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharInventoryPanel.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharInventoryPanel.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { GameIcon, type GameIconName } from '@/components/ui/grimoire/GameIcon/GameIcon'
+import { InventorySlot } from '@/components/ui/grimoire/InventorySlot/InventorySlot'
+import { cn } from '@/lib/utils'
+
+import { buildVelkharInventoryView, VELKHAR_BAG_CAPACITY } from '../_lib/velkhar-inventory-model'
+
+import type { InventoryItemRef } from '@grimoire/shared'
+
+interface VelkharInventoryPanelProps {
+  iron: number | null
+  items: InventoryItemRef[]
+}
+
+function itemIcon(item: InventoryItemRef): GameIconName {
+  if (item.category === 'artifact' || item.category === 'heirloom') return 'artifact'
+  if (item.category === 'key') return 'key'
+  if (item.category === 'equipment') return 'crossed-swords'
+  return 'chest'
+}
+
+interface ItemSlotProps {
+  fallbackIcon: GameIconName
+  item: InventoryItemRef | null
+  label: string
+  onSelect: (item: InventoryItemRef) => void
+  selectedId: string | null
+}
+
+function ItemSlot({ fallbackIcon, item, label, onSelect, selectedId }: ItemSlotProps) {
+  const unavailable = !item || item.state === 'locked' || item.state === 'pending'
+  const stateLabel =
+    item?.state === 'locked' ? ', locked' : item?.state === 'pending' ? ', pending' : ''
+  const equippedLabel = item?.equippedSlot ? ', equipped' : ''
+
+  return (
+    <div
+      className={cn(
+        'velkhar-inventory-slot',
+        item?.equippedSlot && 'velkhar-inventory-slot--equipped',
+        item?.state === 'locked' && 'velkhar-inventory-slot--locked',
+        item?.state === 'pending' && 'velkhar-inventory-slot--pending'
+      )}
+    >
+      <InventorySlot
+        disabled={unavailable}
+        icon={<GameIcon decorative name={item ? itemIcon(item) : fallbackIcon} size={48} />}
+        label={item ? `${label}: ${item.name}${equippedLabel}${stateLabel}` : `${label}, empty`}
+        quantity={item && item.quantity > 1 ? item.quantity : undefined}
+        selected={item?.id === selectedId}
+        onClick={() => item && onSelect(item)}
+      />
+      <span aria-hidden="true">{item?.name ?? label}</span>
+    </div>
+  )
+}
+
+export function VelkharInventoryPanel({ iron, items }: VelkharInventoryPanelProps) {
+  const inventory = useMemo(() => buildVelkharInventoryView(items), [items])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const selectedItem = items.find((item) => item.id === selectedId) ?? null
+  const bagSlots = Array.from(
+    { length: VELKHAR_BAG_CAPACITY },
+    (_, index) => inventory.bagItems[index] ?? null
+  )
+
+  return (
+    <div className="velkhar-inventory">
+      <div className="velkhar-inventory__summary" aria-label="Inventory summary">
+        <span>
+          <GameIcon decorative name="coin" size={24} /> Iron <strong>{iron ?? '—'}</strong>
+        </span>
+        <span>
+          <GameIcon decorative name="chest" size={24} /> Bag{' '}
+          <strong>
+            {inventory.bagItems.length}/{VELKHAR_BAG_CAPACITY}
+          </strong>
+        </span>
+      </div>
+
+      <section aria-labelledby="velkhar-equipment-title">
+        <div className="velkhar-session-window__section-heading">
+          <h3 id="velkhar-equipment-title">Worn equipment</h3>
+          <span>8 fixed slots</span>
+        </div>
+        <div className="velkhar-inventory__grid velkhar-inventory__grid--equipment">
+          {inventory.equipment.map((slot) => (
+            <ItemSlot
+              key={slot.id}
+              fallbackIcon={slot.icon}
+              item={slot.item}
+              label={slot.label}
+              selectedId={selectedId}
+              onSelect={(item) => setSelectedId(item.id)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="velkhar-bag-title">
+        <div className="velkhar-session-window__section-heading">
+          <h3 id="velkhar-bag-title">Bag</h3>
+          <span>12 slots</span>
+        </div>
+        <div className="velkhar-inventory__grid velkhar-inventory__grid--bag">
+          {bagSlots.map((item, index) => (
+            <ItemSlot
+              key={item?.id ?? `bag-slot-${index}`}
+              fallbackIcon="chest"
+              item={item}
+              label={`Bag slot ${index + 1}`}
+              selectedId={selectedId}
+              onSelect={(nextItem) => setSelectedId(nextItem.id)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <div className="velkhar-inventory__specials">
+        <section aria-labelledby="velkhar-artifact-title">
+          <h3 id="velkhar-artifact-title">Artifact</h3>
+          <ItemSlot
+            fallbackIcon="artifact"
+            item={inventory.artifact}
+            label="Dedicated artifact slot"
+            selectedId={selectedId}
+            onSelect={(item) => setSelectedId(item.id)}
+          />
+        </section>
+        <section aria-labelledby="velkhar-heirloom-title">
+          <h3 id="velkhar-heirloom-title">Heirloom</h3>
+          <ItemSlot
+            fallbackIcon="memory"
+            item={inventory.heirloom}
+            label="Inherited item slot"
+            selectedId={selectedId}
+            onSelect={(item) => setSelectedId(item.id)}
+          />
+        </section>
+      </div>
+
+      <aside className="velkhar-inventory__detail" aria-live="polite">
+        {selectedItem ? (
+          <>
+            <p className="velkhar-session-window__eyebrow">Item detail</p>
+            <h3>{selectedItem.name}</h3>
+            <p>{selectedItem.description ?? 'No description has been revealed yet.'}</p>
+            {selectedItem.allowedActions?.length ? (
+              <p className="velkhar-inventory__permissions">
+                Authorized now: {selectedItem.allowedActions.join(', ')}
+              </p>
+            ) : (
+              <p className="velkhar-session-window__muted">
+                No action is authorized in this scene.
+              </p>
+            )}
+          </>
+        ) : (
+          <div className="velkhar-session-window__empty">
+            <GameIcon decorative name="eye" size={48} />
+            <p>Select an available item to inspect it.</p>
+          </div>
+        )}
+      </aside>
+    </div>
+  )
+}

--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.test.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.test.tsx
@@ -10,7 +10,8 @@ import { VelkharSession } from './VelkharSession'
 
 import type { SceneResponse } from '@grimoire/shared'
 
-const { createSessionMock, postGameActionMock } = vi.hoisted(() => ({
+const { abandonSessionMock, createSessionMock, postGameActionMock } = vi.hoisted(() => ({
+  abandonSessionMock: vi.fn(),
   createSessionMock: vi.fn(),
   postGameActionMock: vi.fn(),
 }))
@@ -31,6 +32,7 @@ vi.mock('next/image', () => ({
 
 vi.mock('@/features/game-session/api/game-session-api', () => ({
   gameSessionApi: {
+    abandonSession: abandonSessionMock,
     createSession: createSessionMock,
     postGameAction: postGameActionMock,
   },
@@ -64,7 +66,45 @@ const OPENING_RESPONSE: SceneResponse = {
     createdAt: '2026-07-16T00:00:00.000Z',
   },
   updatedStats: { ...MOCK_CHARACTER.stats.survival },
-  updatedInventory: [],
+  updatedInventory: [
+    {
+      id: 'item-sabre',
+      name: 'Salt sabre',
+      quantity: 1,
+      category: 'equipment',
+      equippedSlot: 'main-hand',
+      description: 'A worn blade balanced for the salt roads.',
+      allowedActions: ['unequip', 'inspect'],
+    },
+    {
+      id: 'item-water',
+      name: 'Waterskin',
+      quantity: 2,
+      category: 'bag',
+      description: 'Enough water for another day.',
+      allowedActions: ['use', 'inspect'],
+    },
+    {
+      id: 'item-seal',
+      name: 'Sealed letter',
+      quantity: 1,
+      category: 'bag',
+      state: 'locked',
+    },
+    {
+      id: 'item-rations',
+      name: 'Travel rations',
+      quantity: 1,
+      category: 'bag',
+      state: 'pending',
+    },
+    {
+      id: 'item-voice',
+      name: 'Voice of the Sands',
+      quantity: 1,
+      category: 'artifact',
+    },
+  ],
   notifications: [],
   source: 'ai',
 }
@@ -89,10 +129,12 @@ const NEXT_RESPONSE: SceneResponse = {
 
 describe('VelkharSession', () => {
   beforeEach(() => {
+    abandonSessionMock.mockReset()
     createSessionMock.mockReset()
     postGameActionMock.mockReset()
     createSessionMock.mockResolvedValue(OPENING_RESPONSE)
     postGameActionMock.mockResolvedValue(NEXT_RESPONSE)
+    abandonSessionMock.mockResolvedValue({ status: 'ended', endReason: 'abandon' })
     useSessionStore.setState({
       anonymousRequestCount: 0,
       showSoftPrompt: false,
@@ -154,10 +196,76 @@ describe('VelkharSession', () => {
     await screen.findByText('Salt moves across the road.')
     await user.click(screen.getByRole('button', { name: 'Open character sheet' }))
 
-    expect(screen.getByRole('dialog', { name: 'character panel' })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: MOCK_CHARACTER.name })).toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: 'Character panel' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 3, name: MOCK_CHARACTER.name })).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Close panel' }))
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('partage la même source entre la quickbar et les 8+12 emplacements détaillés', async () => {
+    const user = userEvent.setup()
+    render(<VelkharSession initialCharacter={MOCK_CHARACTER} />)
+
+    await screen.findByText('Salt moves across the road.')
+    await user.click(screen.getByRole('button', { name: 'Open inventory, 5 items' }))
+
+    expect(screen.getByRole('dialog', { name: 'Inventory panel' })).toBeInTheDocument()
+    expect(screen.getByText('8 fixed slots')).toBeInTheDocument()
+    expect(screen.getByText('12 slots')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Main hand: Salt sabre, equipped/ })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /Bag slot 2: Sealed letter, locked/ })).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: /Bag slot 3: Travel rations, pending/ })
+    ).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Bag slot 4, empty' })).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: /Bag slot 1: Waterskin/ }))
+    expect(screen.getByRole('heading', { name: 'Waterskin' })).toBeInTheDocument()
+    expect(screen.getByText('Authorized now: use, inspect')).toBeInTheDocument()
+  })
+
+  it('restaure le focus après Escape', async () => {
+    const user = userEvent.setup()
+    render(<VelkharSession initialCharacter={MOCK_CHARACTER} />)
+
+    await screen.findByText('Salt moves across the road.')
+    const trigger = screen.getByRole('button', { name: 'Open character sheet' })
+    await user.click(trigger)
+    expect(screen.getByRole('button', { name: 'Close panel' })).toHaveFocus()
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it('enferme la navigation clavier dans la fenêtre', async () => {
+    const user = userEvent.setup()
+    render(<VelkharSession initialCharacter={MOCK_CHARACTER} />)
+
+    await screen.findByText('Salt moves across the road.')
+    await user.click(screen.getByRole('button', { name: 'Open session menu' }))
+    expect(screen.getByRole('button', { name: 'Close panel' })).toHaveFocus()
+
+    await user.tab({ shift: true })
+    expect(screen.getByRole('button', { name: 'Abandon this run' })).toHaveFocus()
+    await user.tab()
+    expect(screen.getByRole('button', { name: 'Close panel' })).toHaveFocus()
+  })
+
+  it('demande confirmation avant un abandon et attend le backend', async () => {
+    const user = userEvent.setup()
+    render(<VelkharSession initialCharacter={MOCK_CHARACTER} />)
+
+    await screen.findByText('Salt moves across the road.')
+    await user.click(screen.getByRole('button', { name: 'Open session menu' }))
+    await user.click(screen.getByRole('button', { name: 'Abandon this run' }))
+
+    expect(screen.getByRole('alertdialog', { name: 'Confirm abandon run' })).toBeInTheDocument()
+    expect(abandonSessionMock).not.toHaveBeenCalled()
+    await user.click(screen.getByRole('button', { name: 'Confirm abandon' }))
+
+    await waitFor(() => expect(abandonSessionMock).toHaveBeenCalledWith('session-1'))
+    expect(await screen.findByText('This run has become a Chronicle')).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.tsx
@@ -92,6 +92,8 @@ export function VelkharSession({ initialCharacter, locale = 'en' }: VelkharSessi
     reduceWorldState,
     resumeHref: `${VELKHAR_WORLD.routes.session}/resume`,
   })
+  const abandonSession = session.abandon
+  const closeTool = useCallback(() => setOpenTool(null), [])
 
   const people = getPeople(initialCharacter.people)
   const vocation = getVocation(initialCharacter.vocation)
@@ -120,6 +122,11 @@ export function VelkharSession({ initialCharacter, locale = 'en' }: VelkharSessi
     },
     [submitFreeAction]
   )
+
+  const handleAbandon = useCallback(async () => {
+    const abandoned = await abandonSession()
+    if (abandoned) closeTool()
+  }, [abandonSession, closeTool])
 
   return (
     <>
@@ -248,10 +255,14 @@ export function VelkharSession({ initialCharacter, locale = 'en' }: VelkharSessi
       />
       <VelkharSessionToolPanel
         character={initialCharacter}
+        ending={session.ending}
+        iron={session.response?.updatedStats.iron ?? null}
         inventory={session.inventory}
         openTool={openTool}
         source={session.source}
-        onClose={() => setOpenTool(null)}
+        survival={session.worldState}
+        onAbandon={handleAbandon}
+        onClose={closeTool}
       />
       <SoftSignupPrompt />
     </>

--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSessionMenu.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSessionMenu.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+import { GameButton } from '@/components/ui/grimoire/GameButton/GameButton'
+import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
+
+import { VELKHAR_WORLD } from '../../_config/velkhar-world'
+
+interface VelkharSessionMenuProps {
+  ending: boolean
+  onAbandon: () => Promise<void>
+  onResume: () => void
+  source?: 'ai' | 'stub'
+}
+
+export function VelkharSessionMenu({
+  ending,
+  onAbandon,
+  onResume,
+  source,
+}: VelkharSessionMenuProps) {
+  const [confirmingAbandon, setConfirmingAbandon] = useState(false)
+
+  if (confirmingAbandon) {
+    return (
+      <div
+        className="velkhar-session-menu__confirmation"
+        role="alertdialog"
+        aria-label="Confirm abandon run"
+      >
+        <GameIcon decorative name="warning" size={64} />
+        <h3>Abandon this run?</h3>
+        <p>
+          This ends the current character’s journey and starts Chronicle generation. It cannot be
+          undone.
+        </p>
+        <div className="velkhar-session-menu__confirmation-actions">
+          <GameButton disabled={ending} onClick={() => setConfirmingAbandon(false)} variant="ghost">
+            Keep playing
+          </GameButton>
+          <GameButton loading={ending} onClick={() => void onAbandon()} tone="danger">
+            Confirm abandon
+          </GameButton>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="velkhar-session-menu">
+      <p className="velkhar-session-menu__status">
+        <span aria-hidden="true" data-online={source === 'ai'} />
+        The Game Master is {source === 'ai' ? 'alive and listening' : 'using its fallback tale'}.
+      </p>
+
+      <GameButton leadingIcon={<GameIcon decorative name="arrow" size={24} />} onClick={onResume}>
+        Resume the journey
+      </GameButton>
+
+      <GameButton
+        disabled
+        leadingIcon={<GameIcon decorative name="crafting" size={24} />}
+        variant="ghost"
+      >
+        Settings — coming soon
+      </GameButton>
+
+      <Link
+        className="velkhar-session-menu__link"
+        href={`${VELKHAR_WORLD.routes.aveugle}?return=run`}
+      >
+        <GameIcon decorative name="hourglass" size={24} />
+        Return to the Blind One
+      </Link>
+
+      <button
+        className="velkhar-session-menu__danger"
+        onClick={() => setConfirmingAbandon(true)}
+        type="button"
+      >
+        Abandon this run
+      </button>
+    </div>
+  )
+}

--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSessionToolPanel.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSessionToolPanel.tsx
@@ -1,41 +1,48 @@
-import {
-  ATTRIBUTE_LABELS,
-  attributeModifier,
-  type Character,
-  type InventoryItemRef,
-} from '@grimoire/shared'
-import Link from 'next/link'
-
-import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
 import { GameWindow } from '@/components/ui/grimoire/GameWindow/GameWindow'
 
-import { VELKHAR_WORLD } from '../../_config/velkhar-world'
+import { VelkharCharacterSheet } from './VelkharCharacterSheet'
+import { VelkharInventoryPanel } from './VelkharInventoryPanel'
+import { VelkharSessionMenu } from './VelkharSessionMenu'
+
+import type { Character, InventoryItemRef, SurvivalStats } from '@grimoire/shared'
 
 export type VelkharSessionTool = 'character' | 'inventory' | 'menu'
 
 interface VelkharSessionToolPanelProps {
   character: Character
+  ending: boolean
+  iron: number | null
   inventory: InventoryItemRef[]
   openTool: VelkharSessionTool | null
+  onAbandon: () => Promise<void>
   onClose: () => void
   source?: 'ai' | 'stub'
+  survival: SurvivalStats
 }
-
-const ATTRIBUTE_ORDER = ['blood', 'breath', 'ash'] as const
 
 export function VelkharSessionToolPanel({
   character,
+  ending,
+  iron,
   inventory,
+  onAbandon,
   onClose,
   openTool,
   source,
+  survival,
 }: VelkharSessionToolPanelProps) {
   if (!openTool) return null
 
   return (
     <GameWindow
       className="velkhar-session-window"
-      label={`${openTool} panel`}
+      label={
+        openTool === 'inventory'
+          ? 'Inventory panel'
+          : openTool === 'character'
+            ? 'Character panel'
+            : 'Session menu'
+      }
       onClose={onClose}
       title={
         openTool === 'inventory'
@@ -45,54 +52,19 @@ export function VelkharSessionToolPanel({
             : 'Session menu'
       }
     >
-      {openTool === 'inventory' ? (
-        inventory.length > 0 ? (
-          <ul className="velkhar-session-window__inventory">
-            {inventory.map((item) => (
-              <li key={item.id}>
-                <GameIcon decorative name="artifact" size={32} />
-                <span>{item.name}</span>
-                <strong>×{item.quantity}</strong>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <div className="velkhar-session-window__empty">
-            <GameIcon decorative name="chest" size={64} />
-            <p>Your field kit is empty. What you find on the road will appear here.</p>
-          </div>
-        )
-      ) : null}
+      {openTool === 'inventory' ? <VelkharInventoryPanel iron={iron} items={inventory} /> : null}
 
       {openTool === 'character' ? (
-        <>
-          <p className="velkhar-session-window__story">{character.backstory}</p>
-          <dl className="velkhar-session-window__attributes">
-            {ATTRIBUTE_ORDER.map((attribute) => {
-              const value = character.stats.attributes[attribute]
-              const modifier = attributeModifier(value)
-              return (
-                <div key={attribute}>
-                  <dt>{ATTRIBUTE_LABELS[attribute].en}</dt>
-                  <dd>
-                    {value} <small>{modifier >= 0 ? `+${modifier}` : modifier}</small>
-                  </dd>
-                </div>
-              )
-            })}
-          </dl>
-        </>
+        <VelkharCharacterSheet character={character} survival={survival} />
       ) : null}
 
       {openTool === 'menu' ? (
-        <div className="velkhar-session-window__menu">
-          <p>
-            The Game Master is {source === 'ai' ? 'alive and listening' : 'using its fallback tale'}
-            .
-          </p>
-          <Link href={`${VELKHAR_WORLD.routes.aveugle}?return=run`}>Return to the Blind One</Link>
-          <Link href="/dashboard">Leave for the Chronicles</Link>
-        </div>
+        <VelkharSessionMenu
+          ending={ending}
+          onAbandon={onAbandon}
+          onResume={onClose}
+          source={source}
+        />
       ) : null}
     </GameWindow>
   )

--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSurvivalHud.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSurvivalHud.tsx
@@ -1,10 +1,5 @@
-import { GameHudDock } from '@/components/ui/grimoire/GameHudDock/GameHudDock'
 import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
-import { GameProgressRing } from '@/components/ui/grimoire/GameProgressRing/GameProgressRing'
-import { InventoryQuickbar } from '@/components/ui/grimoire/InventoryQuickbar/InventoryQuickbar'
-import { InventorySlot } from '@/components/ui/grimoire/InventorySlot/InventorySlot'
-import { ResourceCounter } from '@/components/ui/grimoire/ResourceCounter/ResourceCounter'
-import { StatBar } from '@/components/ui/grimoire/StatBar/StatBar'
+import { GameSessionHud } from '@/features/game-session/components/GameSessionHud'
 
 import type { Attributes, InventoryItemRef, SurvivalStats } from '@grimoire/shared'
 
@@ -27,92 +22,93 @@ export function VelkharSurvivalHud({
   survival,
 }: VelkharSurvivalHudProps) {
   return (
-    <GameHudDock className="velkhar-session__hud" label="Character status and field kit">
-      <div className="velkhar-session__stats">
-        <StatBar
-          icon={<GameIcon decorative name="blood-drop" size={24} />}
-          label="Blood"
-          max={survival.maxHp}
-          size="sm"
-          tone="danger"
-          value={survival.hp}
-        />
-        <StatBar
-          icon={<GameIcon decorative name="wind" size={24} />}
-          label="Breath"
-          max={18}
-          size="sm"
-          tone="aqua"
-          value={attributes.breath}
-        />
-        <StatBar
-          icon={<GameIcon decorative name="fire" size={24} />}
-          label="Ash"
-          max={18}
-          size="sm"
-          tone="ember"
-          value={attributes.ash}
-        />
-      </div>
-
-      <div className="velkhar-session__rings">
-        <GameProgressRing
-          icon={<GameIcon decorative name="water" size={24} />}
-          label="Thirst"
-          max={100}
-          size="sm"
-          tone="aqua"
-          value={survival.thirst}
-        />
-        <GameProgressRing
-          icon={<GameIcon decorative name="hunger" size={24} />}
-          label="Hunger"
-          max={100}
-          size="sm"
-          tone="ember"
-          value={survival.hunger}
-        />
-        <GameProgressRing
-          icon={<GameIcon decorative name="moon" size={24} />}
-          label="Fatigue"
-          max={100}
-          size="sm"
-          value={100 - survival.energy}
-        />
-        <GameProgressRing
-          className="velkhar-session__calamine-ring"
-          icon={<GameIcon decorative name="warning" size={24} />}
-          label="Calamine"
-          max={100}
-          size="sm"
-          value={survival.calamine}
-        />
-      </div>
-
-      <ResourceCounter
-        compact
-        icon={<GameIcon decorative name="coin" size={32} />}
-        label="Iron"
-        value="?"
-      />
-
-      <InventoryQuickbar className="velkhar-session__quickbar" label="Session tools">
-        <InventorySlot
-          icon={<GameIcon decorative name="chest" size={48} />}
-          label={`Open inventory, ${inventory.length} items`}
-          onClick={onOpenInventory}
-        />
-        <InventorySlot
-          icon={<GameIcon decorative name="stranger" size={48} />}
-          label="Open character sheet"
-          onClick={onOpenCharacter}
-        />
-        <InventorySlot
-          icon={<GameIcon decorative name="journal" size={48} />}
-          label="Open session menu"
-          onClick={onOpenMenu}
-        />
-      </InventoryQuickbar>
-    </GameHudDock>
+    <GameSessionHud
+      className="velkhar-session__hud"
+      label="Character status and field kit"
+      resource={{
+        icon: <GameIcon decorative name="coin" size={32} />,
+        label: 'Iron',
+        value: '?',
+      }}
+      statusBars={[
+        {
+          id: 'health',
+          icon: <GameIcon decorative name="blood-drop" size={24} />,
+          label: 'Blood',
+          max: survival.maxHp,
+          tone: 'danger',
+          value: survival.hp,
+        },
+        {
+          id: 'breath',
+          icon: <GameIcon decorative name="wind" size={24} />,
+          label: 'Breath',
+          max: 18,
+          tone: 'aqua',
+          value: attributes.breath,
+        },
+        {
+          id: 'ash',
+          icon: <GameIcon decorative name="fire" size={24} />,
+          label: 'Ash',
+          max: 18,
+          tone: 'ember',
+          value: attributes.ash,
+        },
+      ]}
+      statusGauges={[
+        {
+          id: 'thirst',
+          icon: <GameIcon decorative name="water" size={24} />,
+          label: 'Thirst',
+          max: 100,
+          tone: 'aqua',
+          value: survival.thirst,
+        },
+        {
+          id: 'hunger',
+          icon: <GameIcon decorative name="hunger" size={24} />,
+          label: 'Hunger',
+          max: 100,
+          tone: 'ember',
+          value: survival.hunger,
+        },
+        {
+          id: 'fatigue',
+          icon: <GameIcon decorative name="moon" size={24} />,
+          label: 'Fatigue',
+          max: 100,
+          value: 100 - survival.energy,
+        },
+        {
+          className: 'velkhar-session__calamine-ring',
+          id: 'calamine',
+          icon: <GameIcon decorative name="warning" size={24} />,
+          label: 'Calamine',
+          max: 100,
+          value: survival.calamine,
+        },
+      ]}
+      tools={[
+        {
+          id: 'inventory',
+          icon: <GameIcon decorative name="chest" size={48} />,
+          label: `Open inventory, ${inventory.length} items`,
+          onClick: onOpenInventory,
+        },
+        {
+          id: 'character',
+          icon: <GameIcon decorative name="stranger" size={48} />,
+          label: 'Open character sheet',
+          onClick: onOpenCharacter,
+        },
+        {
+          id: 'menu',
+          icon: <GameIcon decorative name="journal" size={48} />,
+          label: 'Open session menu',
+          onClick: onOpenMenu,
+        },
+      ]}
+    />
   )
 }

--- a/apps/frontend/src/app/(game)/velkhar/session/_lib/velkhar-inventory-model.ts
+++ b/apps/frontend/src/app/(game)/velkhar/session/_lib/velkhar-inventory-model.ts
@@ -1,0 +1,50 @@
+import type { GameIconName } from '@/components/ui/grimoire/GameIcon/GameIcon'
+import type { InventoryItemRef } from '@grimoire/shared'
+
+export const VELKHAR_BAG_CAPACITY = 12
+
+export const VELKHAR_EQUIPMENT_SLOTS = [
+  { id: 'main-hand', icon: 'crossed-swords', label: 'Main hand' },
+  { id: 'off-hand', icon: 'shield', label: 'Off hand' },
+  { id: 'armor', icon: 'shield', label: 'Armor' },
+  { id: 'cloak', icon: 'stranger', label: 'Cloak' },
+  { id: 'head', icon: 'helmet', label: 'Head' },
+  { id: 'accessory', icon: 'diamond', label: 'Accessory' },
+  { id: 'belt', icon: 'key', label: 'Belt' },
+  { id: 'feet', icon: 'footprint', label: 'Feet' },
+] as const satisfies readonly { id: string; icon: GameIconName; label: string }[]
+
+export interface VelkharEquipmentSlot {
+  icon: GameIconName
+  id: string
+  item: InventoryItemRef | null
+  label: string
+}
+
+export interface VelkharInventoryView {
+  artifact: InventoryItemRef | null
+  bagItems: InventoryItemRef[]
+  equipment: VelkharEquipmentSlot[]
+  heirloom: InventoryItemRef | null
+}
+
+export function buildVelkharInventoryView(items: InventoryItemRef[]): VelkharInventoryView {
+  const artifact = items.find((item) => item.category === 'artifact') ?? null
+  const heirloom = items.find((item) => item.category === 'heirloom') ?? null
+  const equipment = VELKHAR_EQUIPMENT_SLOTS.map((slot) => ({
+    ...slot,
+    item: items.find((item) => item.equippedSlot === slot.id) ?? null,
+  }))
+  const equippedIds = new Set(equipment.flatMap((slot) => (slot.item ? [slot.item.id] : [])))
+  const bagItems = items
+    .filter(
+      (item) =>
+        item.category !== 'artifact' &&
+        item.category !== 'heirloom' &&
+        item.category !== 'key' &&
+        !equippedIds.has(item.id)
+    )
+    .slice(0, VELKHAR_BAG_CAPACITY)
+
+  return { artifact, bagItems, equipment, heirloom }
+}

--- a/apps/frontend/src/app/(game)/velkhar/session/_theme/velkhar-session.css
+++ b/apps/frontend/src/app/(game)/velkhar/session/_theme/velkhar-session.css
@@ -18,7 +18,12 @@
 
 .velkhar-session::after {
   background:
-    radial-gradient(circle at 50% 32%, transparent 0 18%, rgba(3, 3, 2, 0.12) 52%, rgba(3, 3, 2, 0.46) 100%),
+    radial-gradient(
+      circle at 50% 32%,
+      transparent 0 18%,
+      rgba(3, 3, 2, 0.12) 52%,
+      rgba(3, 3, 2, 0.46) 100%
+    ),
     linear-gradient(
       180deg,
       rgba(3, 3, 2, 0.03) 0%,
@@ -355,72 +360,8 @@
   opacity: 0.45;
 }
 
-.velkhar-session__hud {
-  padding: clamp(0.55rem, 0.8vw, 0.8rem) clamp(0.85rem, 1.4vw, 1.45rem);
-}
-
-.velkhar-session__hud::before {
-  border-image-width: 14px;
-  border-width: 14px;
-}
-
-.velkhar-session__hud .game-hud-dock__content {
-  display: grid;
-  gap: clamp(0.75rem, 1.5vw, 1.5rem);
-  grid-template-columns: minmax(17rem, 22rem) minmax(18rem, auto) auto auto;
-  justify-content: space-between;
-}
-
-.velkhar-session__stats {
-  display: grid;
-  gap: 0.28rem;
-  max-width: 22rem;
-  width: 100%;
-}
-
-.velkhar-session__hud .stat-bar__heading {
-  margin-bottom: 0.15rem;
-}
-
-.velkhar-session__hud .stat-bar__label {
-  font-size: clamp(0.68rem, 0.75vw, 0.88rem);
-}
-
-.velkhar-session__hud .stat-bar__value {
-  font-size: clamp(0.76rem, 0.78vw, 0.94rem);
-}
-
-.velkhar-session__hud .stat-bar__track {
-  height: 8px;
-}
-
-.velkhar-session__rings {
-  align-items: center;
-  display: flex;
-  gap: clamp(0.3rem, 0.55vw, 0.62rem);
-}
-
-.velkhar-session__hud .game-progress-ring {
-  --game-ring-size: clamp(3.4rem, 4.7vw, 4.55rem);
-
-  gap: 0.2rem;
-}
-
-.velkhar-session__hud .game-progress-ring__label {
-  font-size: clamp(0.65rem, 0.68vw, 0.8rem);
-}
-
 .velkhar-session__calamine-ring {
   filter: drop-shadow(0 0 8px rgba(217, 164, 65, 0.22));
-}
-
-.velkhar-session__quickbar {
-  gap: 0.55rem;
-}
-
-.velkhar-session__quickbar .inventory-slot {
-  min-height: clamp(3.5rem, 4.8vw, 4.5rem);
-  min-width: clamp(3.5rem, 4.8vw, 4.5rem);
 }
 
 .game-session-source {
@@ -440,13 +381,12 @@
 .velkhar-session-window {
   --game-window-backdrop: rgba(0, 0, 0, 0.22);
   --game-window-background:
-    linear-gradient(rgba(10, 8, 6, 0.96), rgba(7, 6, 4, 0.98)),
-    url('/landing/textures/grain.svg');
+    linear-gradient(rgba(10, 8, 6, 0.96), rgba(7, 6, 4, 0.98)), url('/landing/textures/grain.svg');
   --game-window-border: 1px solid var(--border-gold);
   --game-window-right: clamp(1rem, 3vw, 3rem);
   --game-window-shadow: 0 22px 80px rgba(0, 0, 0, 0.68);
   --game-window-top: 5.5rem;
-  --game-window-width: min(25rem, calc(100vw - 2rem));
+  --game-window-width: min(46rem, calc(100vw - 2rem));
 }
 
 .velkhar-session-window .game-window {
@@ -463,9 +403,9 @@
 
 .velkhar-session-window .game-window__header h2 {
   font-size: 1.6rem;
+  text-wrap: balance;
 }
 
-.velkhar-session-window__inventory,
 .velkhar-session-window__attributes {
   display: grid;
   gap: 0.65rem;
@@ -474,7 +414,6 @@
   padding: 0;
 }
 
-.velkhar-session-window__inventory li,
 .velkhar-session-window__attributes > div {
   align-items: center;
   background: rgba(217, 164, 65, 0.05);
@@ -483,6 +422,18 @@
   gap: 0.75rem;
   grid-template-columns: auto minmax(0, 1fr) auto;
   padding: 0.65rem;
+}
+
+.velkhar-session-window__attributes > div[data-attribute='blood'] {
+  box-shadow: inset 3px 0 color-mix(in srgb, var(--blood) 72%, transparent);
+}
+
+.velkhar-session-window__attributes > div[data-attribute='breath'] {
+  box-shadow: inset 3px 0 color-mix(in srgb, var(--soul) 72%, transparent);
+}
+
+.velkhar-session-window__attributes > div[data-attribute='ash'] {
+  box-shadow: inset 3px 0 color-mix(in srgb, var(--cendre) 72%, transparent);
 }
 
 .velkhar-session-window__attributes dt {
@@ -496,6 +447,7 @@
   font-family: var(--font-game-heading);
   font-size: 1.35rem;
   margin: 0;
+  font-variant-numeric: tabular-nums;
 }
 
 .velkhar-session-window__attributes small {
@@ -506,11 +458,13 @@
 
 .velkhar-session-window__story,
 .velkhar-session-window__empty p,
-.velkhar-session-window__menu p {
+.velkhar-session-menu p,
+.velkhar-inventory__detail p {
   color: var(--ink-2);
   font-family: var(--font-game-body);
   font-size: 1.05rem;
   line-height: 1.55;
+  text-wrap: pretty;
 }
 
 .velkhar-session-window__empty {
@@ -520,27 +474,359 @@
   text-align: center;
 }
 
-.velkhar-session-window__menu {
-  display: grid;
-  gap: 0.75rem;
+.velkhar-session-window__eyebrow {
+  color: var(--gold);
+  font-family: var(--font-game-ui);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  margin: 0 0 0.2rem;
+  text-transform: uppercase;
 }
 
-.velkhar-session-window__menu a {
-  border: 1px solid var(--border-gold);
+.velkhar-session-window__muted {
+  color: var(--ink-2);
+  font-family: var(--font-game-body);
+  margin: 0;
+}
+
+.velkhar-session-window__section-heading {
+  align-items: baseline;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.65rem;
+}
+
+.velkhar-session-window__section-heading h3,
+.velkhar-inventory__specials h3,
+.velkhar-character-sheet h4 {
+  color: var(--gold-light);
+  font-family: var(--font-game-heading);
+  font-size: 1rem;
+  font-weight: 500;
+  margin: 0;
+  text-wrap: balance;
+}
+
+.velkhar-session-window__section-heading span {
+  color: var(--ink-2);
+  font-family: var(--font-game-ui);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.velkhar-character-sheet {
+  display: grid;
+  gap: 1.35rem;
+}
+
+.velkhar-character-sheet__identity {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+}
+
+.velkhar-character-sheet__identity h3 {
+  color: var(--gold-light);
+  font-family: var(--font-game-heading);
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  font-weight: 500;
+  margin: 0;
+  text-wrap: balance;
+}
+
+.velkhar-character-sheet__identity p:last-child {
+  color: var(--ink-2);
+  font-family: var(--font-game-ui);
+  margin: 0.2rem 0 0;
+}
+
+.velkhar-character-sheet__survival {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  margin: 0.65rem 0 0;
+}
+
+.velkhar-character-sheet__survival > div {
+  background: color-mix(in srgb, var(--gold) 6%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--gold) 18%, transparent);
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.65rem;
+}
+
+.velkhar-character-sheet__survival dt {
+  color: var(--ink-2);
+  font-family: var(--font-game-ui);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+}
+
+.velkhar-character-sheet__survival dd {
+  color: var(--parchment);
+  font-family: var(--font-game-heading);
+  font-variant-numeric: tabular-nums;
+  margin: 0;
+}
+
+.velkhar-character-sheet__survival [data-danger='true'] dd {
+  color: color-mix(in srgb, var(--blood) 70%, var(--parchment));
+}
+
+.velkhar-character-sheet__conditions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  list-style: none;
+  margin: 0.65rem 0 0;
+  padding: 0;
+}
+
+.velkhar-character-sheet__conditions li {
+  background: color-mix(in srgb, var(--blood) 12%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--blood) 34%, transparent);
+  color: var(--parchment);
+  font-family: var(--font-game-ui);
+  font-size: 0.78rem;
+  padding: 0.35rem 0.55rem;
+}
+
+.velkhar-inventory {
+  display: grid;
+  gap: 1.35rem;
+}
+
+.velkhar-inventory__summary {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.velkhar-inventory__summary > span {
+  align-items: center;
+  background: color-mix(in srgb, var(--gold) 7%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--gold) 19%, transparent);
+  color: var(--ink-2);
+  display: flex;
+  font-family: var(--font-game-ui);
+  gap: 0.4rem;
+  min-height: 44px;
+  padding: 0.45rem 0.7rem;
+}
+
+.velkhar-inventory__summary strong {
+  color: var(--gold-light);
+  font-variant-numeric: tabular-nums;
+}
+
+.velkhar-inventory__grid {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.velkhar-inventory__grid--equipment {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.velkhar-inventory__grid--bag {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.velkhar-inventory-slot {
+  align-items: center;
+  display: grid;
+  gap: 0.25rem;
+  justify-items: center;
+  min-width: 0;
+  position: relative;
+}
+
+.velkhar-inventory-slot .inventory-slot {
+  min-height: 56px;
+  min-width: 56px;
+  width: 56px;
+}
+
+.velkhar-inventory-slot > span {
+  color: var(--ink-2);
+  font-family: var(--font-game-ui);
+  font-size: 0.68rem;
+  max-width: 100%;
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.velkhar-inventory-slot--equipped::after,
+.velkhar-inventory-slot--locked::after,
+.velkhar-inventory-slot--pending::after {
+  background: var(--void);
   color: var(--gold-light);
   font-family: var(--font-game-ui);
+  font-size: 0.55rem;
+  letter-spacing: 0.06em;
+  padding: 0.12rem 0.25rem;
+  position: absolute;
+  right: 0;
+  text-transform: uppercase;
+  top: 0;
+}
+
+.velkhar-inventory-slot--equipped::after {
+  content: 'Worn';
+}
+.velkhar-inventory-slot--locked::after {
+  content: 'Locked';
+}
+.velkhar-inventory-slot--pending::after {
+  content: '…';
+}
+
+.velkhar-inventory__specials {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: 1fr 1fr;
+}
+
+.velkhar-inventory__specials section {
+  align-items: center;
+  background: color-mix(in srgb, var(--gold) 5%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--gold) 16%, transparent);
+  display: flex;
+  justify-content: space-between;
+  padding: 0.7rem;
+}
+
+.velkhar-inventory__detail {
+  background: color-mix(in srgb, var(--gold) 5%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--gold) 16%, transparent),
+    0 12px 28px color-mix(in srgb, var(--void) 48%, transparent);
+  min-height: 8.5rem;
+  padding: 1rem;
+}
+
+.velkhar-inventory__detail h3 {
+  color: var(--gold-light);
+  font-family: var(--font-game-heading);
+  font-size: 1.35rem;
+  font-weight: 500;
+  margin: 0;
+}
+
+.velkhar-inventory__permissions {
+  color: var(--soul) !important;
+  font-family: var(--font-game-ui) !important;
+  font-size: 0.78rem !important;
+  text-transform: capitalize;
+}
+
+.velkhar-session-menu {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.velkhar-session-menu .game-button {
+  width: 100%;
+}
+
+.velkhar-session-menu__status {
+  align-items: center;
+  color: var(--ink-2);
+  display: flex;
+  gap: 0.6rem;
+  margin: 0 0 0.4rem;
+}
+
+.velkhar-session-menu__status span {
+  background: var(--cendre);
+  border-radius: 50%;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--cendre) 15%, transparent);
+  height: 0.55rem;
+  width: 0.55rem;
+}
+
+.velkhar-session-menu__status span[data-online='true'] {
+  background: var(--soul);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--soul) 15%, transparent);
+}
+
+.velkhar-session-menu__link {
+  align-items: center;
+  box-shadow: inset 0 0 0 1px var(--border-gold);
+  color: var(--gold-light);
+  display: flex;
+  font-family: var(--font-game-ui);
+  gap: 0.65rem;
+  min-height: 44px;
   padding: 0.7rem 0.85rem;
+  transition-property: box-shadow, color;
+  transition-duration: var(--motion-ui);
+}
+
+.velkhar-session-menu__link:hover {
+  box-shadow:
+    inset 0 0 0 1px var(--gold-light),
+    0 0 18px color-mix(in srgb, var(--gold) 14%, transparent);
+}
+
+.velkhar-session-menu__danger {
+  background: transparent;
+  border: 0;
+  color: color-mix(in srgb, var(--blood) 70%, var(--parchment));
+  cursor: pointer;
+  font-family: var(--font-game-ui);
+  min-height: 44px;
+  padding: 0.65rem;
+  text-decoration: underline;
+  text-underline-offset: 0.25rem;
+  transition-property: color, scale;
+  transition-duration: var(--motion-ui);
+}
+
+.velkhar-session-menu__danger:hover {
+  color: var(--parchment);
+}
+.velkhar-session-menu__danger:active {
+  scale: 0.96;
+}
+.velkhar-session-menu__danger:focus-visible {
+  outline: 2px solid var(--gold-light);
+  outline-offset: 3px;
+}
+
+.velkhar-session-menu__confirmation {
+  align-items: center;
+  display: grid;
+  gap: 0.8rem;
+  justify-items: center;
+  padding: 1rem 0.5rem;
+  text-align: center;
+}
+
+.velkhar-session-menu__confirmation h3 {
+  color: color-mix(in srgb, var(--blood) 65%, var(--parchment));
+  font-family: var(--font-game-heading);
+  font-size: 1.55rem;
+  font-weight: 500;
+  margin: 0;
+  text-wrap: balance;
+}
+
+.velkhar-session-menu__confirmation p {
+  color: var(--ink-2);
+  margin: 0;
+  max-width: 32rem;
+}
+
+.velkhar-session-menu__confirmation-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
 }
 
 @media (max-width: 1120px) {
-  .velkhar-session__hud .game-hud-dock__content {
-    grid-template-columns: minmax(15rem, 20rem) auto auto;
-  }
-
-  .velkhar-session__hud .resource-counter {
-    display: none;
-  }
-
   .game-session-source {
     display: none;
   }
@@ -573,18 +859,6 @@
 
   .velkhar-session__topbar-end > a {
     font-size: 0.92rem;
-  }
-
-  .velkhar-session__hud .game-hud-dock__content {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .velkhar-session__rings {
-    justify-content: center;
-  }
-
-  .velkhar-session__quickbar {
-    justify-content: end;
   }
 }
 
@@ -627,30 +901,35 @@
     display: none;
   }
 
-  .velkhar-session__hud .game-hud-dock__content {
-    grid-template-columns: 1fr;
-  }
-
-  .velkhar-session__rings {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    width: 100%;
-  }
-
-  .velkhar-session__hud .game-progress-ring {
-    --game-ring-size: clamp(3.1rem, 16vw, 4rem);
-
-    min-width: 0;
-  }
-
-  .velkhar-session__quickbar {
-    justify-content: center;
-  }
-
   .velkhar-session-window .game-window {
     inset: 0;
     max-height: none;
     position: fixed;
+    width: 100%;
+  }
+
+  .velkhar-session-window .game-window__content {
+    padding: 1rem;
+  }
+
+  .velkhar-character-sheet__survival {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .velkhar-inventory__grid--equipment {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .velkhar-inventory__grid--bag {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .velkhar-inventory__specials {
+    grid-template-columns: 1fr;
+  }
+
+  .velkhar-session-menu__confirmation-actions {
+    display: grid;
     width: 100%;
   }
 }

--- a/apps/frontend/src/components/ui/grimoire/GameWindow/GameWindow.tsx
+++ b/apps/frontend/src/components/ui/grimoire/GameWindow/GameWindow.tsx
@@ -24,18 +24,49 @@ export interface GameWindowProps {
  */
 export function GameWindow({ children, className, label, onClose, title }: GameWindowProps) {
   const closeRef = useRef<HTMLButtonElement>(null)
+  const dialogRef = useRef<HTMLElement>(null)
 
   useEffect(() => {
     const previouslyFocused = document.activeElement as HTMLElement | null
+    const previousOverflow = document.documentElement.style.overflow
+    document.documentElement.style.overflow = 'hidden'
     closeRef.current?.focus()
 
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onClose()
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+        return
+      }
+
+      if (event.key !== 'Tab') return
+
+      const focusableElements = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(
+          'a[href], button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+        ) ?? []
+      )
+      if (focusableElements.length === 0) {
+        event.preventDefault()
+        dialogRef.current?.focus()
+        return
+      }
+
+      const firstElement = focusableElements[0]
+      const lastElement = focusableElements[focusableElements.length - 1]
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault()
+        lastElement?.focus()
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault()
+        firstElement?.focus()
+      }
     }
 
-    window.addEventListener('keydown', closeOnEscape)
+    document.addEventListener('keydown', handleKeyDown)
     return () => {
-      window.removeEventListener('keydown', closeOnEscape)
+      document.documentElement.style.overflow = previousOverflow
+      document.removeEventListener('keydown', handleKeyDown)
       previouslyFocused?.focus()
     }
   }, [onClose])
@@ -44,11 +75,20 @@ export function GameWindow({ children, className, label, onClose, title }: GameW
     <div className={cn('game-window-layer', className)}>
       <button
         aria-label="Dismiss panel"
+        aria-hidden="true"
         className="game-window-layer__backdrop"
         onClick={onClose}
+        tabIndex={-1}
         type="button"
       />
-      <section aria-label={label} aria-modal="true" className="game-window" role="dialog">
+      <section
+        ref={dialogRef}
+        aria-label={label}
+        aria-modal="true"
+        className="game-window"
+        role="dialog"
+        tabIndex={-1}
+      >
         <div className="game-window__header">
           <h2>{title}</h2>
           <GameButton

--- a/apps/frontend/src/features/game-session/api/game-session-api.ts
+++ b/apps/frontend/src/features/game-session/api/game-session-api.ts
@@ -1,4 +1,4 @@
-import type { GameSessionResponse } from '../model/game-session.types'
+import type { GameSessionEndResponse, GameSessionResponse } from '../model/game-session.types'
 import type { ApiResponse, Locale } from '@grimoire/shared'
 
 /** Payload accepted by the game action route. Mirrors the backend Zod schema. */
@@ -21,6 +21,16 @@ async function readSceneResponse<TResponse extends GameSessionResponse>(
   response: Response
 ): Promise<TResponse> {
   const body = (await response.json()) as ApiResponse<TResponse>
+
+  if (!response.ok || !body.success || !body.data) {
+    throw new Error(body.error ?? `Game request failed (${response.status})`)
+  }
+
+  return body.data
+}
+
+async function readEndResponse(response: Response): Promise<GameSessionEndResponse> {
+  const body = (await response.json()) as ApiResponse<GameSessionEndResponse>
 
   if (!response.ok || !body.success || !body.data) {
     throw new Error(body.error ?? `Game request failed (${response.status})`)
@@ -62,7 +72,19 @@ export async function postGameAction<TResponse extends GameSessionResponse = Gam
   return readSceneResponse<TResponse>(response)
 }
 
+/** Ends the current run only after the session menu confirmation. */
+export async function abandonSession(sessionId: string): Promise<GameSessionEndResponse> {
+  const response = await fetch('/api/game/session/abandon', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sessionId }),
+  })
+
+  return readEndResponse(response)
+}
+
 export const gameSessionApi = {
+  abandonSession,
   createSession,
   postGameAction,
 } as const

--- a/apps/frontend/src/features/game-session/components/GameSessionHud.test.tsx
+++ b/apps/frontend/src/features/game-session/components/GameSessionHud.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { GameSessionHud } from './GameSessionHud'
+
+describe('GameSessionHud', () => {
+  it('compose un footer avec les ressources fournies par un autre univers', async () => {
+    const user = userEvent.setup()
+    const openLoadout = vi.fn()
+
+    render(
+      <GameSessionHud
+        label="Pilot status"
+        resource={{ label: 'Credits', value: 420 }}
+        statusBars={[
+          { id: 'health', label: 'Health', max: 100, tone: 'danger', value: 72 },
+          { id: 'shield', label: 'Shield', max: 50, tone: 'aqua', value: 30 },
+        ]}
+        statusGauges={[{ id: 'stress', label: 'Stress', max: 100, tone: 'ember', value: 25 }]}
+        toolLabel="Pilot tools"
+        tools={[{ id: 'loadout', label: 'Open loadout', onClick: openLoadout }]}
+      />
+    )
+
+    expect(screen.getByRole('complementary', { name: 'Pilot status' })).toBeInTheDocument()
+    expect(screen.getByRole('progressbar', { name: 'Health' })).toHaveAttribute(
+      'aria-valuenow',
+      '72'
+    )
+    expect(screen.getByRole('progressbar', { name: 'Stress' })).toHaveAttribute(
+      'aria-valuenow',
+      '25'
+    )
+    expect(screen.getByLabelText('Credits : 420')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Open loadout' }))
+    expect(openLoadout).toHaveBeenCalledTimes(1)
+  })
+
+  it('accepte un univers sans monnaie ni jauge circulaire', () => {
+    render(
+      <GameSessionHud
+        label="Minimal status"
+        statusBars={[{ id: 'health', label: 'Health points', max: 12, tone: 'danger', value: 12 }]}
+        statusGauges={[]}
+        tools={[]}
+      />
+    )
+
+    const minimalHud = screen.getByRole('complementary', { name: 'Minimal status' })
+    expect(minimalHud).toHaveAttribute('data-has-resource', 'false')
+    expect(minimalHud).toHaveAttribute('data-has-gauges', 'false')
+    expect(screen.queryByLabelText(/Credits/)).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/features/game-session/components/GameSessionHud.tsx
+++ b/apps/frontend/src/features/game-session/components/GameSessionHud.tsx
@@ -1,0 +1,136 @@
+import { GameHudDock } from '@/components/ui/grimoire/GameHudDock/GameHudDock'
+import { GameProgressRing } from '@/components/ui/grimoire/GameProgressRing/GameProgressRing'
+import { InventoryQuickbar } from '@/components/ui/grimoire/InventoryQuickbar/InventoryQuickbar'
+import { InventorySlot } from '@/components/ui/grimoire/InventorySlot/InventorySlot'
+import { ResourceCounter } from '@/components/ui/grimoire/ResourceCounter/ResourceCounter'
+import { StatBar } from '@/components/ui/grimoire/StatBar/StatBar'
+
+import type { GameProgressRingTone } from '@/components/ui/grimoire/GameProgressRing/GameProgressRing'
+import type { StatBarTone } from '@/components/ui/grimoire/StatBar/StatBar'
+import type { ReactNode } from 'react'
+
+import './game-session-hud.css'
+
+export interface GameSessionHudStatusBar {
+  className?: string
+  icon?: ReactNode
+  id: string
+  label: string
+  max: number
+  tone: StatBarTone
+  value: number
+}
+
+export interface GameSessionHudStatusGauge {
+  className?: string
+  icon?: ReactNode
+  id: string
+  label: string
+  max: number
+  tone?: GameProgressRingTone
+  value: number
+}
+
+export interface GameSessionHudResource {
+  icon?: ReactNode
+  label: string
+  value: number | string
+}
+
+export interface GameSessionHudTool {
+  disabled?: boolean
+  icon?: ReactNode
+  id: string
+  label: string
+  onClick: () => void
+  quantity?: number
+  selected?: boolean
+}
+
+export interface GameSessionHudProps {
+  className?: string
+  label: string
+  resource?: GameSessionHudResource | null
+  statusBars: readonly GameSessionHudStatusBar[]
+  statusGauges: readonly GameSessionHudStatusGauge[]
+  toolLabel?: string
+  tools: readonly GameSessionHudTool[]
+}
+
+/**
+ * World-agnostic game-session footer. Each universe injects its own labels,
+ * values, icons and tones while the responsive layout stays consistent.
+ */
+export function GameSessionHud({
+  className,
+  label,
+  resource,
+  statusBars,
+  statusGauges,
+  toolLabel = 'Session tools',
+  tools,
+}: GameSessionHudProps) {
+  return (
+    <GameHudDock
+      className={`game-session-hud ${className ?? ''}`}
+      data-has-gauges={statusGauges.length > 0 ? 'true' : 'false'}
+      data-has-resource={resource ? 'true' : 'false'}
+      label={label}
+    >
+      <div className="game-session-hud__bars">
+        {statusBars.map((status) => (
+          <StatBar
+            key={status.id}
+            className={status.className}
+            icon={status.icon}
+            label={status.label}
+            max={status.max}
+            size="sm"
+            tone={status.tone}
+            value={status.value}
+          />
+        ))}
+      </div>
+
+      {statusGauges.length > 0 ? (
+        <div className="game-session-hud__gauges">
+          {statusGauges.map((gauge) => (
+            <GameProgressRing
+              key={gauge.id}
+              className={gauge.className}
+              icon={gauge.icon}
+              label={gauge.label}
+              max={gauge.max}
+              size="sm"
+              tone={gauge.tone}
+              value={gauge.value}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {resource ? (
+        <ResourceCounter
+          compact
+          icon={resource.icon}
+          label={resource.label}
+          value={resource.value}
+        />
+      ) : null}
+
+      <InventoryQuickbar className="game-session-hud__tools" label={toolLabel}>
+        {tools.map((tool) => (
+          <InventorySlot
+            key={tool.id}
+            disabled={tool.disabled}
+            icon={tool.icon}
+            label={tool.label}
+            quantity={tool.quantity}
+            selected={tool.selected}
+            onClick={tool.onClick}
+          />
+        ))}
+      </InventoryQuickbar>
+    </GameHudDock>
+  )
+}

--- a/apps/frontend/src/features/game-session/components/game-session-hud.css
+++ b/apps/frontend/src/features/game-session/components/game-session-hud.css
@@ -1,0 +1,130 @@
+.game-session-hud {
+  padding: clamp(0.55rem, 0.8vw, 0.8rem) clamp(0.85rem, 1.4vw, 1.45rem);
+}
+
+.game-session-hud::before {
+  border-image-width: 14px;
+  border-width: 14px;
+}
+
+.game-session-hud .game-hud-dock__content {
+  display: grid;
+  gap: clamp(0.75rem, 1.5vw, 1.5rem);
+  grid-template-columns: minmax(17rem, 22rem) minmax(18rem, auto) auto auto;
+  justify-content: space-between;
+}
+
+.game-session-hud[data-has-resource='false'] .game-hud-dock__content {
+  grid-template-columns: minmax(17rem, 22rem) minmax(18rem, auto) auto;
+}
+
+.game-session-hud[data-has-gauges='false'][data-has-resource='true'] .game-hud-dock__content {
+  grid-template-columns: minmax(17rem, 22rem) auto auto;
+}
+
+.game-session-hud[data-has-gauges='false'][data-has-resource='false'] .game-hud-dock__content {
+  grid-template-columns: minmax(17rem, 22rem) auto;
+}
+
+.game-session-hud__bars {
+  display: grid;
+  gap: 0.28rem;
+  max-width: 22rem;
+  width: 100%;
+}
+
+.game-session-hud .stat-bar__heading {
+  margin-bottom: 0.15rem;
+}
+
+.game-session-hud .stat-bar__label {
+  font-size: clamp(0.68rem, 0.75vw, 0.88rem);
+}
+
+.game-session-hud .stat-bar__value {
+  font-size: clamp(0.76rem, 0.78vw, 0.94rem);
+}
+
+.game-session-hud .stat-bar__track {
+  height: 8px;
+}
+
+.game-session-hud__gauges {
+  align-items: center;
+  display: flex;
+  gap: clamp(0.3rem, 0.55vw, 0.62rem);
+}
+
+.game-session-hud .game-progress-ring {
+  --game-ring-size: clamp(3.4rem, 4.7vw, 4.55rem);
+
+  gap: 0.2rem;
+}
+
+.game-session-hud .game-progress-ring__label {
+  font-size: clamp(0.65rem, 0.68vw, 0.8rem);
+}
+
+.game-session-hud__tools {
+  gap: 0.55rem;
+}
+
+.game-session-hud__tools .inventory-slot {
+  min-height: clamp(3.5rem, 4.8vw, 4.5rem);
+  min-width: clamp(3.5rem, 4.8vw, 4.5rem);
+}
+
+@media (max-width: 1120px) {
+  .game-session-hud .game-hud-dock__content,
+  .game-session-hud[data-has-resource='false'] .game-hud-dock__content {
+    grid-template-columns: minmax(15rem, 20rem) auto auto;
+  }
+
+  .game-session-hud[data-has-gauges='false'] .game-hud-dock__content {
+    grid-template-columns: minmax(15rem, 20rem) auto;
+  }
+
+  .game-session-hud .resource-counter {
+    display: none;
+  }
+}
+
+@media (max-width: 880px) {
+  .game-session-hud .game-hud-dock__content,
+  .game-session-hud[data-has-gauges='false'] .game-hud-dock__content,
+  .game-session-hud[data-has-resource='false'] .game-hud-dock__content {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .game-session-hud__gauges {
+    justify-content: center;
+  }
+
+  .game-session-hud__tools {
+    justify-content: end;
+  }
+}
+
+@media (max-width: 620px) {
+  .game-session-hud .game-hud-dock__content,
+  .game-session-hud[data-has-gauges='false'] .game-hud-dock__content,
+  .game-session-hud[data-has-resource='false'] .game-hud-dock__content {
+    grid-template-columns: 1fr;
+  }
+
+  .game-session-hud__gauges {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(3.1rem, 1fr));
+    width: 100%;
+  }
+
+  .game-session-hud .game-progress-ring {
+    --game-ring-size: clamp(3.1rem, 16vw, 4rem);
+
+    min-width: 0;
+  }
+
+  .game-session-hud__tools {
+    justify-content: center;
+  }
+}

--- a/apps/frontend/src/features/game-session/hooks/use-game-session.ts
+++ b/apps/frontend/src/features/game-session/hooks/use-game-session.ts
@@ -27,6 +27,7 @@ export interface UseGameSessionResult<
   TWorldState,
   TResponse extends GameSessionResponse,
 > extends GameSessionState<TWorldState, TResponse> {
+  abandon: () => Promise<boolean>
   choose: (choice: GameSessionChoice) => void
   retry: () => void
   submitFreeAction: (action: string) => void
@@ -44,6 +45,7 @@ export function useGameSession<TWorldState, TResponse extends GameSessionRespons
   resumeHref,
 }: UseGameSessionOptions<TWorldState, TResponse>): UseGameSessionResult<TWorldState, TResponse> {
   const [state, setState] = useState<GameSessionState<TWorldState, TResponse>>({
+    ending: false,
     error: null,
     gameOver: false,
     inventory: [],
@@ -74,6 +76,7 @@ export function useGameSession<TWorldState, TResponse extends GameSessionRespons
       setState((current) => ({
         ...current,
         error: null,
+        ending: false,
         gameOver: response.scene.consequences?.gameOver === true,
         inventory: response.updatedInventory,
         limitReached: false,
@@ -93,11 +96,12 @@ export function useGameSession<TWorldState, TResponse extends GameSessionRespons
   const handleRequestError = useCallback((error: unknown) => {
     setState((current) => {
       if (error instanceof Error && error.message === 'Anonymous limit reached') {
-        return { ...current, limitReached: true, loading: false }
+        return { ...current, ending: false, limitReached: true, loading: false }
       }
 
       return {
         ...current,
+        ending: false,
         error: error instanceof Error ? error.message : 'The Game Master fell silent.',
         loading: false,
       }
@@ -210,5 +214,26 @@ export function useGameSession<TWorldState, TResponse extends GameSessionRespons
     else void openSession()
   }, [openSession, submitAction])
 
-  return { ...state, choose, retry, submitFreeAction }
+  const abandon = useCallback(async () => {
+    const sessionId = sessionIdRef.current
+    if (!sessionId || state.ending) return false
+
+    setState((current) => ({ ...current, ending: true, error: null }))
+    try {
+      await api.abandonSession(sessionId)
+      forgetActiveGameSession()
+      setState((current) => ({
+        ...current,
+        ending: false,
+        gameOver: true,
+        loading: false,
+      }))
+      return true
+    } catch (error) {
+      handleRequestError(error)
+      return false
+    }
+  }, [api, handleRequestError, state.ending])
+
+  return { ...state, abandon, choose, retry, submitFreeAction }
 }

--- a/apps/frontend/src/features/game-session/model/game-session.types.ts
+++ b/apps/frontend/src/features/game-session/model/game-session.types.ts
@@ -19,9 +19,14 @@ export interface GameSessionDiceRoll {
 }
 
 export interface GameSessionInventoryItem {
+  allowedActions?: ('use' | 'equip' | 'unequip' | 'inspect')[]
+  category?: 'equipment' | 'bag' | 'artifact' | 'heirloom' | 'key'
+  description?: string
+  equippedSlot?: string
   id: string
   name: string
   quantity: number
+  state?: 'ready' | 'locked' | 'pending'
 }
 
 export interface GameSessionNotification {
@@ -49,12 +54,18 @@ export interface GameSessionResponse {
   updatedStats: Record<string, number>
 }
 
+export interface GameSessionEndResponse {
+  endReason: 'inn' | 'abandon'
+  status: 'ended'
+}
+
 export interface PendingGameAction {
   choice?: GameSessionChoice
   freeAction?: string
 }
 
 export interface GameSessionApi<TResponse extends GameSessionResponse = GameSessionResponse> {
+  abandonSession: (sessionId: string) => Promise<GameSessionEndResponse>
   createSession: (locale: Locale) => Promise<TResponse>
   postGameAction: (input: {
     sessionId: string
@@ -70,6 +81,7 @@ export interface GameSessionState<
   TResponse extends GameSessionResponse = GameSessionResponse,
 > {
   error: string | null
+  ending: boolean
   gameOver: boolean
   inventory: GameSessionInventoryItem[]
   limitReached: boolean

--- a/docs/public/current-state/NEXT_ACTIONS.md
+++ b/docs/public/current-state/NEXT_ACTIONS.md
@@ -2,38 +2,37 @@
 type: actions
 visibility: public
 rag: true
-updated: 2026-07-16
+updated: 2026-07-17
 ---
 
 # Next Actions
 
 ## Immédiat
 
-1. **Finaliser #149** : valider la nouvelle architecture frontend multi-univers, les frontières
-   ESLint, les routes Velkhar inchangées et la boucle de session partagée.
+1. **Finaliser #134** : relire et livrer l’inventaire 8+12, la fiche personnage et le menu de
+   session accessibles, puis ouvrir la PR vers `develop`.
 
 ## EPIC frontend #123 — ordre recommandé
 
-2. [#134](https://github.com/AdamDjo/Grimoire-game/issues/134) — **Inventaire, fiche personnage et menu de session**.
-3. [#132](https://github.com/AdamDjo/Grimoire-game/issues/132) — **Fin de run et Chronique publique**.
-4. [#135](https://github.com/AdamDjo/Grimoire-game/issues/135) — **Auth complète et conversion anonyme**.
-5. [#136](https://github.com/AdamDjo/Grimoire-game/issues/136) — **Profil, Paramètres et confidentialité**.
-6. [#130](https://github.com/AdamDjo/Grimoire-game/issues/130), [#131](https://github.com/AdamDjo/Grimoire-game/issues/131), [#127](https://github.com/AdamDjo/Grimoire-game/issues/127), puis [#129](https://github.com/AdamDjo/Grimoire-game/issues/129).
+2. [#132](https://github.com/AdamDjo/Grimoire-game/issues/132) — **Fin de run et Chronique publique**.
+3. [#135](https://github.com/AdamDjo/Grimoire-game/issues/135) — **Auth complète et conversion anonyme**.
+4. [#136](https://github.com/AdamDjo/Grimoire-game/issues/136) — **Profil, Paramètres et confidentialité**.
+5. [#130](https://github.com/AdamDjo/Grimoire-game/issues/130), [#131](https://github.com/AdamDjo/Grimoire-game/issues/131), [#127](https://github.com/AdamDjo/Grimoire-game/issues/127), puis [#129](https://github.com/AdamDjo/Grimoire-game/issues/129).
 
 ## A3 — mémoire narrative, suite (après merge #111)
 
-7. [#114](https://github.com/AdamDjo/Grimoire-game/issues/114) — **pgvector / rappel sémantique** sur les `MemoryChunk`.
-8. [#117](https://github.com/AdamDjo/Grimoire-game/issues/117) — **World events (Level C)**, priorité basse (dépend du contenu design, pas du code).
+6. [#114](https://github.com/AdamDjo/Grimoire-game/issues/114) — **pgvector / rappel sémantique** sur les `MemoryChunk`.
+7. [#117](https://github.com/AdamDjo/Grimoire-game/issues/117) — **World events (Level C)**, priorité basse (dépend du contenu design, pas du code).
 
 ## Phase 1B — écrans restants
 
-9. **Backend Auberge de L'Aveugle** : remplacer les fixtures frontend de #126 par `aveugle.service.ts` et ses contrats API.
-10. **Écran Character Create (la Forge)** : 4 vocations + concept libre, peuples, attribution triptyque.
-11. **Écran World Map (Makhzen)** : carte désertique, régions, points d'intérêt.
+8. **Backend Auberge de L'Aveugle** : remplacer les fixtures frontend de #126 par `aveugle.service.ts` et ses contrats API.
+9. **Écran Character Create (la Forge)** : 4 vocations + concept libre, peuples, attribution triptyque.
+10. **Écran World Map (Makhzen)** : carte désertique, régions, points d'intérêt.
 
 ## Différé
 
-12. #101 — fallback chain multi-modèles OpenRouter (ouvert, non implémenté).
-13. Ticket dédié vulnérabilités Dependabot (3 critiques sur `develop`).
+11. #101 — fallback chain multi-modèles OpenRouter (ouvert, non implémenté).
+12. Ticket dédié vulnérabilités Dependabot (3 critiques sur `develop`).
 
 > Garde-fous produit inchangés : **Velkhar only**, MVP court (vertical slice 45-70 min), lore progressif, moat backend d'abord. Voir [[PHASE-1B-BACKLOG]].

--- a/docs/public/current-state/PROJECT_STATUS.md
+++ b/docs/public/current-state/PROJECT_STATUS.md
@@ -3,7 +3,7 @@ type: status
 visibility: public
 rag: true
 source_of_truth: true
-updated: 2026-07-16
+updated: 2026-07-17
 ---
 
 # Project Status
@@ -12,13 +12,16 @@ updated: 2026-07-16
 
 - Projet : **GRIMOIRE — Of Ash and Salt**
 - Phase actuelle : **Phase 1B — parcours frontend Velkhar** (EPIC #123), après livraison du moteur backend et de la mémoire narrative principale.
-- Branche active : `feature/149-multi-universe-frontend-architecture`.
-- Priorité active : réorganiser le frontend multi-univers sans changement fonctionnel, avec
-  Velkhar colocalisé sous `(game)`, une boucle de session partagée et des primitives UI sans canon.
-- Ordre recommandé ensuite : #134 inventaire/fiche/menu, puis #132 fin de run et Chronique.
+- Branche active : `feature/134-inventaire-fiche-menu`.
+- Priorité active : compléter Game Session avec la fiche personnage, l’inventaire canonique,
+  l’équipement et le menu accessible sans quitter la narration.
+- Ordre recommandé ensuite : #132 fin de run et Chronique, puis #135 auth complète.
 
 ## Livré récemment
 
+- **#149 — architecture frontend multi-univers** : ✅ mergée (PR #150 → `develop`). Velkhar
+  est colocalisé sous `(game)`, la boucle de session est partagée et les frontières ESLint
+  empêchent les dépendances inversées.
 - **#126 — Auberge de L’Aveugle** : ✅ mergée (PR #143 → `develop`). Deux flows distincts : seuil narratif avant création et hub immersif après création du personnage, fixé à `100dvh` sur desktop avec les espaces Parler, Souvenirs et Présage.
 - **#125 — Game Session pixel-perfect** : ✅ mergée (PR #148 → `develop`). Narration
   prioritaire, choix typés, action libre, dés et conséquences, HUD compact et panneaux de session.

--- a/docs/public/tech/FRONTEND_ARCHITECTURE.md
+++ b/docs/public/tech/FRONTEND_ARCHITECTURE.md
@@ -179,6 +179,23 @@ Velkhar injecte :
 
 Un futur monde peut réutiliser le contrôleur sans importer un type de personnage Velkhar.
 
+## HUD de session partagé
+
+`features/game-session/components/GameSessionHud.tsx` possède la structure responsive commune du
+footer de jeu. Il ne connaît aucun univers et reçoit uniquement quatre groupes de props :
+
+- `statusBars` : ressources principales sous forme de barres ;
+- `statusGauges` : états secondaires sous forme de jauges ;
+- `resource` : monnaie ou ressource ponctuelle, optionnelle ;
+- `tools` : raccourcis vers inventaire, fiche, menu ou outils propres à l’univers.
+
+Chaque monde conserve un adaptateur local. Par exemple, `VelkharSurvivalHud` transforme SANG,
+SOUFFLE, CENDRE, faim, soif, fatigue et Calamine en configuration de `GameSessionHud`. Un autre
+univers peut fournir PV, bouclier, stress et crédits sans importer le modèle de survie Velkhar.
+
+La structure, les breakpoints et l’accessibilité restent partagés. Les libellés, valeurs, icônes,
+tons, nombre de jauges et présence de la monnaie restent configurables par univers.
+
 ## Nommage
 
 - Composant partagé : `DiceRoll`, `GameWindow`, `NarrativePanel`.

--- a/packages/shared/src/types/scene.types.ts
+++ b/packages/shared/src/types/scene.types.ts
@@ -65,10 +65,30 @@ export interface SceneResponse {
 }
 
 export interface InventoryItemRef {
+  /** Actions explicitly authorized by the backend for the current scene. */
+  allowedActions?: InventoryItemAction[];
+  /** Generic placement hint. Worlds decide how categories map to their UI. */
+  category?: InventoryItemCategory;
+  description?: string;
+  /** Backend-owned equipment slot id, when the item is currently worn. */
+  equippedSlot?: string;
   id: string;
   name: string;
   quantity: number;
+  /** Transient availability supplied by the backend contract. */
+  state?: InventoryItemState;
 }
+
+export type InventoryItemAction = "use" | "equip" | "unequip" | "inspect";
+
+export type InventoryItemCategory =
+  | "equipment"
+  | "bag"
+  | "artifact"
+  | "heirloom"
+  | "key";
+
+export type InventoryItemState = "ready" | "locked" | "pending";
 
 export interface GameNotification {
   type:


### PR DESCRIPTION
## Summary
- ajoute la fiche personnage, l inventaire 8+12 et le menu de session accessible
- branche l abandon confirme sur le contrat backend existant
- mutualise le footer via un GameSessionHud configurable pour tous les univers
- met a jour les contrats et la documentation architecture

## Test plan
- [x] pnpm type-check
- [x] pnpm lint
- [x] 84 tests frontend
- [x] 102 tests backend
- [x] build Next.js
- [x] QA desktop 1440x900 et mobile 390x844

Closes #134