### PR TITLE
feat(frontend): construire la fin de run et la Chronique publique

### DIFF
--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.test.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.test.tsx
@@ -266,6 +266,6 @@ describe('VelkharSession', () => {
     await user.click(screen.getByRole('button', { name: 'Confirm abandon' }))
 
     await waitFor(() => expect(abandonSessionMock).toHaveBeenCalledWith('session-1'))
-    expect(await screen.findByText('This run has become a Chronicle')).toBeInTheDocument()
+    expect(await screen.findByText('Quelques pas, pas encore une Chronique')).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.tsx
@@ -13,6 +13,7 @@ import { LocationIdentity } from '@/components/ui/grimoire/LocationIdentity/Loca
 import { NarrativeComposer } from '@/components/ui/grimoire/NarrativeComposer/NarrativeComposer'
 import { PlayerIdentity } from '@/components/ui/grimoire/PlayerIdentity/PlayerIdentity'
 import { SoftSignupPrompt } from '@/features/auth/components/SoftSignupPrompt/SoftSignupPrompt'
+import { ChronicleEndExperience } from '@/features/chronicle/components/ChronicleEndExperience'
 import { gameSessionApi } from '@/features/game-session/api/game-session-api'
 import { ChoiceList } from '@/features/game-session/components/ChoiceList'
 import { ConsequenceList } from '@/features/game-session/components/ConsequenceList'
@@ -35,6 +36,7 @@ import type {
 } from '@grimoire/shared'
 
 import '../_theme/velkhar-session.css'
+import '@/features/chronicle/chronicle.css'
 
 interface VelkharSessionProps {
   initialCharacter: Character
@@ -198,14 +200,7 @@ export function VelkharSession({ initialCharacter, locale = 'en' }: VelkharSessi
                   </button>
                 </div>
               ) : session.gameOver ? (
-                <div className="velkhar-session__state" role="status">
-                  <GameIcon decorative name="book" size={48} />
-                  <h1>This run has become a Chronicle</h1>
-                  <p>The salt keeps what it takes. Your ending is ready to be remembered.</p>
-                  <Link href={`${VELKHAR_WORLD.routes.aveugle}?return=chronicle`}>
-                    Return with your Chronicle
-                  </Link>
-                </div>
+                <ChronicleEndExperience sessionId={session.sessionId} turnCount={session.turn} />
               ) : (
                 <>
                   <NarrativePanel narrative={narrative} loading={session.loading} />

--- a/apps/frontend/src/app/chronique/[slug]/ChroniclePublicPage.tsx
+++ b/apps/frontend/src/app/chronique/[slug]/ChroniclePublicPage.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import Link from 'next/link'
+
+import { ChronicleReader } from '@/features/chronicle/components/ChronicleReader'
+import { ChronicleState } from '@/features/chronicle/components/ChronicleState'
+import { useChronicle } from '@/features/chronicle/hooks/use-chronicle'
+
+interface ChroniclePublicPageProps {
+  slug: string
+}
+
+export function ChroniclePublicPage({ slug }: ChroniclePublicPageProps) {
+  const { chronicle, retry, status } = useChronicle({ kind: 'public', reference: slug })
+  const fallbackStatus = status === 'ready' ? 'loading' : status
+
+  return (
+    <main className="chronicle-page">
+      <nav className="chronicle-page__nav" aria-label="Navigation principale">
+        <Link href="/" aria-label="Accueil de Grimoire">
+          GRIMOIRE
+        </Link>
+        <span>Une trace de Velkhar</span>
+      </nav>
+      {status === 'ready' && chronicle ? (
+        <ChronicleReader chronicle={chronicle} />
+      ) : (
+        <ChronicleState status={fallbackStatus} onRetry={retry} />
+      )}
+    </main>
+  )
+}

--- a/apps/frontend/src/app/chronique/[slug]/page.tsx
+++ b/apps/frontend/src/app/chronique/[slug]/page.tsx
@@ -1,0 +1,38 @@
+import { ChroniclePublicPage } from './ChroniclePublicPage'
+
+import type { Metadata } from 'next'
+
+import '@/features/chronicle/chronicle.css'
+
+interface ChroniclePageProps {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: ChroniclePageProps): Promise<Metadata> {
+  const { slug } = await params
+  const canonical = `/chronique/${encodeURIComponent(slug)}`
+
+  return {
+    title: 'Une Chronique de Velkhar | GRIMOIRE',
+    description: 'Le récit d’une route parcourue dans Velkhar, conservé par le Grimoire.',
+    alternates: { canonical },
+    openGraph: {
+      title: 'Une Chronique de Velkhar',
+      description: 'Une trace laissée dans le monde de GRIMOIRE.',
+      images: [{ url: '/scenes/doigt-casse-session.webp', alt: 'Les cendres de Velkhar' }],
+      type: 'article',
+      url: canonical,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: 'Une Chronique de Velkhar',
+      description: 'Une trace laissée dans le monde de GRIMOIRE.',
+      images: ['/scenes/doigt-casse-session.webp'],
+    },
+  }
+}
+
+export default async function ChroniclePage({ params }: ChroniclePageProps) {
+  const { slug } = await params
+  return <ChroniclePublicPage slug={slug} />
+}

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -44,6 +44,7 @@ const caveat = Caveat({
 })
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://grimoire.game'),
   title: 'GRIMOIRE - Of Ash and Salt',
   description:
     'GRIMOIRE est un roguelike narratif par IA. Explore Velkhar, fais des choix libres, lance les des aux pivots et laisse une trace dans un monde qui se souvient.',

--- a/apps/frontend/src/features/chronicle/api/chronicle-api.test.ts
+++ b/apps/frontend/src/features/chronicle/api/chronicle-api.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getPublicChronicle, getSessionChronicle } from './chronicle-api'
+
+import type { ChronicleApiError } from './chronicle-api'
+
+const PRIVATE_CHRONICLE = {
+  id: 'chronicle-1',
+  userId: 'private-user',
+  characterId: 'private-character',
+  sessionId: 'private-session',
+  endReason: 'death',
+  title: 'Les cendres du puits',
+  bodyMarkdown: 'Le sel gardait le silence.',
+  mood: 'melancholic',
+  keyMoments: [{ label: 'Le puits', sceneRef: 2 }],
+  tagline: 'Toute route laisse une marque.',
+  createdAt: '2026-07-17T00:00:00.000Z',
+} as const
+
+describe('chronicle api', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('projette le contrat privé sans identité dans le lecteur de session', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ success: true, data: PRIVATE_CHRONICLE }), { status: 200 })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const chronicle = await getSessionChronicle('session/1')
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/chronicles/session/session%2F1', {
+      cache: 'no-store',
+    })
+    expect(chronicle).toEqual({
+      bodyMarkdown: PRIVATE_CHRONICLE.bodyMarkdown,
+      createdAt: PRIVATE_CHRONICLE.createdAt,
+      endReason: PRIVATE_CHRONICLE.endReason,
+      keyMoments: PRIVATE_CHRONICLE.keyMoments,
+      mood: PRIVATE_CHRONICLE.mood,
+      tagline: PRIVATE_CHRONICLE.tagline,
+      title: PRIVATE_CHRONICLE.title,
+    })
+    expect(chronicle).not.toHaveProperty('userId')
+    expect(chronicle).not.toHaveProperty('sessionId')
+  })
+
+  it('refuse une Chronique publique non publiée', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: { ...PRIVATE_CHRONICLE, published: false, slug: 'cendres-du-puits' },
+          }),
+          { status: 200 }
+        )
+      )
+    )
+
+    await expect(getPublicChronicle('cendres-du-puits')).rejects.toEqual(
+      expect.objectContaining<Partial<ChronicleApiError>>({ status: 404 })
+    )
+  })
+
+  it('normalise une publication partielle sans laisser passer de champs privés', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              bodyMarkdown: 'Une dernière empreinte dans le sel.',
+              published: true,
+              slug: 'derniere-empreinte',
+              userId: 'must-not-leak',
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    )
+
+    const chronicle = await getPublicChronicle('derniere-empreinte')
+
+    expect(chronicle.title).toBe('Une Chronique de Velkhar')
+    expect(chronicle.mood).toBe('melancholic')
+    expect(chronicle.keyMoments).toEqual([])
+    expect(chronicle).not.toHaveProperty('userId')
+  })
+
+  it('distingue une absence publique des erreurs réseau', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ success: false, error: 'Not found' }), { status: 404 })
+        )
+    )
+
+    await expect(getPublicChronicle('inconnue')).rejects.toEqual(
+      expect.objectContaining<Partial<ChronicleApiError>>({ status: 404 })
+    )
+  })
+})

