### PR TITLE
feat(auth): convertir les sessions anonymes

### DIFF
--- a/apps/frontend/src/app/(auth)/_components/AuthAccessForm.tsx
+++ b/apps/frontend/src/app/(auth)/_components/AuthAccessForm.tsx
@@ -1,0 +1,208 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+import { GameButton } from '@/components/ui/grimoire/GameButton/GameButton'
+import { GameDivider } from '@/components/ui/grimoire/GameDivider/GameDivider'
+import { GameField } from '@/components/ui/grimoire/GameField/GameField'
+import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
+import { GameInput } from '@/components/ui/grimoire/GameInput/GameInput'
+import { GamePanel } from '@/components/ui/grimoire/GamePanel/GamePanel'
+import { getAccessRecoveryHref, getAuthHref } from '@/lib/internal-navigation'
+import { createClient } from '@/lib/supabase/client'
+
+import type { FormEvent } from 'react'
+
+import '../login/login-form.css'
+
+type AccessMode = 'login' | 'signup'
+type FormStatus = 'idle' | 'loading' | 'sent' | 'error'
+
+interface AuthAccessFormProps {
+  anonymousSession: boolean
+  initialError?: boolean
+  mode: AccessMode
+  nextPath: string
+}
+
+const COPY = {
+  login: {
+    icon: 'key',
+    eyebrow: 'Les portes de Velkhar',
+    title: 'Reprendre votre chronique',
+    description: 'Vos choix, vos souvenirs et les traces laissées dans le monde vous attendent.',
+    submit: 'Recevoir le lien d’accès',
+    sent: 'Si cette adresse possède un compte, un lien d’accès vient d’être envoyé.',
+  },
+  signup: {
+    icon: 'book',
+    eyebrow: 'Une trace qui demeure',
+    title: 'Conserver votre chronique',
+    description: 'Ajoutez un accès à votre voyage sans recommencer votre aventure.',
+    submit: 'Conserver avec mon email',
+    sent: 'Lien envoyé. Confirmez cette adresse pour conserver vos traces.',
+  },
+} as const
+
+function createCallbackUrl(nextPath: string): string {
+  const callbackUrl = new URL('/auth/callback', window.location.origin)
+  callbackUrl.searchParams.set('next', nextPath)
+  return callbackUrl.toString()
+}
+
+export function AuthAccessForm({
+  anonymousSession,
+  initialError = false,
+  mode,
+  nextPath,
+}: AuthAccessFormProps) {
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState<FormStatus>(initialError ? 'error' : 'idle')
+  const copy = COPY[mode]
+  const isConversion = mode === 'signup' && anonymousSession
+
+  async function handleMagicLink(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setStatus('loading')
+
+    try {
+      const supabase = createClient()
+      const emailRedirectTo = createCallbackUrl(nextPath)
+      const result = isConversion
+        ? await supabase.auth.updateUser({ email }, { emailRedirectTo })
+        : await supabase.auth.signInWithOtp({
+            email,
+            options: {
+              emailRedirectTo,
+              shouldCreateUser: mode === 'signup',
+            },
+          })
+
+      setStatus(result.error ? 'error' : 'sent')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  async function handleOAuth(provider: 'google' | 'discord') {
+    setStatus('loading')
+
+    try {
+      const supabase = createClient()
+      const options = { redirectTo: createCallbackUrl(nextPath) }
+      const result = isConversion
+        ? await supabase.auth.linkIdentity({ provider, options })
+        : await supabase.auth.signInWithOAuth({ provider, options })
+
+      if (result.error) setStatus('error')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  return (
+    <GamePanel className="login-form" ornament="diamond" padding="lg" variant="main">
+      <header className="login-form__header">
+        <GameIcon decorative name={copy.icon} size={48} />
+        <p className="login-form__eyebrow">{copy.eyebrow}</p>
+        <h1>{copy.title}</h1>
+        <p>{copy.description}</p>
+      </header>
+
+      {isConversion ? (
+        <aside className="login-form__preservation" aria-label="Données conservées">
+          <GameIcon decorative name="memory" size={24} />
+          <p>
+            Votre personnage, le run en cours, vos Souvenirs et votre Chronique restent attachés à
+            cette même trace.
+          </p>
+        </aside>
+      ) : null}
+
+      {mode === 'login' && anonymousSession ? (
+        <p className="login-form__account-switch">
+          Cette connexion ouvre un compte existant. Pour rattacher la trace actuelle,{' '}
+          <Link href={getAuthHref('/signup', nextPath)}>créez plutôt votre accès</Link>.
+        </p>
+      ) : null}
+
+      <GameDivider size="sm" />
+
+      <form className="login-form__fields" onSubmit={handleMagicLink}>
+        <GameField label="Adresse de messager">
+          <GameInput
+            autoComplete="email"
+            disabled={status === 'loading' || status === 'sent'}
+            leadingIcon={<GameIcon decorative name="envelope" size={24} />}
+            name="email"
+            placeholder="vous@exemple.fr"
+            required
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </GameField>
+
+        <GameButton
+          className="login-form__submit"
+          disabled={status === 'sent'}
+          loading={status === 'loading'}
+          size="lg"
+          type="submit"
+        >
+          {copy.submit}
+        </GameButton>
+
+        {mode === 'login' ? (
+          <p className="login-form__recovery-link">
+            <Link href={getAccessRecoveryHref(nextPath)}>Renvoyer un lien d’accès</Link>
+          </p>
+        ) : null}
+
+        <div className="login-form__oauth" aria-label="Accès avec un service externe">
+          <GameButton
+            disabled={status === 'loading' || status === 'sent'}
+            onClick={() => handleOAuth('google')}
+            type="button"
+            variant="secondary"
+          >
+            Continuer avec Google
+          </GameButton>
+          <GameButton
+            disabled={status === 'loading' || status === 'sent'}
+            onClick={() => handleOAuth('discord')}
+            type="button"
+            variant="secondary"
+          >
+            Continuer avec Discord
+          </GameButton>
+        </div>
+
+        <div
+          aria-live="polite"
+          className="login-form__status"
+          role={status === 'error' ? 'alert' : 'status'}
+        >
+          {status === 'sent' ? <p>{copy.sent}</p> : null}
+          {status === 'error' ? (
+            <p>La demande n’a pas abouti. Vérifiez votre connexion puis réessayez.</p>
+          ) : null}
+        </div>
+      </form>
+
+      <p className="login-form__footer">
+        {mode === 'login' ? (
+          <>
+            Première visite ?{' '}
+            <Link href={getAuthHref('/signup', nextPath)}>Conserver votre trace</Link>
+          </>
+        ) : (
+          <>
+            Chronique existante ? <Link href={getAuthHref('/login', nextPath)}>Se connecter</Link>
+          </>
+        )}
+      </p>
+    </GamePanel>
+  )
+}

--- a/apps/frontend/src/app/(auth)/forgot-password/ForgotPasswordForm.tsx
+++ b/apps/frontend/src/app/(auth)/forgot-password/ForgotPasswordForm.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+import { GameButton } from '@/components/ui/grimoire/GameButton/GameButton'
+import { GameDivider } from '@/components/ui/grimoire/GameDivider/GameDivider'
+import { GameField } from '@/components/ui/grimoire/GameField/GameField'
+import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
+import { GameInput } from '@/components/ui/grimoire/GameInput/GameInput'
+import { GamePanel } from '@/components/ui/grimoire/GamePanel/GamePanel'
+import { getAuthHref } from '@/lib/internal-navigation'
+import { createClient } from '@/lib/supabase/client'
+
+import type { FormEvent } from 'react'
+
+import '../login/login-form.css'
+
+interface ForgotPasswordFormProps {
+  nextPath: string
+}
+
+export function ForgotPasswordForm({ nextPath }: ForgotPasswordFormProps) {
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState<'idle' | 'loading' | 'sent' | 'error'>('idle')
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setStatus('loading')
+
+    try {
+      const callbackUrl = new URL('/auth/callback', window.location.origin)
+      callbackUrl.searchParams.set('next', nextPath)
+      const { error } = await createClient().auth.signInWithOtp({
+        email,
+        options: {
+          emailRedirectTo: callbackUrl.toString(),
+          shouldCreateUser: false,
+        },
+      })
+      setStatus(error ? 'error' : 'sent')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  return (
+    <GamePanel className="login-form" ornament="diamond" padding="lg" variant="main">
+      <header className="login-form__header">
+        <GameIcon decorative name="unlock" size={48} />
+        <p className="login-form__eyebrow">Lien refermé</p>
+        <h1>Retrouver votre accès</h1>
+        <p>Recevez un nouveau lien de connexion à l’adresse liée à votre chronique.</p>
+      </header>
+      <GameDivider size="sm" />
+      <form className="login-form__fields" onSubmit={handleSubmit}>
+        <GameField label="Adresse de messager">
+          <GameInput
+            autoComplete="email"
+            disabled={status === 'loading' || status === 'sent'}
+            leadingIcon={<GameIcon decorative name="envelope" size={24} />}
+            name="email"
+            placeholder="vous@exemple.fr"
+            required
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </GameField>
+        <GameButton
+          className="login-form__submit"
+          disabled={status === 'sent'}
+          loading={status === 'loading'}
+          size="lg"
+          type="submit"
+        >
+          Envoyer un nouveau lien
+        </GameButton>
+        <div
+          aria-live="polite"
+          className="login-form__status"
+          role={status === 'error' ? 'alert' : 'status'}
+        >
+          {status === 'sent' ? (
+            <p>Si cette adresse possède un compte, un nouveau lien d’accès vient d’être envoyé.</p>
+          ) : null}
+          {status === 'error' ? (
+            <p>La demande n’a pas abouti. Vérifiez votre connexion puis réessayez.</p>
+          ) : null}
+        </div>
+      </form>
+      <p className="login-form__footer">
+        <Link href={getAuthHref('/login', nextPath)}>Retour à la connexion</Link>
+      </p>
+    </GamePanel>
+  )
+}

--- a/apps/frontend/src/app/(auth)/forgot-password/page.tsx
+++ b/apps/frontend/src/app/(auth)/forgot-password/page.tsx
@@ -1,48 +1,19 @@
-import Link from 'next/link'
+import { getSafeInternalDestination } from '@/lib/internal-navigation'
 
-import { GameButton } from '@/components/ui/grimoire/GameButton/GameButton'
-import { GameDivider } from '@/components/ui/grimoire/GameDivider/GameDivider'
-import { GameField } from '@/components/ui/grimoire/GameField/GameField'
-import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
-import { GameInput } from '@/components/ui/grimoire/GameInput/GameInput'
-import { GamePanel } from '@/components/ui/grimoire/GamePanel/GamePanel'
+import { ForgotPasswordForm } from './ForgotPasswordForm'
 
 import type { Metadata } from 'next'
 
-import '../login/login-form.css'
-
 export const metadata: Metadata = {
   title: 'Retrouver votre accès · GRIMOIRE',
+  description: 'Recevez un nouveau lien sécurisé pour retrouver l’accès à votre chronique.',
 }
 
-export default function ForgotPasswordPage() {
-  return (
-    <GamePanel className="login-form" ornament="diamond" padding="lg" variant="main">
-      <header className="login-form__header">
-        <GameIcon decorative name="unlock" size={48} />
-        <p className="login-form__eyebrow">Sceau égaré</p>
-        <h1>Retrouver votre accès</h1>
-        <p>Nous enverrons les instructions à l’adresse liée à votre chronique.</p>
-      </header>
-      <GameDivider size="sm" />
-      <form className="login-form__fields">
-        <GameField label="Adresse de messager">
-          <GameInput
-            autoComplete="email"
-            leadingIcon={<GameIcon decorative name="envelope" size={24} />}
-            name="email"
-            placeholder="vous@exemple.fr"
-            required
-            type="email"
-          />
-        </GameField>
-        <GameButton className="login-form__submit" size="lg" type="submit">
-          Envoyer les instructions
-        </GameButton>
-      </form>
-      <p className="login-form__footer">
-        <Link href="/login">Retour à la connexion</Link>
-      </p>
-    </GamePanel>
-  )
+interface ForgotPasswordPageProps {
+  searchParams: Promise<{ next?: string | string[] }>
+}
+
+export default async function ForgotPasswordPage({ searchParams }: ForgotPasswordPageProps) {
+  const { next } = await searchParams
+  return <ForgotPasswordForm nextPath={getSafeInternalDestination(next)} />
 }

--- a/apps/frontend/src/app/(auth)/login/LoginForm.tsx
+++ b/apps/frontend/src/app/(auth)/login/LoginForm.tsx
@@ -1,119 +1,20 @@
 'use client'
 
-import Link from 'next/link'
-import { useState } from 'react'
-
-import { GameButton } from '@/components/ui/grimoire/GameButton/GameButton'
-import { GameDivider } from '@/components/ui/grimoire/GameDivider/GameDivider'
-import { GameField } from '@/components/ui/grimoire/GameField/GameField'
-import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
-import { GameInput } from '@/components/ui/grimoire/GameInput/GameInput'
-import { GamePanel } from '@/components/ui/grimoire/GamePanel/GamePanel'
-import { getAuthHref } from '@/lib/internal-navigation'
-import { createClient } from '@/lib/supabase/client'
-
-import type { FormEvent } from 'react'
-
-import './login-form.css'
+import { AuthAccessForm } from '../_components/AuthAccessForm'
 
 interface LoginFormProps {
+  anonymousSession: boolean
+  callbackError?: boolean
   nextPath: string
 }
 
-export function LoginForm({ nextPath }: LoginFormProps) {
-  const [email, setEmail] = useState('')
-  const [status, setStatus] = useState<'idle' | 'loading' | 'sent' | 'error'>('idle')
-
-  async function handleMagicLink(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    setStatus('loading')
-
-    const supabase = createClient()
-    const callbackUrl = new URL('/auth/callback', window.location.origin)
-    callbackUrl.searchParams.set('next', nextPath)
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-      options: { emailRedirectTo: callbackUrl.toString() },
-    })
-
-    setStatus(error ? 'error' : 'sent')
-  }
-
-  async function handleOAuth(provider: 'google' | 'discord') {
-    setStatus('loading')
-    const supabase = createClient()
-    const callbackUrl = new URL('/auth/callback', window.location.origin)
-    callbackUrl.searchParams.set('next', nextPath)
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider,
-      options: { redirectTo: callbackUrl.toString() },
-    })
-
-    if (error) setStatus('error')
-  }
-
+export function LoginForm({ anonymousSession, callbackError = false, nextPath }: LoginFormProps) {
   return (
-    <GamePanel className="login-form" ornament="diamond" padding="lg" variant="main">
-      <header className="login-form__header">
-        <GameIcon decorative name="key" size={48} />
-        <p className="login-form__eyebrow">Les portes de Velkhar</p>
-        <h1>Reprendre votre chronique</h1>
-        <p>Vos choix, vos souvenirs et les traces laissées dans le monde vous attendent.</p>
-      </header>
-
-      <GameDivider size="sm" />
-
-      <form className="login-form__fields" onSubmit={handleMagicLink}>
-        <GameField label="Adresse de messager">
-          <GameInput
-            autoComplete="email"
-            leadingIcon={<GameIcon decorative name="envelope" size={24} />}
-            name="email"
-            placeholder="vous@exemple.fr"
-            required
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-          />
-        </GameField>
-
-        <GameButton
-          className="login-form__submit"
-          loading={status === 'loading'}
-          size="lg"
-          type="submit"
-        >
-          Recevoir le lien d’accès
-        </GameButton>
-
-        <div className="login-form__oauth" aria-label="Connexion avec un service externe">
-          <GameButton
-            disabled={status === 'loading'}
-            onClick={() => handleOAuth('google')}
-            type="button"
-            variant="secondary"
-          >
-            Continuer avec Google
-          </GameButton>
-          <GameButton
-            disabled={status === 'loading'}
-            onClick={() => handleOAuth('discord')}
-            type="button"
-            variant="secondary"
-          >
-            Continuer avec Discord
-          </GameButton>
-        </div>
-
-        <div aria-live="polite" className="login-form__status">
-          {status === 'sent' && <p>Lien envoyé. Vérifiez votre boîte mail.</p>}
-          {status === 'error' && <p>Une erreur est survenue. Réessayez.</p>}
-        </div>
-      </form>
-
-      <p className="login-form__footer">
-        Première visite ? <Link href={getAuthHref('/signup', nextPath)}>Créer votre chronique</Link>
-      </p>
-    </GamePanel>
+    <AuthAccessForm
+      anonymousSession={anonymousSession}
+      initialError={callbackError}
+      mode="login"
+      nextPath={nextPath}
+    />
   )
 }

--- a/apps/frontend/src/app/(auth)/login/login-form.css
+++ b/apps/frontend/src/app/(auth)/login/login-form.css
@@ -49,6 +49,43 @@
   margin-block: 1rem 1.15rem;
 }
 
+.login-form__preservation {
+  align-items: flex-start;
+  background: rgba(53, 196, 172, 0.07);
+  border: 1px solid color-mix(in srgb, var(--soul) 32%, transparent);
+  color: var(--ink-2);
+  display: flex;
+  gap: 0.7rem;
+  margin-top: 1.2rem;
+  padding: 0.8rem 0.9rem;
+}
+
+.login-form__preservation .game-icon {
+  flex: none;
+}
+
+.login-form__preservation p,
+.login-form__account-switch {
+  font-family: var(--font-game-ui);
+  font-size: 0.84rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.login-form__account-switch {
+  color: var(--ink-2);
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.login-form__account-switch a,
+.login-form__recovery-link a {
+  color: var(--gold-light);
+  text-decoration: underline;
+  text-decoration-color: rgba(240, 212, 138, 0.32);
+  text-underline-offset: 0.25em;
+}
+
 .login-form__fields {
   display: grid;
   gap: 0.85rem;
@@ -151,6 +188,13 @@
   width: 100%;
 }
 
+.login-form__recovery-link {
+  font-family: var(--font-game-ui);
+  font-size: 0.82rem;
+  margin: -0.2rem 0 0.15rem;
+  text-align: center;
+}
+
 .login-form__status {
   color: var(--gold-light);
   font-family: var(--font-ui);
@@ -160,6 +204,10 @@
 
 .login-form__status p {
   margin: 0;
+}
+
+.login-form__status[role='alert'] {
+  color: color-mix(in srgb, var(--blood) 58%, var(--parchment));
 }
 
 .login-form__footer {

--- a/apps/frontend/src/app/(auth)/login/page.tsx
+++ b/apps/frontend/src/app/(auth)/login/page.tsx
@@ -1,4 +1,5 @@
 import { getSafeInternalDestination } from '@/lib/internal-navigation'
+import { getViewerSummary } from '@/lib/viewer'
 
 import { LoginForm } from './LoginForm'
 
@@ -10,12 +11,18 @@ export const metadata: Metadata = {
 }
 
 interface LoginPageProps {
-  searchParams: Promise<{ next?: string | string[] }>
+  searchParams: Promise<{ error?: string | string[]; next?: string | string[] }>
 }
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
-  const { next } = await searchParams
+  const [{ error, next }, viewer] = await Promise.all([searchParams, getViewerSummary()])
   const nextPath = getSafeInternalDestination(next)
 
-  return <LoginForm nextPath={nextPath} />
+  return (
+    <LoginForm
+      anonymousSession={viewer.hasSession && viewer.tier === 'anonymous'}
+      callbackError={(Array.isArray(error) ? error[0] : error) === 'callback'}
+      nextPath={nextPath}
+    />
+  )
 }

--- a/apps/frontend/src/app/(auth)/signup/SignupForm.tsx
+++ b/apps/frontend/src/app/(auth)/signup/SignupForm.tsx
@@ -1,121 +1,12 @@
 'use client'
 
-import Link from 'next/link'
-import { useState } from 'react'
-
-import { GameButton } from '@/components/ui/grimoire/GameButton/GameButton'
-import { GameDivider } from '@/components/ui/grimoire/GameDivider/GameDivider'
-import { GameField } from '@/components/ui/grimoire/GameField/GameField'
-import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
-import { GameInput } from '@/components/ui/grimoire/GameInput/GameInput'
-import { GamePanel } from '@/components/ui/grimoire/GamePanel/GamePanel'
-import { getAuthHref } from '@/lib/internal-navigation'
-import { createClient } from '@/lib/supabase/client'
-
-import type { FormEvent } from 'react'
-
-import '../login/login-form.css'
+import { AuthAccessForm } from '../_components/AuthAccessForm'
 
 interface SignupFormProps {
+  anonymousSession: boolean
   nextPath: string
 }
 
-export function SignupForm({ nextPath }: SignupFormProps) {
-  const [email, setEmail] = useState('')
-  const [status, setStatus] = useState<'idle' | 'loading' | 'sent' | 'error'>('idle')
-
-  async function handleMagicLink(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    setStatus('loading')
-
-    const supabase = createClient()
-    const callbackUrl = new URL('/auth/callback', window.location.origin)
-    callbackUrl.searchParams.set('next', nextPath)
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-      options: {
-        shouldCreateUser: true,
-        emailRedirectTo: callbackUrl.toString(),
-      },
-    })
-
-    setStatus(error ? 'error' : 'sent')
-  }
-
-  async function handleOAuth(provider: 'google' | 'discord') {
-    setStatus('loading')
-    const supabase = createClient()
-    const callbackUrl = new URL('/auth/callback', window.location.origin)
-    callbackUrl.searchParams.set('next', nextPath)
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider,
-      options: { redirectTo: callbackUrl.toString() },
-    })
-
-    if (error) setStatus('error')
-  }
-
-  return (
-    <GamePanel className="login-form" ornament="diamond" padding="lg" variant="main">
-      <header className="login-form__header">
-        <GameIcon decorative name="book" size={48} />
-        <p className="login-form__eyebrow">Une légende commence</p>
-        <h1>Créer votre chronique</h1>
-        <p>Choisissez vos sceaux d’accès. Votre personnage viendra ensuite.</p>
-      </header>
-
-      <GameDivider size="sm" />
-
-      <form className="login-form__fields" onSubmit={handleMagicLink}>
-        <GameField label="Adresse de messager">
-          <GameInput
-            autoComplete="email"
-            leadingIcon={<GameIcon decorative name="envelope" size={24} />}
-            name="email"
-            placeholder="vous@exemple.fr"
-            required
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-          />
-        </GameField>
-        <GameButton
-          className="login-form__submit"
-          loading={status === 'loading'}
-          size="lg"
-          type="submit"
-        >
-          Recevoir le lien d’inscription
-        </GameButton>
-
-        <div className="login-form__oauth" aria-label="Inscription avec un service externe">
-          <GameButton
-            disabled={status === 'loading'}
-            onClick={() => handleOAuth('google')}
-            type="button"
-            variant="secondary"
-          >
-            Continuer avec Google
-          </GameButton>
-          <GameButton
-            disabled={status === 'loading'}
-            onClick={() => handleOAuth('discord')}
-            type="button"
-            variant="secondary"
-          >
-            Continuer avec Discord
-          </GameButton>
-        </div>
-
-        <div aria-live="polite" className="login-form__status">
-          {status === 'sent' && <p>Lien envoyé. Vérifiez votre boîte mail.</p>}
-          {status === 'error' && <p>Une erreur est survenue. Réessayez.</p>}
-        </div>
-      </form>
-
-      <p className="login-form__footer">
-        Chronique existante ? <Link href={getAuthHref('/login', nextPath)}>Se connecter</Link>
-      </p>
-    </GamePanel>
-  )
+export function SignupForm({ anonymousSession, nextPath }: SignupFormProps) {
+  return <AuthAccessForm anonymousSession={anonymousSession} mode="signup" nextPath={nextPath} />
 }

--- a/apps/frontend/src/app/(auth)/signup/page.tsx
+++ b/apps/frontend/src/app/(auth)/signup/page.tsx
@@ -1,4 +1,5 @@
 import { getSafeInternalDestination } from '@/lib/internal-navigation'
+import { getViewerSummary } from '@/lib/viewer'
 
 import { SignupForm } from './SignupForm'
 
@@ -14,8 +15,13 @@ interface SignupPageProps {
 }
 
 export default async function SignupPage({ searchParams }: SignupPageProps) {
-  const { next } = await searchParams
+  const [{ next }, viewer] = await Promise.all([searchParams, getViewerSummary()])
   const nextPath = getSafeInternalDestination(next)
 
-  return <SignupForm nextPath={nextPath} />
+  return (
+    <SignupForm
+      anonymousSession={viewer.hasSession && viewer.tier === 'anonymous'}
+      nextPath={nextPath}
+    />
+  )
 }

--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.tsx
@@ -21,6 +21,7 @@ import { DiceRoll } from '@/features/game-session/components/DiceRoll'
 import { NarrativePanel } from '@/features/game-session/components/NarrativePanel'
 import { SourceBadge } from '@/features/game-session/components/SourceBadge'
 import { useGameSession } from '@/features/game-session/hooks/use-game-session'
+import { getAuthHref } from '@/lib/internal-navigation'
 
 import { VELKHAR_WORLD } from '../../_config/velkhar-world'
 
@@ -186,7 +187,9 @@ export function VelkharSession({ initialCharacter, locale = 'en' }: VelkharSessi
                   <GameIcon decorative name="lock" size={48} />
                   <h1>Your Chronicle is waiting</h1>
                   <p>Create a free account to keep this run and continue playing.</p>
-                  <Link href="/signup">Create account</Link>
+                  <Link href={getAuthHref('/signup', `${VELKHAR_WORLD.routes.session}/resume`)}>
+                    Create account
+                  </Link>
                 </div>
               ) : session.error ? (
                 <div className="velkhar-session__state" role="alert">

--- a/apps/frontend/src/app/(main)/dashboard/_components/DashboardContent/DashboardContent.tsx
+++ b/apps/frontend/src/app/(main)/dashboard/_components/DashboardContent/DashboardContent.tsx
@@ -3,6 +3,7 @@ import { GameIcon } from '@/components/ui/grimoire/GameIcon/GameIcon'
 import { GamePanel } from '@/components/ui/grimoire/GamePanel/GamePanel'
 import { GameSectionHeading } from '@/components/ui/grimoire/GameSectionHeading/GameSectionHeading'
 import { WORLD_ROUTES } from '@/config/worlds'
+import { SignOutButton } from '@/features/auth/components/SignOutButton/SignOutButton'
 import { getAuthHref } from '@/lib/internal-navigation'
 
 import type { DashboardViewModel } from '../../_data/dashboard-view-model'
@@ -104,6 +105,7 @@ export function DashboardContent({ tier, viewModel }: DashboardContentProps) {
           Le Dashboard retrouve vos traces. L’Auberge de L’Aveugle reste le seul hub entre les runs.
         </p>
       </aside>
+      {tier !== 'anonymous' ? <SignOutButton /> : null}
     </main>
   )
 }

--- a/apps/frontend/src/app/(main)/dashboard/_components/DashboardContent/dashboard-content.css
+++ b/apps/frontend/src/app/(main)/dashboard/_components/DashboardContent/dashboard-content.css
@@ -116,6 +116,43 @@
   text-wrap: pretty;
 }
 
+.auth-sign-out {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+
+.auth-sign-out button {
+  background: transparent;
+  border: 0;
+  color: var(--ink-2);
+  cursor: pointer;
+  font-family: var(--font-game-ui);
+  font-size: 0.82rem;
+  min-height: 44px;
+  padding: 0.5rem 0.75rem;
+  text-decoration: underline;
+  text-decoration-color: rgba(232, 220, 192, 0.24);
+  text-underline-offset: 0.3em;
+}
+
+.auth-sign-out button:hover {
+  color: var(--gold-light);
+}
+
+.auth-sign-out button:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.auth-sign-out span {
+  color: color-mix(in srgb, var(--blood) 58%, var(--parchment));
+  font-family: var(--font-game-ui);
+  font-size: 0.8rem;
+}
+
 @media (max-width: 900px) {
   .dashboard-content__grid {
     grid-template-columns: 1fr;

--- a/apps/frontend/src/app/auth/callback/route.ts
+++ b/apps/frontend/src/app/auth/callback/route.ts
@@ -16,5 +16,7 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  return NextResponse.redirect(`${origin}/login`)
+  const loginUrl = new URL('/login', origin)
+  loginUrl.searchParams.set('error', 'callback')
+  return NextResponse.redirect(loginUrl)
 }

--- a/apps/frontend/src/features/auth/components/SignOutButton/SignOutButton.tsx
+++ b/apps/frontend/src/features/auth/components/SignOutButton/SignOutButton.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+
+import { createClient } from '@/lib/supabase/client'
+
+export function SignOutButton() {
+  const router = useRouter()
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle')
+
+  async function handleSignOut() {
+    setStatus('loading')
+    try {
+      const { error } = await createClient().auth.signOut()
+      if (error) {
+        setStatus('error')
+        return
+      }
+      router.replace('/')
+      router.refresh()
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  return (
+    <div className="auth-sign-out">
+      <button disabled={status === 'loading'} onClick={() => void handleSignOut()} type="button">
+        {status === 'loading' ? 'Fermeture de la session…' : 'Se déconnecter'}
+      </button>
+      <span aria-live="polite" role={status === 'error' ? 'alert' : 'status'}>
+        {status === 'error' ? 'La déconnexion a échoué. Réessayez.' : null}
+      </span>
+    </div>
+  )
+}

--- a/apps/frontend/src/features/auth/components/SoftSignupPrompt/SoftSignupPrompt.tsx
+++ b/apps/frontend/src/features/auth/components/SoftSignupPrompt/SoftSignupPrompt.tsx
@@ -1,12 +1,17 @@
 'use client'
 
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 
-import { useSessionStore } from '@/stores/session-store'
+import { getAuthHref } from '@/lib/internal-navigation'
+import { getAnonymousRequestsRemaining, useSessionStore } from '@/stores/session-store'
 
 export function SoftSignupPrompt() {
+  const pathname = usePathname()
+  const anonymousRequestCount = useSessionStore((state) => state.anonymousRequestCount)
   const showSoftPrompt = useSessionStore((state) => state.showSoftPrompt)
   const dismissSoftPrompt = useSessionStore((state) => state.dismissSoftPrompt)
+  const remaining = getAnonymousRequestsRemaining(anonymousRequestCount)
 
   if (!showSoftPrompt) {
     return null
@@ -18,10 +23,15 @@ export function SoftSignupPrompt() {
       className="fixed inset-x-0 bottom-0 z-50 flex flex-wrap items-center justify-center gap-4 border-t border-gold-dark bg-ash/95 px-6 py-4 text-center"
     >
       <p className="m-0 font-manuscript text-parchment">
-        Crée un compte gratuitement pour conserver cette aventure et continuer à jouer.
+        {remaining > 0
+          ? `${remaining} actions anonymes restantes sur cet appareil. Conserve cette aventure gratuitement.`
+          : 'La limite anonyme est atteinte. Conserve cette aventure pour continuer.'}
       </p>
-      <Link href="/signup" className="font-accent text-gold-soft underline">
-        Créer un compte
+      <Link
+        href={getAuthHref('/signup', pathname)}
+        className="font-accent text-gold-soft underline"
+      >
+        Conserver ma trace
       </Link>
       <button
         type="button"

--- a/apps/frontend/src/features/chronicle/components/ChronicleReader.tsx
+++ b/apps/frontend/src/features/chronicle/components/ChronicleReader.tsx
@@ -1,6 +1,8 @@
 import Image from 'next/image'
 import Link from 'next/link'
 
+import { getAuthHref } from '@/lib/internal-navigation'
+
 import { ChronicleBody } from './ChronicleBody'
 import { ChronicleShare } from './ChronicleShare'
 
@@ -76,7 +78,9 @@ export function ChronicleReader({ chronicle, inline = false }: ChronicleReaderPr
         {inline ? (
           <p className="chronicle-reader__account-note">
             Joueur anonyme ?{' '}
-            <Link href="/signup?return=chronicle">Garder cette trace gratuitement</Link>
+            <Link href={getAuthHref('/signup', '/velkhar/aveugle?return=chronicle')}>
+              Garder cette trace gratuitement
+            </Link>
           </p>
         ) : null}
       </footer>

--- a/apps/frontend/src/lib/internal-navigation.test.ts
+++ b/apps/frontend/src/lib/internal-navigation.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { getAuthHref, getSafeInternalDestination } from './internal-navigation'
+import {
+  getAccessRecoveryHref,
+  getAuthHref,
+  getSafeInternalDestination,
+} from './internal-navigation'
 
 describe('getSafeInternalDestination', () => {
   it.each([
@@ -32,6 +36,12 @@ describe('getAuthHref', () => {
   it('encodes a validated return destination', () => {
     expect(getAuthHref('/login', '/velkhar/session/resume?from=dashboard')).toBe(
       '/login?next=%2Fvelkhar%2Fsession%2Fresume%3Ffrom%3Ddashboard'
+    )
+  })
+
+  it('construit une récupération qui conserve une destination validée', () => {
+    expect(getAccessRecoveryHref('/velkhar/aveugle?return=chronicle')).toBe(
+      '/forgot-password?next=%2Fvelkhar%2Faveugle%3Freturn%3Dchronicle'
     )
   })
 })

--- a/apps/frontend/src/lib/internal-navigation.ts
+++ b/apps/frontend/src/lib/internal-navigation.ts
@@ -54,3 +54,8 @@ export function getAuthHref(pathname: '/login' | '/signup', next: string): strin
   const safeNext = getSafeInternalDestination(next)
   return `${pathname}?next=${encodeURIComponent(safeNext)}`
 }
+
+export function getAccessRecoveryHref(next: string): string {
+  const safeNext = getSafeInternalDestination(next)
+  return `/forgot-password?next=${encodeURIComponent(safeNext)}`
+}

--- a/apps/frontend/src/lib/viewer.ts
+++ b/apps/frontend/src/lib/viewer.ts
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server'
 
 export interface ViewerSummary {
   displayName: string | null
+  hasSession: boolean
   tier: ViewerTier
 }
 
@@ -30,8 +31,8 @@ export const getViewerSummary = cache(async (): Promise<ViewerSummary> => {
           ? user.email.split('@')[0]
           : null
 
-    return { displayName, tier }
+    return { displayName, hasSession: user !== null, tier }
   } catch {
-    return { displayName: null, tier: 'anonymous' }
+    return { displayName: null, hasSession: false, tier: 'anonymous' }
   }
 })

--- a/apps/frontend/src/stores/session-store.test.ts
+++ b/apps/frontend/src/stores/session-store.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  ANONYMOUS_SOFT_PROMPT_AT,
+  getAnonymousRequestsRemaining,
+  useSessionStore,
+} from './session-store'
+
+describe('session store anonymous quota', () => {
+  beforeEach(() => {
+    useSessionStore.setState({
+      anonymousRequestCount: 0,
+      showSoftPrompt: false,
+      softPromptDismissed: false,
+    })
+  })
+
+  it('ouvre progressivement le rappel avant la limite', () => {
+    useSessionStore.setState({ anonymousRequestCount: ANONYMOUS_SOFT_PROMPT_AT - 1 })
+    useSessionStore.getState().incrementAnonymousRequestCount()
+
+    expect(useSessionStore.getState().showSoftPrompt).toBe(true)
+    expect(getAnonymousRequestsRemaining(ANONYMOUS_SOFT_PROMPT_AT)).toBe(10)
+  })
+
+  it('respecte le refus du rappel progressif', () => {
+    useSessionStore.setState({ anonymousRequestCount: ANONYMOUS_SOFT_PROMPT_AT - 1 })
+    useSessionStore.getState().incrementAnonymousRequestCount()
+    useSessionStore.getState().dismissSoftPrompt()
+    useSessionStore.getState().incrementAnonymousRequestCount()
+
+    expect(useSessionStore.getState().showSoftPrompt).toBe(false)
+  })
+
+  it('ne produit jamais un quota négatif', () => {
+    expect(getAnonymousRequestsRemaining(99)).toBe(0)
+  })
+})

--- a/apps/frontend/src/stores/session-store.ts
+++ b/apps/frontend/src/stores/session-store.ts
@@ -1,9 +1,15 @@
 import { create } from 'zustand'
 
-const ANONYMOUS_REQUEST_LIMIT = 30
+export const ANONYMOUS_REQUEST_LIMIT = 30
+export const ANONYMOUS_SOFT_PROMPT_AT = 20
+
+export function getAnonymousRequestsRemaining(count: number): number {
+  return Math.max(0, ANONYMOUS_REQUEST_LIMIT - count)
+}
 
 interface SessionState {
   anonymousRequestCount: number
+  softPromptDismissed: boolean
   showSoftPrompt: boolean
   incrementAnonymousRequestCount: () => void
   dismissSoftPrompt: () => void
@@ -11,6 +17,7 @@ interface SessionState {
 
 export const useSessionStore = create<SessionState>((set) => ({
   anonymousRequestCount: 0,
+  softPromptDismissed: false,
   showSoftPrompt: false,
   incrementAnonymousRequestCount: () =>
     set((state) => {
@@ -18,8 +25,11 @@ export const useSessionStore = create<SessionState>((set) => ({
       return {
         anonymousRequestCount,
         showSoftPrompt:
-          anonymousRequestCount >= ANONYMOUS_REQUEST_LIMIT ? true : state.showSoftPrompt,
+          anonymousRequestCount >= ANONYMOUS_REQUEST_LIMIT ||
+          (anonymousRequestCount >= ANONYMOUS_SOFT_PROMPT_AT && !state.softPromptDismissed)
+            ? true
+            : state.showSoftPrompt,
       }
     }),
-  dismissSoftPrompt: () => set({ showSoftPrompt: false }),
+  dismissSoftPrompt: () => set({ showSoftPrompt: false, softPromptDismissed: true }),
 }))


### PR DESCRIPTION
## Summary
- ajoute un composant auth partagé login/signup pour le flux passwordless email, Google et Discord
- gère la conversion anonyme avec conservation explicite de la trace et des destinations internes sûres
- remplace la récupération par un renvoi de magic link, sans reset password classique
- ajoute l'invite progressive avant la limite anonyme et un bouton de déconnexion dashboard

## Test plan
- [x] pnpm --filter @grimoire/frontend test -- internal-navigation session-store
- [x] pnpm --filter @grimoire/frontend type-check
- [x] pnpm --filter @grimoire/frontend lint
- [x] pnpm type-check
- [x] pnpm lint
- [x] pnpm --filter @grimoire/frontend test

Closes #135