--- a/apps/frontend/src/features/chronicle/api/chronicle-api.ts
+++ b/apps/frontend/src/features/chronicle/api/chronicle-api.ts
@@ -1,0 +1,86 @@
+import type { ChronicleView, PublicChroniclePayload } from '../model/chronicle.types'
+import type { ApiResponse, Chronicle } from '@grimoire/shared'
+
+const CHRONICLE_MOODS = new Set(['tragic', 'epic', 'melancholic', 'serene', 'absurd'])
+const END_REASONS = new Set(['death', 'inn', 'abandon'])
+
+function textOrFallback(value: string | undefined, fallback: string): string {
+  const normalized = value?.trim()
+  return normalized && normalized.length > 0 ? normalized : fallback
+}
+
+export class ChronicleApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message)
+    this.name = 'ChronicleApiError'
+  }
+}
+
+function normalizeChronicle(chronicle: Partial<ChronicleView>): ChronicleView {
+  if (!chronicle.bodyMarkdown?.trim()) {
+    throw new ChronicleApiError('Chronicle content incomplete', 422)
+  }
+
+  return {
+    bodyMarkdown: chronicle.bodyMarkdown,
+    createdAt: chronicle.createdAt ?? new Date(0).toISOString(),
+    endReason: END_REASONS.has(chronicle.endReason ?? '') ? chronicle.endReason! : 'death',
+    illustrationUrl: chronicle.illustrationUrl,
+    keyMoments: Array.isArray(chronicle.keyMoments) ? chronicle.keyMoments : [],
+    mood: CHRONICLE_MOODS.has(chronicle.mood ?? '') ? chronicle.mood! : 'melancholic',
+    slug: chronicle.slug,
+    tagline: textOrFallback(chronicle.tagline, 'Une trace demeure dans le sel.'),
+    title: textOrFallback(chronicle.title, 'Une Chronique de Velkhar'),
+  }
+}
+
+function toChronicleView(chronicle: Chronicle): ChronicleView {
+  return normalizeChronicle(chronicle)
+}
+
+async function readApiResponse<T>(response: Response): Promise<T> {
+  const body = (await response.json().catch(() => null)) as ApiResponse<T> | null
+  if (!response.ok || !body?.success || !body.data) {
+    throw new ChronicleApiError(body?.error ?? 'Chronicle unavailable', response.status)
+  }
+  return body.data
+}
+
+/** Existing authenticated #116 contract, used only during the end-of-run flow. */
+export async function getSessionChronicle(sessionId: string): Promise<ChronicleView> {
+  const response = await fetch(`/api/chronicles/session/${encodeURIComponent(sessionId)}`, {
+    cache: 'no-store',
+  })
+  return toChronicleView(await readApiResponse<Chronicle>(response))
+}
+
+/**
+ * Isolated future public contract for #132. The backend can implement this route
+ * without changing the reader or exposing Chronicle ownership fields.
+ */
+export async function getPublicChronicle(slug: string): Promise<ChronicleView> {
+  if (process.env.NODE_ENV === 'development' && slug === 'apercu') {
+    const { CHRONICLE_PREVIEW } = await import('../model/chronicle-preview')
+    return CHRONICLE_PREVIEW
+  }
+
+  const response = await fetch(`/api/chronicles/public/${encodeURIComponent(slug)}`, {
+    cache: 'no-store',
+  })
+  const chronicle = await readApiResponse<PublicChroniclePayload>(response)
+  if (!chronicle.published) throw new ChronicleApiError('Chronicle unpublished', 404)
+  return normalizeChronicle({
+    bodyMarkdown: chronicle.bodyMarkdown,
+    createdAt: chronicle.createdAt,
+    endReason: chronicle.endReason,
+    illustrationUrl: chronicle.illustrationUrl,
+    keyMoments: chronicle.keyMoments,
+    mood: chronicle.mood,
+    slug: chronicle.slug,
+    tagline: chronicle.tagline,
+    title: chronicle.title,
+  })
+}

--- a/apps/frontend/src/features/chronicle/chronicle.css
+++ b/apps/frontend/src/features/chronicle/chronicle.css
@@ -1,0 +1,392 @@
+.chronicle-page {
+  background:
+    radial-gradient(circle at 50% 12%, rgba(145, 102, 47, 0.14), transparent 28rem),
+    linear-gradient(180deg, #0c0906, #050403 42%, #090705);
+  color: var(--parchment);
+  min-height: 100dvh;
+  padding: 1.25rem clamp(1rem, 4vw, 3rem) 6rem;
+}
+
+.chronicle-page::before {
+  background-image: url('/landing/textures/grain.svg');
+  content: '';
+  inset: 0;
+  opacity: 0.045;
+  pointer-events: none;
+  position: fixed;
+}
+
+.chronicle-page__nav {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin: 0 auto clamp(3rem, 8vw, 7rem);
+  max-width: 72rem;
+  position: relative;
+}
+
+.chronicle-page__nav a {
+  color: var(--gold-light);
+  font-family: var(--font-game-display);
+  font-size: 0.9rem;
+  letter-spacing: 0.16em;
+}
+
+.chronicle-page__nav span {
+  color: var(--ink-2);
+  font-family: var(--font-game-ui);
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.chronicle-reader {
+  margin: 0 auto;
+  max-width: 54rem;
+  position: relative;
+}
+
+.chronicle-reader[data-inline='true'] {
+  background: rgba(7, 5, 3, 0.96);
+  border: 1px solid var(--border-gold);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.68);
+  max-height: min(82dvh, 60rem);
+  overflow-y: auto;
+  padding: clamp(1.35rem, 5vw, 4.5rem);
+  width: min(100%, 58rem);
+}
+
+.chronicle-reader__header {
+  margin: 0 auto clamp(2rem, 5vw, 4rem);
+  max-width: 48rem;
+  text-align: center;
+}
+
+.chronicle-reader__eyebrow {
+  color: var(--gold);
+  font-family: var(--font-game-ui);
+  font-size: 0.76rem;
+  letter-spacing: 0.13em;
+  margin: 0 0 1.25rem;
+  text-transform: uppercase;
+}
+
+.chronicle-reader__header h1 {
+  color: #f3e5c6;
+  font-family: var(--font-game-heading);
+  font-size: clamp(2.7rem, 7vw, 5.8rem);
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  line-height: 0.94;
+  margin: 0;
+  text-wrap: balance;
+}
+
+.chronicle-reader[data-inline='true'] .chronicle-reader__header h1 {
+  font-size: clamp(2.25rem, 5vw, 4rem);
+}
+
+.chronicle-reader__tagline {
+  color: var(--ink-2);
+  font-family: var(--font-game-heading);
+  font-size: clamp(1.2rem, 2.5vw, 1.65rem);
+  font-style: italic;
+  line-height: 1.4;
+  margin: 1.5rem auto 0;
+  max-width: 38rem;
+  text-wrap: balance;
+}
+
+.chronicle-reader__illustration {
+  align-items: center;
+  aspect-ratio: 16 / 8;
+  border-block: 1px solid color-mix(in srgb, var(--gold) 42%, transparent);
+  display: flex;
+  justify-content: center;
+  margin: 0 50% clamp(2.5rem, 7vw, 5rem);
+  overflow: hidden;
+  position: relative;
+  transform: translateX(-50%);
+  width: min(72rem, calc(100vw - 2rem));
+}
+
+.chronicle-reader[data-inline='true'] .chronicle-reader__illustration {
+  margin-inline: 0;
+  transform: none;
+  width: 100%;
+}
+
+.chronicle-reader__illustration img {
+  object-fit: cover;
+}
+
+.chronicle-reader__illustration span {
+  color: rgba(240, 212, 138, 0.36);
+  font-family: var(--font-game-display);
+  font-size: clamp(4rem, 12vw, 10rem);
+  text-shadow: 0 0 4rem currentColor;
+}
+
+.chronicle-reader__illustration[data-mood='tragic'] {
+  background: radial-gradient(circle at 50% 74%, #8b2e26 0, #26100e 22%, #050403 68%);
+}
+
+.chronicle-reader__illustration[data-mood='epic'] {
+  background: radial-gradient(circle at 55% 65%, #d19a39 0, #513217 24%, #080604 67%);
+}
+
+.chronicle-reader__illustration[data-mood='melancholic'] {
+  background: radial-gradient(ellipse at 58% 30%, #64717c 0, #252b30 25%, #070707 70%);
+}
+
+.chronicle-reader__illustration[data-mood='serene'] {
+  background: radial-gradient(ellipse at 50% 55%, #477c77 0, #172b29 28%, #050706 72%);
+}
+
+.chronicle-reader__illustration[data-mood='absurd'] {
+  background: conic-gradient(from 210deg at 52% 55%, #1a0f22, #805a2b, #213539, #1a0f22);
+}
+
+.chronicle-reader__moments {
+  border-block: 1px solid rgba(217, 164, 65, 0.18);
+  counter-reset: moments;
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  list-style: none;
+  margin: 0 0 clamp(2.5rem, 7vw, 5rem);
+  padding: 0;
+}
+
+.chronicle-reader__moments li {
+  color: var(--ink-2);
+  counter-increment: moments;
+  font-family: var(--font-game-ui);
+  font-size: 0.85rem;
+  line-height: 1.4;
+  padding: 1rem;
+}
+
+.chronicle-reader__moments li::before {
+  color: var(--gold);
+  content: '0' counter(moments) ' — ';
+  font-variant-numeric: tabular-nums;
+}
+
+.chronicle-body {
+  margin: 0 auto;
+  max-width: 42rem;
+}
+
+.chronicle-body p,
+.chronicle-body blockquote {
+  color: #dfd1b5;
+  font-family: var(--font-game-body);
+  font-size: clamp(1.18rem, 1.1vw + 0.9rem, 1.48rem);
+  line-height: 1.72;
+  margin: 0 0 1.5em;
+}
+
+.chronicle-body p:first-child::first-letter {
+  color: var(--gold-light);
+  float: left;
+  font-family: var(--font-game-display);
+  font-size: 4.6em;
+  line-height: 0.76;
+  padding: 0.09em 0.1em 0 0;
+}
+
+.chronicle-body h2,
+.chronicle-body h3 {
+  color: var(--gold-light);
+  font-family: var(--font-game-heading);
+  font-weight: 500;
+  margin: 2.2em 0 0.7em;
+  text-wrap: balance;
+}
+
+.chronicle-body h2 { font-size: clamp(1.8rem, 4vw, 2.6rem); }
+.chronicle-body h3 { font-size: clamp(1.45rem, 3vw, 2rem); }
+
+.chronicle-body blockquote {
+  border-left: 1px solid var(--gold);
+  color: var(--gold-light);
+  font-style: italic;
+  margin-inline: 0;
+  padding-left: clamp(1rem, 4vw, 2rem);
+}
+
+.chronicle-reader__footer {
+  border-top: 1px solid rgba(217, 164, 65, 0.22);
+  margin-top: clamp(3rem, 9vw, 7rem);
+  padding-top: 2rem;
+}
+
+.chronicle-share {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem 1.1rem;
+  justify-content: center;
+}
+
+.chronicle-share span {
+  color: var(--ink-2);
+  flex-basis: 100%;
+  font-family: var(--font-game-ui);
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.chronicle-share a,
+.chronicle-share button,
+.chronicle-state a,
+.chronicle-state button {
+  background: transparent;
+  border: 0;
+  color: var(--gold-light);
+  cursor: pointer;
+  font-family: var(--font-game-ui);
+  font-size: 0.9rem;
+  padding: 0.35rem;
+  text-decoration: underline;
+  text-decoration-color: rgba(217, 164, 65, 0.35);
+  text-underline-offset: 0.3em;
+}
+
+.chronicle-reader__after {
+  margin: clamp(3rem, 8vw, 6rem) auto 0;
+  text-align: center;
+}
+
+.chronicle-reader__after > p {
+  color: var(--parchment);
+  font-family: var(--font-game-heading);
+  font-size: 1.35rem;
+  font-style: italic;
+}
+
+.chronicle-reader__after nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-top: 1.4rem;
+}
+
+.chronicle-reader__after a {
+  border: 1px solid var(--border-gold);
+  color: var(--gold-light);
+  font-family: var(--font-game-ui);
+  padding: 0.7rem 1rem;
+  transition: background var(--motion-ui), border-color var(--motion-ui);
+}
+
+.chronicle-reader__after a:hover { background: rgba(217, 164, 65, 0.08); border-color: var(--gold); }
+
+.chronicle-reader__account-note {
+  color: var(--ink-2);
+  font-family: var(--font-game-ui);
+  font-size: 0.8rem;
+  margin: 2rem 0 0;
+  text-align: center;
+}
+
+.chronicle-reader__account-note a { color: var(--gold-light); text-decoration: underline; }
+
+.chronicle-state,
+.chronicle-transition {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: auto;
+  min-height: min(70dvh, 42rem);
+  padding: 2rem;
+  text-align: center;
+}
+
+.chronicle-state__mark {
+  color: rgba(217, 164, 65, 0.42);
+  font-family: var(--font-game-display);
+  font-size: 4rem;
+}
+
+.chronicle-state h1 {
+  color: var(--gold-light);
+  font-family: var(--font-game-heading);
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  font-weight: 500;
+  margin: 0.5rem 0;
+}
+
+.chronicle-state p {
+  color: var(--ink-2);
+  font-family: var(--font-game-body);
+  font-size: 1.15rem;
+  line-height: 1.6;
+  max-width: 36rem;
+}
+
+.chronicle-state__progress {
+  background: rgba(217, 164, 65, 0.16);
+  height: 1px;
+  margin-top: 2rem;
+  overflow: hidden;
+  position: relative;
+  width: min(18rem, 70vw);
+}
+
+.chronicle-state__progress::after {
+  animation: chronicle-writing 1.8s ease-in-out infinite;
+  background: var(--gold-light);
+  content: '';
+  inset: 0;
+  position: absolute;
+  transform: translateX(-100%);
+}
+
+@keyframes chronicle-writing { 50%, 100% { transform: translateX(100%); } }
+
+.chronicle-transition {
+  background: #050403;
+  inset: 0;
+  min-height: 100dvh;
+  position: fixed;
+  z-index: 80;
+}
+
+.chronicle-transition span {
+  animation: chronicle-mark 2.4s var(--ease-grimoire-out) both;
+  background: var(--gold);
+  height: 1px;
+  margin-bottom: 2rem;
+  width: min(16rem, 60vw);
+}
+
+.chronicle-transition p {
+  animation: chronicle-copy 2.4s var(--ease-grimoire-out) both;
+  color: var(--parchment);
+  font-family: var(--font-game-heading);
+  font-size: clamp(1.8rem, 5vw, 3.2rem);
+  font-style: italic;
+}
+
+@keyframes chronicle-mark { from { opacity: 0; scale: 0 1; } 45% { opacity: 1; scale: 1; } to { opacity: 0.35; } }
+@keyframes chronicle-copy { from { opacity: 0; translate: 0 0.6rem; } 40%, 80% { opacity: 1; translate: 0; } to { opacity: 0; } }
+
+@media (max-width: 640px) {
+  .chronicle-page__nav span { display: none; }
+  .chronicle-reader__moments { grid-template-columns: 1fr; }
+  .chronicle-reader__moments li + li { border-top: 1px solid rgba(217, 164, 65, 0.12); }
+  .chronicle-reader__after nav { align-items: stretch; flex-direction: column; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chronicle-state__progress::after,
+  .chronicle-transition p,
+  .chronicle-transition span { animation: none; }
+}
+

--- a/apps/frontend/src/features/chronicle/components/ChronicleBody.tsx
+++ b/apps/frontend/src/features/chronicle/components/ChronicleBody.tsx
@@ -1,0 +1,22 @@
+interface ChronicleBodyProps {
+  markdown: string
+}
+
+/** Deliberately small, safe renderer for the prose-only Chronicle contract. */
+export function ChronicleBody({ markdown }: ChronicleBodyProps) {
+  const blocks = markdown
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter(Boolean)
+
+  return (
+    <div className="chronicle-body">
+      {blocks.map((block, index) => {
+        if (block.startsWith('### ')) return <h3 key={index}>{block.slice(4)}</h3>
+        if (block.startsWith('## ')) return <h2 key={index}>{block.slice(3)}</h2>
+        if (block.startsWith('> ')) return <blockquote key={index}>{block.slice(2)}</blockquote>
+        return <p key={index}>{block.replaceAll('\n', ' ')}</p>
+      })}
+    </div>
+  )
+}

--- a/apps/frontend/src/features/chronicle/components/ChronicleEndExperience.tsx
+++ b/apps/frontend/src/features/chronicle/components/ChronicleEndExperience.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { useChronicle } from '../hooks/use-chronicle'
+
+import { ChronicleReader } from './ChronicleReader'
+import { ChronicleState } from './ChronicleState'
+
+interface ChronicleEndExperienceProps {
+  sessionId: string | null
+  turnCount: number
+}
+
+export function ChronicleEndExperience({ sessionId, turnCount }: ChronicleEndExperienceProps) {
+  const [transitionComplete, setTransitionComplete] = useState(false)
+  const { chronicle, retry, status } = useChronicle({
+    kind: 'session',
+    reference: sessionId,
+    tooShort: turnCount < 5,
+  })
+
+  useEffect(() => {
+    const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+    const timeout = window.setTimeout(() => setTransitionComplete(true), reducedMotion ? 0 : 2400)
+    return () => window.clearTimeout(timeout)
+  }, [])
+
+  if (!transitionComplete) {
+    return (
+      <section className="chronicle-transition" role="status" aria-live="polite">
+        <span aria-hidden="true" />
+        <p>Ton aventure prend fin…</p>
+      </section>
+    )
+  }
+
+  if (status === 'ready' && chronicle) return <ChronicleReader chronicle={chronicle} inline />
+  const fallbackStatus = status === 'ready' ? 'loading' : status
+  return <ChronicleState status={fallbackStatus} onRetry={retry} />
+}

--- a/apps/frontend/src/features/chronicle/components/ChronicleReader.test.tsx
+++ b/apps/frontend/src/features/chronicle/components/ChronicleReader.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ChronicleReader } from './ChronicleReader'
+
+import type { ChronicleView } from '../model/chronicle.types'
+
+const CHRONICLE: ChronicleView = {
+  bodyMarkdown:
+    'Le sel gardait le silence.\n\n## Le dernier seuil\n\n> Personne ne revient intact.',
+  createdAt: '2026-07-17T00:00:00.000Z',
+  endReason: 'death',
+  keyMoments: [{ label: 'Le puits sans fond', sceneRef: 3 }],
+  mood: 'melancholic',
+  slug: 'les-cendres-du-puits',
+  tagline: 'Toute route laisse une marque.',
+  title: 'Les cendres du puits',
+}
+
+describe('ChronicleReader', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('rend la hiérarchie éditoriale, le fallback d’ambiance et les sorties', () => {
+    render(<ChronicleReader chronicle={CHRONICLE} />)
+
+    expect(screen.getByRole('heading', { level: 1, name: CHRONICLE.title })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: 'Le dernier seuil' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('img', { name: 'Illustration mélancolique de Velkhar' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('list', { name: 'Moments marquants' })).toHaveTextContent(
+      'Le puits sans fond'
+    )
+    expect(screen.getByRole('link', { name: 'Revenir à l’Aveugle' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Créer un nouveau personnage' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Retrouver mes traces' })).toBeInTheDocument()
+  })
+
+  it('copie le lien public avec un retour explicite', async () => {
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+    render(<ChronicleReader chronicle={CHRONICLE} />)
+
+    await user.click(screen.getByRole('button', { name: 'Copier le lien' }))
+
+    expect(writeText).toHaveBeenCalledWith(window.location.href)
+    expect(screen.getByRole('button', { name: 'Lien copié' })).toBeInTheDocument()
+  })
+
+  it('ne propose pas de partage inline avant attribution du slug public', () => {
+    render(<ChronicleReader chronicle={{ ...CHRONICLE, slug: undefined }} inline />)
+
+    expect(screen.queryByLabelText('Partager cette Chronique')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Garder cette trace gratuitement' })
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/features/chronicle/components/ChronicleReader.tsx
+++ b/apps/frontend/src/features/chronicle/components/ChronicleReader.tsx
@@ -1,0 +1,85 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+import { ChronicleBody } from './ChronicleBody'
+import { ChronicleShare } from './ChronicleShare'
+
+import type { ChronicleView } from '../model/chronicle.types'
+
+interface ChronicleReaderProps {
+  chronicle: ChronicleView
+  inline?: boolean
+}
+
+const MOOD_LABELS: Record<ChronicleView['mood'], string> = {
+  absurd: 'Étrange',
+  epic: 'Épique',
+  melancholic: 'Mélancolique',
+  serene: 'Sereine',
+  tragic: 'Tragique',
+}
+
+export function ChronicleReader({ chronicle, inline = false }: ChronicleReaderProps) {
+  return (
+    <article className="chronicle-reader" data-inline={inline} data-mood={chronicle.mood}>
+      <header className="chronicle-reader__header">
+        <p className="chronicle-reader__eyebrow">
+          Chronique de Velkhar · {MOOD_LABELS[chronicle.mood]}
+        </p>
+        <h1>{chronicle.title}</h1>
+        <p className="chronicle-reader__tagline">{chronicle.tagline}</p>
+      </header>
+
+      <div
+        className="chronicle-reader__illustration"
+        data-mood={chronicle.mood}
+        role={chronicle.illustrationUrl ? undefined : 'img'}
+        aria-label={
+          chronicle.illustrationUrl
+            ? undefined
+            : `Illustration ${MOOD_LABELS[chronicle.mood].toLowerCase()} de Velkhar`
+        }
+      >
+        {chronicle.illustrationUrl ? (
+          <Image
+            alt=""
+            fill
+            priority
+            sizes="(max-width: 760px) 100vw, 860px"
+            src={chronicle.illustrationUrl}
+          />
+        ) : (
+          <span aria-hidden="true">V</span>
+        )}
+      </div>
+
+      {chronicle.keyMoments.length > 0 ? (
+        <ol className="chronicle-reader__moments" aria-label="Moments marquants">
+          {chronicle.keyMoments.slice(0, 4).map((moment) => (
+            <li key={`${moment.sceneRef}-${moment.label}`}>{moment.label}</li>
+          ))}
+        </ol>
+      ) : null}
+
+      <ChronicleBody markdown={chronicle.bodyMarkdown} />
+
+      <footer className="chronicle-reader__footer">
+        {!inline || chronicle.slug ? <ChronicleShare title={chronicle.title} /> : null}
+        <div className="chronicle-reader__after">
+          <p>La route s’arrête ici. La trace, elle, demeure.</p>
+          <nav aria-label="Après la Chronique">
+            <Link href="/velkhar/aveugle?return=chronicle">Revenir à l’Aveugle</Link>
+            <Link href="/velkhar/character-create">Créer un nouveau personnage</Link>
+            <Link href="/dashboard">Retrouver mes traces</Link>
+          </nav>
+        </div>
+        {inline ? (
+          <p className="chronicle-reader__account-note">
+            Joueur anonyme ?{' '}
+            <Link href="/signup?return=chronicle">Garder cette trace gratuitement</Link>
+          </p>
+        ) : null}
+      </footer>
+    </article>
+  )
+}

--- a/apps/frontend/src/features/chronicle/components/ChronicleShare.tsx
+++ b/apps/frontend/src/features/chronicle/components/ChronicleShare.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface ChronicleShareProps {
+  title: string
+}
+
+export function ChronicleShare({ title }: ChronicleShareProps) {
+  const [copied, setCopied] = useState(false)
+  const [currentUrl, setCurrentUrl] = useState('')
+  const shareText = `Ma Chronique de Velkhar — ${title}`
+  const encodedUrl = encodeURIComponent(currentUrl)
+  const encodedText = encodeURIComponent(shareText)
+
+  useEffect(() => setCurrentUrl(window.location.href), [])
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(currentUrl)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1800)
+    } catch {
+      setCopied(false)
+    }
+  }
+
+  return (
+    <div className="chronicle-share" aria-label="Partager cette Chronique">
+      <span>Partager la trace</span>
+      <button type="button" onClick={() => void copyLink()}>
+        {copied ? 'Lien copié' : 'Copier le lien'}
+      </button>
+      <a
+        href={`https://x.com/intent/post?text=${encodedText}&url=${encodedUrl}`}
+        rel="noreferrer"
+        target="_blank"
+      >
+        X
+      </a>
+      <a
+        href={`https://bsky.app/intent/compose?text=${encodedText}%20${encodedUrl}`}
+        rel="noreferrer"
+        target="_blank"
+      >
+        Bluesky
+      </a>
+      <a
+        href={`mailto:rgpd@grimoire.game?subject=${encodeURIComponent(`Signalement de Chronique — ${title}`)}`}
+      >
+        Signaler
+      </a>
+    </div>
+  )
+}

--- a/apps/frontend/src/features/chronicle/components/ChronicleState.tsx
+++ b/apps/frontend/src/features/chronicle/components/ChronicleState.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link'
+
+import type { ChronicleAvailability } from '../model/chronicle.types'
+
+interface ChronicleStateProps {
+  onRetry: () => void
+  status: Exclude<ChronicleAvailability, 'ready'>
+}
+
+const COPY = {
+  error: {
+    title: 'L’encre s’est interrompue',
+    body: 'La Chronique n’a pas pu être chargée. Ta fin de partie est conservée.',
+  },
+  loading: {
+    title: 'Le Grimoire rassemble tes traces',
+    body: 'Les choix, les blessures et les rencontres deviennent un dernier récit. Cela peut prendre quelques instants.',
+  },
+  'too-short': {
+    title: 'Quelques pas, pas encore une Chronique',
+    body: 'Cette route fut trop brève pour former un récit, mais sa fin compte malgré tout.',
+  },
+  unavailable: {
+    title: 'Cette Chronique demeure introuvable',
+    body: 'Elle est peut-être encore en train de s’écrire, privée, ou retirée du Grimoire.',
+  },
+} as const
+
+export function ChronicleState({ onRetry, status }: ChronicleStateProps) {
+  const copy = COPY[status]
+  return (
+    <section
+      className="chronicle-state"
+      aria-live="polite"
+      role={status === 'error' ? 'alert' : 'status'}
+    >
+      <span className="chronicle-state__mark" aria-hidden="true">
+        V
+      </span>
+      <h1>{copy.title}</h1>
+      <p>{copy.body}</p>
+      {status === 'loading' ? (
+        <div className="chronicle-state__progress" aria-hidden="true" />
+      ) : null}
+      {status === 'error' || status === 'unavailable' ? (
+        <button type="button" onClick={onRetry}>
+          Réessayer
+        </button>
+      ) : null}
+      {status !== 'loading' ? (
+        <Link href="/velkhar/aveugle?return=chronicle">Revenir à l’Aveugle</Link>
+      ) : null}
+    </section>
+  )
+}

--- a/apps/frontend/src/features/chronicle/hooks/use-chronicle.ts
+++ b/apps/frontend/src/features/chronicle/hooks/use-chronicle.ts
@@ -1,0 +1,81 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+import { ChronicleApiError, getPublicChronicle, getSessionChronicle } from '../api/chronicle-api'
+
+import type { ChronicleAvailability, ChronicleView } from '../model/chronicle.types'
+
+const POLL_DELAY_MS = 2500
+const MAX_SESSION_POLLS = 12
+
+interface UseChronicleOptions {
+  kind: 'public' | 'session'
+  reference: string | null
+  tooShort?: boolean
+}
+
+interface UseChronicleResult {
+  chronicle: ChronicleView | null
+  retry: () => void
+  status: ChronicleAvailability
+}
+
+export function useChronicle({
+  kind,
+  reference,
+  tooShort = false,
+}: UseChronicleOptions): UseChronicleResult {
+  const [attempt, setAttempt] = useState(0)
+  const [chronicle, setChronicle] = useState<ChronicleView | null>(null)
+  const [status, setStatus] = useState<ChronicleAvailability>(tooShort ? 'too-short' : 'loading')
+
+  const retry = useCallback(() => {
+    setChronicle(null)
+    setStatus(tooShort ? 'too-short' : 'loading')
+    setAttempt((current) => current + 1)
+  }, [tooShort])
+
+  useEffect(() => {
+    if (tooShort) {
+      setStatus('too-short')
+      return
+    }
+    if (!reference) {
+      setStatus('error')
+      return
+    }
+
+    let cancelled = false
+    let timeout: ReturnType<typeof setTimeout> | undefined
+
+    const load = async (poll = 0) => {
+      try {
+        const result =
+          kind === 'session'
+            ? await getSessionChronicle(reference)
+            : await getPublicChronicle(reference)
+        if (cancelled) return
+        setChronicle(result)
+        setStatus('ready')
+      } catch (error) {
+        if (cancelled) return
+        const notFound = error instanceof ChronicleApiError && error.status === 404
+        if (kind === 'session' && notFound && poll < MAX_SESSION_POLLS) {
+          timeout = setTimeout(() => void load(poll + 1), POLL_DELAY_MS)
+          return
+        }
+        setStatus(notFound ? 'unavailable' : 'error')
+      }
+    }
+
+    setStatus('loading')
+    void load()
+    return () => {
+      cancelled = true
+      if (timeout) clearTimeout(timeout)
+    }
+  }, [attempt, kind, reference, tooShort])
+
+  return { chronicle, retry, status }
+}

--- a/apps/frontend/src/features/chronicle/model/chronicle-preview.ts
+++ b/apps/frontend/src/features/chronicle/model/chronicle-preview.ts
@@ -1,0 +1,42 @@
+import type { ChronicleView } from './chronicle.types'
+
+/** Local design fixture. It is reachable only through the development-only adapter guard. */
+export const CHRONICLE_PREVIEW: ChronicleView = {
+  bodyMarkdown: `Le vent avait effacé la route derrière Yarel avant même qu’il comprenne qu’il ne la reprendrait jamais. Devant lui, les pierres du puits sortaient du sel comme les dents d’une bête morte. Il marcha pourtant. Les Sahelins apprennent tôt que l’immobilité tue plus sûrement que la soif, et Yarel avait passé sa vie à avancer quand les autres cherchaient un abri.
+
+La première nuit, il partagea son eau avec une inconnue qui refusait de donner son nom. Elle portait autour du poignet un fil rouge, couleur interdite sous les lunes de Velkhar. Au matin, elle avait disparu. À sa place reposait une pièce de fer noir, encore chaude, marquée d’un œil fermé.
+
+## Là où le sel écoute
+
+Au troisième jour, la Calamine commença à parler avec la voix de ceux qu’il avait laissés derrière lui. Elle ne criait pas. Elle murmurait des souvenirs exacts : l’odeur du pain brûlé dans la maison de sa mère, le poids d’une main sur son épaule, la promesse faite à un frère qui n’avait jamais existé. Yarel serra la pièce jusqu’au sang et poursuivit vers les tours noyées de Tissan.
+
+Dans les ruines, il trouva le veilleur Ors, assis devant une porte sans mur. Le vieil homme connaissait son nom. Il connaissait aussi celui de l’inconnue au fil rouge, mais demanda un souvenir en échange. Yarel offrit le visage de son père. Le marché fut conclu sans lumière ni témoin. Quand la porte s’ouvrit, il ne sut plus pourquoi cette perte lui faisait mal.
+
+De l’autre côté attendait une salle pleine de pluie. L’eau tombait vers le plafond et chaque goutte contenait une scène possible : Yarel rentrant chez lui, Yarel couronné dans une cité étrangère, Yarel mort sous un ciel sans lune. Au centre, l’inconnue tenait une lampe de verre. Elle lui demanda de choisir une vie et d’abandonner toutes les autres.
+
+> Certaines portes ne s’ouvrent qu’une fois. Certaines dettes aussi.
+
+Yarel refusa. Il brisa la lampe avec la pièce de fer noir. Toutes les pluies tombèrent en même temps. La tour trembla, les images éclatèrent, et la Calamine entra en lui comme une marée froide. Il courut tandis que Tissan s’effondrait autour de ses pas. Ors riait quelque part derrière la pierre, ou peut-être était-ce seulement le vent.
+
+Il atteignit le puits au lever du jour. L’inconnue l’y attendait encore, débarrassée de son fil rouge. Elle lui tendit une gourde et Yarel comprit enfin : elle n’avait jamais cherché à le sauver. Elle voulait savoir combien de routes un homme pouvait perdre avant de ne plus reconnaître celle qui le ramenait à lui-même.
+
+Yarel but. L’eau avait le goût du fer et des choses oubliées. Quand il releva les yeux, le désert était vide. Sa vocation de Marcheur du Sel ne signifiait plus rien, sinon cette obstination ancienne : poser un pied devant l’autre jusqu’à ce que le monde cède ou que le corps refuse.
+
+Il fit encore sept pas. Le huitième resta suspendu au-dessus du sel.
+
+Bien plus tard, des voyageurs trouvèrent près du puits une pièce noire, un fil rouge et une suite d’empreintes qui s’arrêtait sans chute ni retour. Aucun corps. Aucun nom. Seulement la certitude qu’un homme avait marché jusque-là pour refuser la vie qu’on voulait choisir à sa place.
+
+Velkhar conserva le reste.`,
+  createdAt: '2026-07-17T00:00:00.000Z',
+  endReason: 'death',
+  keyMoments: [
+    { label: 'La pièce à l’œil fermé', sceneRef: 2 },
+    { label: 'Le marché du veilleur Ors', sceneRef: 6 },
+    { label: 'La lampe des vies possibles', sceneRef: 9 },
+    { label: 'Sept pas après le puits', sceneRef: 12 },
+  ],
+  mood: 'melancholic',
+  slug: 'apercu',
+  tagline: 'Certaines routes refusent le retour.',
+  title: 'Le huitième pas',
+}

--- a/apps/frontend/src/features/chronicle/model/chronicle.types.ts
+++ b/apps/frontend/src/features/chronicle/model/chronicle.types.ts
@@ -1,0 +1,20 @@
+import type { ChronicleEndReason, ChronicleKeyMoment, ChronicleMood } from '@grimoire/shared'
+
+export type ChronicleAvailability = 'loading' | 'ready' | 'too-short' | 'unavailable' | 'error'
+
+/** Public-safe projection. Identity and ownership fields never reach the reading UI. */
+export interface ChronicleView {
+  bodyMarkdown: string
+  createdAt: string
+  endReason: ChronicleEndReason
+  illustrationUrl?: string
+  keyMoments: ChronicleKeyMoment[]
+  mood: ChronicleMood
+  slug?: string
+  tagline: string
+  title: string
+}
+
+export interface PublicChroniclePayload extends ChronicleView {
+  published: boolean
+}

--- a/apps/frontend/src/features/game-session/hooks/use-game-session.ts
+++ b/apps/frontend/src/features/game-session/hooks/use-game-session.ts
@@ -45,6 +45,7 @@ export function useGameSession<TWorldState, TResponse extends GameSessionRespons
   resumeHref,
 }: UseGameSessionOptions<TWorldState, TResponse>): UseGameSessionResult<TWorldState, TResponse> {
   const [state, setState] = useState<GameSessionState<TWorldState, TResponse>>({
+    endReason: null,
     ending: false,
     error: null,
     gameOver: false,
@@ -55,6 +56,7 @@ export function useGameSession<TWorldState, TResponse extends GameSessionRespons
     roll: null,
     response: null,
     scene: null,
+    sessionId: null,
     selectedChoiceId: null,
     source: undefined,
     turn: 0,
@@ -77,6 +79,7 @@ export function useGameSession<TWorldState, TResponse extends GameSessionRespons
         ...current,
         error: null,
         ending: false,
+        endReason: response.scene.consequences?.gameOver === true ? 'death' : null,
         gameOver: response.scene.consequences?.gameOver === true,
         inventory: response.updatedInventory,
         limitReached: false,
@@ -84,6 +87,7 @@ export function useGameSession<TWorldState, TResponse extends GameSessionRespons
         roll: response.diceRoll ?? null,
         response,
         scene: response.scene,
+        sessionId: response.scene.sessionId,
         selectedChoiceId: null,
         source: response.source,
         turn: current.turn + 1,
@@ -225,6 +229,7 @@ export function useGameSession<TWorldState, TResponse extends GameSessionRespons
       setState((current) => ({
         ...current,
         ending: false,
+        endReason: 'abandon',
         gameOver: true,
         loading: false,
       }))

--- a/apps/frontend/src/features/game-session/model/game-session.types.ts
+++ b/apps/frontend/src/features/game-session/model/game-session.types.ts
@@ -80,6 +80,7 @@ export interface GameSessionState<
   TWorldState,
   TResponse extends GameSessionResponse = GameSessionResponse,
 > {
+  endReason: 'death' | 'inn' | 'abandon' | null
   error: string | null
   ending: boolean
   gameOver: boolean
@@ -90,6 +91,7 @@ export interface GameSessionState<
   response: TResponse | null
   roll: GameSessionDiceRoll | null
   scene: TResponse['scene'] | null
+  sessionId: string | null
   selectedChoiceId: string | null
   source?: GameSessionResponse['source']
   turn: number

--- a/docs/public/current-state/NEXT_ACTIONS.md
+++ b/docs/public/current-state/NEXT_ACTIONS.md
@@ -9,30 +9,29 @@ updated: 2026-07-17
 
 ## Immédiat
 
-1. **Finaliser #134** : relire et livrer l’inventaire 8+12, la fiche personnage et le menu de
-   session accessibles, puis ouvrir la PR vers `develop`.
+1. **Finaliser #132** : relire et livrer la fin de run, l’attente de génération et le lecteur de
+   Chronique public, puis ouvrir la PR vers `develop`.
 
 ## EPIC frontend #123 — ordre recommandé
 
-2. [#132](https://github.com/AdamDjo/Grimoire-game/issues/132) — **Fin de run et Chronique publique**.
-3. [#135](https://github.com/AdamDjo/Grimoire-game/issues/135) — **Auth complète et conversion anonyme**.
-4. [#136](https://github.com/AdamDjo/Grimoire-game/issues/136) — **Profil, Paramètres et confidentialité**.
-5. [#130](https://github.com/AdamDjo/Grimoire-game/issues/130), [#131](https://github.com/AdamDjo/Grimoire-game/issues/131), [#127](https://github.com/AdamDjo/Grimoire-game/issues/127), puis [#129](https://github.com/AdamDjo/Grimoire-game/issues/129).
+2. [#135](https://github.com/AdamDjo/Grimoire-game/issues/135) — **Auth complète et conversion anonyme**.
+3. [#136](https://github.com/AdamDjo/Grimoire-game/issues/136) — **Profil, Paramètres et confidentialité**.
+4. [#130](https://github.com/AdamDjo/Grimoire-game/issues/130), [#131](https://github.com/AdamDjo/Grimoire-game/issues/131), [#127](https://github.com/AdamDjo/Grimoire-game/issues/127), puis [#129](https://github.com/AdamDjo/Grimoire-game/issues/129).
 
 ## A3 — mémoire narrative, suite (après merge #111)
 
-6. [#114](https://github.com/AdamDjo/Grimoire-game/issues/114) — **pgvector / rappel sémantique** sur les `MemoryChunk`.
-7. [#117](https://github.com/AdamDjo/Grimoire-game/issues/117) — **World events (Level C)**, priorité basse (dépend du contenu design, pas du code).
+5. [#114](https://github.com/AdamDjo/Grimoire-game/issues/114) — **pgvector / rappel sémantique** sur les `MemoryChunk`.
+6. [#117](https://github.com/AdamDjo/Grimoire-game/issues/117) — **World events (Level C)**, priorité basse (dépend du contenu design, pas du code).
 
 ## Phase 1B — écrans restants
 
-8. **Backend Auberge de L'Aveugle** : remplacer les fixtures frontend de #126 par `aveugle.service.ts` et ses contrats API.
-9. **Écran Character Create (la Forge)** : 4 vocations + concept libre, peuples, attribution triptyque.
-10. **Écran World Map (Makhzen)** : carte désertique, régions, points d'intérêt.
+7. **Backend Auberge de L'Aveugle** : remplacer les fixtures frontend de #126 par `aveugle.service.ts` et ses contrats API.
+8. **Écran Character Create (la Forge)** : 4 vocations + concept libre, peuples, attribution triptyque.
+9. **Écran World Map (Makhzen)** : carte désertique, régions, points d'intérêt.
 
 ## Différé
 
-11. #101 — fallback chain multi-modèles OpenRouter (ouvert, non implémenté).
-12. Ticket dédié vulnérabilités Dependabot (3 critiques sur `develop`).
+10. #101 — fallback chain multi-modèles OpenRouter (ouvert, non implémenté).
+11. Ticket dédié vulnérabilités Dependabot (3 critiques sur `develop`).
 
 > Garde-fous produit inchangés : **Velkhar only**, MVP court (vertical slice 45-70 min), lore progressif, moat backend d'abord. Voir [[PHASE-1B-BACKLOG]].

--- a/docs/public/current-state/PROJECT_STATUS.md
+++ b/docs/public/current-state/PROJECT_STATUS.md
@@ -12,13 +12,16 @@ updated: 2026-07-17
 
 - Projet : **GRIMOIRE — Of Ash and Salt**
 - Phase actuelle : **Phase 1B — parcours frontend Velkhar** (EPIC #123), après livraison du moteur backend et de la mémoire narrative principale.
-- Branche active : `feature/134-inventaire-fiche-menu`.
-- Priorité active : compléter Game Session avec la fiche personnage, l’inventaire canonique,
-  l’équipement et le menu accessible sans quitter la narration.
-- Ordre recommandé ensuite : #132 fin de run et Chronique, puis #135 auth complète.
+- Branche active : `feature/132-fin-run-chronique`.
+- Priorité active : compléter la fin de run, l’attente de génération et le lecteur public de
+  Chronique sans introduire de dépendance au futur contrat de publication backend.
+- Ordre recommandé ensuite : #135 auth complète, puis #136 profil et confidentialité.
 
 ## Livré récemment
 
+- **#134 — inventaire, fiche et menu de session** : ✅ mergée (PR #153 → `develop`). Le HUD
+  multi-univers partage désormais ses jauges, ressources, inventaire rapide et commandes, tandis
+  que Velkhar injecte ses statistiques et son équipement canonique 8+12.
 - **#149 — architecture frontend multi-univers** : ✅ mergée (PR #150 → `develop`). Velkhar
   est colocalisé sous `(game)`, la boucle de session est partagée et les frontières ESLint
   empêchent les dépendances inversées.


### PR DESCRIPTION
## Summary

- add the end-of-run transition and Chronicle generation states, including retry and too-short runs
- add a public-safe frontend adapter plus the editorial inline/public Chronicle reader
- add five mood fallbacks, sharing, reporting, social metadata, post-run choices, and a development preview
- keep the future public slug endpoint isolated from the existing private Chronicle contract

## Test plan

- [x] monorepo type-check passes
- [x] monorepo lint passes
- [x] 91 frontend tests pass
- [x] Next.js production build passes
- [x] tested locally on desktop and mobile

Closes #132