### PR TITLE
docs(status): séparer le suivi frontend et backend

### DIFF
--- a/.claude/agents/backend-dev/agent.md
+++ b/.claude/agents/backend-dev/agent.md
@@ -13,7 +13,7 @@ You are a senior backend engineer on **Grimoire**, an AI-powered narrative RPG.
 Read these files in order — they contain all the rules, don't re-derive them:
 
 1. `docs/00-START-HERE.md` — project entrypoint
-2. `docs/public/current-state/PROJECT_STATUS.md` — current branch, phase, active priority
+2. `docs/public/current-state/BACKEND_STATUS.md` + `BACKEND_NEXT.md` — backend state and priority
 3. `apps/backend/CLAUDE.md` — all backend rules
 4. `docs/public/tech/ARCHITECTURE_RULES.md` — backend/AI/frontend invariants
 5. `docs/public/nav/task-router.md` — targeted docs and canon routing
@@ -21,6 +21,9 @@ Read these files in order — they contain all the rules, don't re-derive them:
 ## Scope
 
 Work ONLY in `apps/backend/`. If new shared types are needed, add them to `packages/shared/` first, then run type-check.
+
+If progress docs must change, edit only `BACKEND_STATUS.md` and `BACKEND_NEXT.md`. Never edit
+`PROJECT_STATUS.md`, `NEXT_ACTIONS.md`, `RELEASE_READINESS.md` or the `FRONTEND_*` files from a backend feature branch.
 
 ## After Every Task
 

--- a/.claude/agents/frontend-dev/agent.md
+++ b/.claude/agents/frontend-dev/agent.md
@@ -13,7 +13,7 @@ You are a senior frontend engineer on **Grimoire**, an AI-powered narrative RPG.
 Read these files in order — they contain all the rules, don't re-derive them:
 
 1. `docs/00-START-HERE.md` — project entrypoint
-2. `docs/public/current-state/PROJECT_STATUS.md` — current branch, phase, active priority
+2. `docs/public/current-state/FRONTEND_STATUS.md` + `FRONTEND_NEXT.md` — frontend state and priority
 3. `docs/public/nav/task-router.md` — targeted docs and canon routing
 4. `docs/public/design/GAME_DESIGN.md` + `docs/public/design/DESIGN_TOKENS.md` — design/gameplay rules
 5. `apps/frontend/CLAUDE.md` — all frontend rules
@@ -21,6 +21,9 @@ Read these files in order — they contain all the rules, don't re-derive them:
 ## Scope
 
 Work ONLY in `apps/frontend/`. If new shared types are needed, add them to `packages/shared/` first.
+
+If progress docs must change, edit only `FRONTEND_STATUS.md` and `FRONTEND_NEXT.md`. Never edit
+`PROJECT_STATUS.md`, `NEXT_ACTIONS.md`, `RELEASE_READINESS.md` or the `BACKEND_*` files from a frontend feature branch.
 
 ## After Every Task
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -13,7 +13,8 @@ Feature to implement: $ARGUMENTS
 
 ### Step 1: Understand
 
-- Read `docs/public/current-state/PROJECT_STATUS.md` and `docs/public/current-state/NEXT_ACTIONS.md` to know current phase and project state
+- Read `docs/public/current-state/PROJECT_STATUS.md`, then only the matching domain pair:
+  `FRONTEND_STATUS.md` + `FRONTEND_NEXT.md` or `BACKEND_STATUS.md` + `BACKEND_NEXT.md`
 - Read relevant CLAUDE.md files for the target workspace
 - Read existing related code to understand patterns
 - Identify which files need to be created or modified
@@ -46,5 +47,6 @@ Feature to implement: $ARGUMENTS
 
 ### Step 6: Update Progress
 
-- Update `docs/public/current-state/PROJECT_STATUS.md` and `docs/public/current-state/NEXT_ACTIONS.md` to reflect completed items and new project state
+- Update only the matching domain status/actions files when progress documentation is in scope
+- Never update `PROJECT_STATUS.md`, `NEXT_ACTIONS.md` or `RELEASE_READINESS.md` from a feature branch
 - Report what was done and what's next

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -7,9 +7,12 @@ allowed-tools: Read, Glob
 
 Show the current project status by:
 
-1. Read `docs/public/current-state/PROJECT_STATUS.md` and `docs/public/current-state/NEXT_ACTIONS.md` from the project root
-2. Count completed vs total tasks in each phase
-3. Present a clean summary:
+1. Read `docs/public/current-state/PROJECT_STATUS.md`.
+2. Read `RELEASE_READINESS.md` for a global/release request, or only the matching
+   `FRONTEND_STATUS.md` + `FRONTEND_NEXT.md` / `BACKEND_STATUS.md` + `BACKEND_NEXT.md` pair.
+3. Never infer an active branch from `PROJECT_STATUS.md`; use git status when needed.
+4. Count completed vs total release blockers from the selected status file.
+5. Present a clean summary:
 
 Format:
 
@@ -28,5 +31,5 @@ NEXT TASKS:
 - [ ] Task 3
 ```
 
-4. Also check git status to see if there are uncommitted changes
-5. Report any blockers or issues found
+5. Also check git status to see if there are uncommitted changes.
+6. Report any blockers or issues found.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,25 +2,34 @@
 
 > Fichier projet lu par les outils IA.
 > Lire d'abord : `docs/00-START-HERE.md`.
-> État vivant : `docs/public/current-state/PROJECT_STATUS.md`.
+> État vivant : `docs/public/current-state/PROJECT_STATUS.md`, puis statut du domaine.
 > Routeur : `docs/public/nav/task-router.md`.
 
 ## Sources de vérité
 
-| Besoin                 | Source                                                 |
-| ---------------------- | ------------------------------------------------------ |
-| Statut actuel          | `docs/public/current-state/PROJECT_STATUS.md`          |
-| Prochaines actions     | `docs/public/current-state/NEXT_ACTIONS.md`            |
-| Architecture           | `docs/public/tech/ARCHITECTURE_RULES.md`               |
-| Stack                  | `docs/public/tech/TECH_STACK.md`                       |
-| Design                 | `docs/public/design/GAME_DESIGN.md`                    |
-| Tokens UI              | `docs/public/design/DESIGN_TOKENS.md`                  |
-| Canon                  | `docs/public/nav/canon-index.md` → `docs/public/raw/*` |
-| Politique privé/public | `docs/public/nav/PRIVATE_CANON_POLICY.md`              |
+| Besoin                 | Source                                                              |
+| ---------------------- | ------------------------------------------------------------------- |
+| Statut actuel          | `docs/public/current-state/PROJECT_STATUS.md`                       |
+| Release / go-no-go     | `docs/public/current-state/RELEASE_READINESS.md`                    |
+| État / actions front   | `docs/public/current-state/FRONTEND_STATUS.md` + `FRONTEND_NEXT.md` |
+| État / actions back    | `docs/public/current-state/BACKEND_STATUS.md` + `BACKEND_NEXT.md`   |
+| Architecture           | `docs/public/tech/ARCHITECTURE_RULES.md`                            |
+| Stack                  | `docs/public/tech/TECH_STACK.md`                                    |
+| Design                 | `docs/public/design/GAME_DESIGN.md`                                 |
+| Tokens UI              | `docs/public/design/DESIGN_TOKENS.md`                               |
+| Canon                  | `docs/public/nav/canon-index.md` → `docs/public/raw/*`              |
+| Politique privé/public | `docs/public/nav/PRIVATE_CANON_POLICY.md`                           |
 
 ## Invariants
 
 Voir `docs/public/tech/ARCHITECTURE_RULES.md`.
+
+## Propriété des docs d'état
+
+- Un chantier frontend modifie uniquement `FRONTEND_STATUS.md` et `FRONTEND_NEXT.md`.
+- Un chantier backend modifie uniquement `BACKEND_STATUS.md` et `BACKEND_NEXT.md`.
+- `PROJECT_STATUS.md` est un index stable, sans branche active.
+- `RELEASE_READINESS.md` se met à jour après merge sur `develop`, pas depuis une branche fonctionnelle.
 
 ## Stack courte
 

--- a/docs/00-START-HERE.md
+++ b/docs/00-START-HERE.md
@@ -11,11 +11,13 @@ Point d'entrée stable pour tout agent IA. Ne pas y stocker l'état vivant du pr
 
 ## Lecture minimale
 
-1. Statut actuel : [[public/current-state/PROJECT_STATUS]]
-2. Prochaines actions : [[public/current-state/NEXT_ACTIONS]]
-3. Routeur de tâche : [[public/nav/task-router]]
-4. Règles d'architecture : [[public/tech/ARCHITECTURE_RULES]]
-5. Politique canon privé : [[public/nav/PRIVATE_CANON_POLICY]]
+1. Index d'état : [[public/current-state/PROJECT_STATUS]]
+2. Préparation release : [[public/current-state/RELEASE_READINESS]]
+3. Statut du domaine concerné : [[public/current-state/FRONTEND_STATUS]] ou [[public/current-state/BACKEND_STATUS]]
+4. Prochaines actions du domaine : [[public/current-state/FRONTEND_NEXT]] ou [[public/current-state/BACKEND_NEXT]]
+5. Routeur de tâche : [[public/nav/task-router]]
+6. Règles d'architecture : [[public/tech/ARCHITECTURE_RULES]]
+7. Politique canon privé : [[public/nav/PRIVATE_CANON_POLICY]]
 
 ## Règles absolues
 
@@ -29,6 +31,7 @@ Point d'entrée stable pour tout agent IA. Ne pas y stocker l'état vivant du pr
 docs/
 ├── 00-HOME.md              # dashboard Obsidian humain
 ├── 00-START-HERE.md        # point d'entrée IA stable
+├── public/current-state/   # états séparés frontend/backend/release
 ├── public/                 # docs partageables, routables, versionnées (canon inclus)
 └── private/                # plans en cours, assets lourds, archives — gitignored
 ```

--- a/docs/public/archive/plans/PHASE-1B-BACKLOG.md
+++ b/docs/public/archive/plans/PHASE-1B-BACKLOG.md
@@ -1,8 +1,8 @@
-# Phase 1B — Backlog
+# Phase 1B — Backlog archivé
 
-> **Statut** : Phase 1B **en cours**. Landing (Phase 1A) mergée. Vertical slice gamesession livrée en démo (EPIC #95, PR #102).
-> B1 (triptyque shared) et B2 (OpenRouter provider) sont faits. Prochains écrans : Auberge de L'Aveugle (priorité 1), Character Create, World Map.
-> Source de vérité à jour : [[PROJECT_STATUS]] · [[NEXT_ACTIONS]].
+> **Statut : archivé.** Cette photographie Phase 1B n'est plus une source de tâches.
+> Sources vivantes : [[../../current-state/PROJECT_STATUS]] · [[../../current-state/FRONTEND_NEXT]] ·
+> [[../../current-state/BACKEND_NEXT]].
 
 ## Garde-fous produit
 

--- a/docs/public/archive/plans/PLAN-DURCIR-MOTEUR-SESSION.md
+++ b/docs/public/archive/plans/PLAN-DURCIR-MOTEUR-SESSION.md
@@ -1,6 +1,6 @@
-# PLAN — Durcir le moteur de session backend (A1 + A2) · Phase 1B
+# PLAN — Durcir le moteur de session backend (A1 + A2) · Phase 1B — archivé
 
-> **Doc de reprise.** Si je reviens plus tard, je lis ce fichier + l'issue GitHub du chantier et je reprends où j'en étais.
+> **Statut : livré.** Issue #109 fermée. Conservé pour historique ; ne pas utiliser comme doc de reprise.
 > **d20 souverain + world-state persistant.** Rapatrier au backend les règles aujourd'hui simulées au front.
 > **Dernière mise à jour** : 2026-07-12.
 

--- a/docs/public/archive/plans/PLAN-GAMESESSION-1B.md
+++ b/docs/public/archive/plans/PLAN-GAMESESSION-1B.md
@@ -1,6 +1,6 @@
-# PLAN — Vertical-slice gamesession Velkhar (MJ IA) · Phase 1B
+# PLAN — Vertical-slice gamesession Velkhar (MJ IA) · Phase 1B — archivé
 
-> **Doc de reprise.** Si je reviens plus tard, je lis ce fichier + l'EPIC [#95](https://github.com/AdamDjo/Grimoire-game/issues/95) et je reprends où j'en étais.
+> **Statut : livré.** EPIC #95 fermée. Conservé pour historique ; ne pas utiliser comme doc de reprise.
 > **Dernière mise à jour** : 2026-07-11.
 
 ---
@@ -155,7 +155,7 @@ UI déjà dispo : `Heading`, `NavBar`, `Footer`, `Section`, `PageShell`, `StatIt
 - `docs/public/raw/06-SURVIVAL.md` — 4 jauges + Calamine + conditions + biomes + équipement.
 - `docs/public/raw/14-META-WORLD.md` §2 — Souvenirs.
 - `docs/public/tech/TECH_STACK.md` — Express+TS, OpenRouter, Supabase+pgvector, flux de tour.
-- `docs/public/plans-actifs/PHASE-1B-BACKLOG.md` — bloqueurs B1/B2/B3, écrans, tests.
+- `docs/public/archive/plans/PHASE-1B-BACKLOG.md` — photographie historique des bloqueurs B1/B2/B3.
 
 ---
 

--- a/docs/public/archive/plans/PLAN-UI-KIT-PRODUCTION.md
+++ b/docs/public/archive/plans/PLAN-UI-KIT-PRODUCTION.md
@@ -1,6 +1,6 @@
-# Plan de production du UI Kit Grimoire
+# Plan de production du UI Kit Grimoire — archivé
 
-> Statut : plan validable avant implémentation.
+> Statut : livré par l'issue #93 et la PR #121 le 13 juillet 2026. Conservé pour historique.
 > Portée : assainissement des assets, pipeline reproductible, composants React
 > réutilisables, Storybook, tests, documentation et migration progressive.
 > Contrainte Git : créer les issues avant les branches. Ne pas mélanger ce

--- a/docs/public/current-state/BACKEND_NEXT.md
+++ b/docs/public/current-state/BACKEND_NEXT.md
@@ -1,0 +1,25 @@
+---
+type: backend-actions
+visibility: public
+rag: true
+source_of_truth: true
+owner: backend
+updated: 2026-07-17
+---
+
+# Backend Next
+
+## Avant v0.1.0
+
+1. Terminer et merger #147 sans étendre le scope à l'échange Souvenir/lore.
+2. Livrer #101 pour éviter qu'un 429 OpenRouter transforme trop souvent une scène en stub.
+3. Résoudre #152 ou fournir au frontend un signal permettant de masquer le concept libre.
+4. Déployer l'API et les migrations avec #161.
+5. Traiter l'audit sécurité #162.
+6. Supporter le golden path réel #129.
+
+## Après v0.1.0
+
+1. #114 — rappel sémantique pgvector.
+2. #117 — World events scriptés.
+3. #133 — échange Souvenir contre lore.

--- a/docs/public/current-state/BACKEND_STATUS.md
+++ b/docs/public/current-state/BACKEND_STATUS.md
@@ -1,0 +1,37 @@
+---
+type: backend-status
+visibility: public
+rag: true
+source_of_truth: true
+owner: backend
+updated: 2026-07-17
+---
+
+# Backend Status
+
+## Actif
+
+- Issue : #147 — brancher l'Auberge de L'Aveugle à la base et aux contrats API.
+- Branche connue : `feature/147-auberge-aveugle-backend`.
+- Le ticket reste volontairement unique pendant son chantier actif pour éviter un redécoupage
+  concurrent ; il est suivi par l'epic backend #165.
+
+## Livré sur develop
+
+- #103 et #146 — Prisma/Supabase, world-state et personnage persistants.
+- #107 — auth Supabase et vérification JWT/JWKS.
+- #109 — d20, conséquences et world-state souverains côté backend.
+- #111 et #113 — mémoire narrative N2/N1.
+- #115 et #116 — Souvenirs nommés et Chronique de fin de run.
+- #154 et #155 — gestion des erreurs asynchrones et délimitation du texte libre dans le prompt.
+
+## Gaps v0.1.0
+
+- #147 — retirer les fixtures autoritatives de l'Auberge ;
+- #101 — fallback multi-modèles face aux 429 OpenRouter ;
+- #152 — résolution canonique du concept libre ;
+- #161 — hébergement API, migrations, secrets, CORS et healthcheck ;
+- #162 — vulnérabilités critiques/hautes ;
+- #129 — golden path contre les services réels.
+
+Epic : #165. Coordination frontend : #123.

--- a/docs/public/current-state/FRONTEND_NEXT.md
+++ b/docs/public/current-state/FRONTEND_NEXT.md
@@ -1,0 +1,26 @@
+---
+type: frontend-actions
+visibility: public
+rag: true
+source_of_truth: true
+owner: frontend
+updated: 2026-07-17
+---
+
+# Frontend Next
+
+## Avant v0.1.0
+
+1. Faire relire et merger la PR #160 qui ferme #135.
+2. Après #147, remplacer les fixtures autoritatives de l'Auberge par les contrats réels.
+3. Intégrer #152 ou masquer proprement le concept libre pour la première release.
+4. Participer à #161 pour les variables Vercel et redirects Supabase.
+5. Exécuter #129 contre l'environnement de release.
+
+## Après v0.1.0
+
+1. #136 — Profil, Paramètres et confidentialité.
+2. #130 — Chronologie personnelle.
+3. #131 — Galerie des Souvenirs.
+4. #127 — World Map progressive.
+5. #159 — linking multi-provider.

--- a/docs/public/current-state/FRONTEND_STATUS.md
+++ b/docs/public/current-state/FRONTEND_STATUS.md
@@ -1,0 +1,38 @@
+---
+type: frontend-status
+visibility: public
+rag: true
+source_of_truth: true
+owner: frontend
+updated: 2026-07-17
+---
+
+# Frontend Status
+
+## Actif
+
+- Issue : #135 — auth complète et conversion anonyme.
+- Branche : `feature/135-auth-conversion-anonyme`.
+- PR : #160 vers `develop`, CI et preview Vercel vertes ; review/merge restant.
+
+## Livré sur develop
+
+- #93 / PR #121 — UI Kit Grimoire global ; le chantier UI Kit est terminé.
+- #149 — architecture frontend multi-univers.
+- #124 — Forge guidée, branchée ensuite à la persistance par #146.
+- #126 et #142 — Auberge UI et cinématique d'entrée.
+- #125 et #134 — Game Session, inventaire, fiche et menu.
+- #128 — dashboard, reprise et navigation.
+- #132 — fin de run et lecteur de Chronique.
+
+## Gaps v0.1.0
+
+- intégrer les contrats réels de l'Auberge lorsque #147 sera livré ;
+- décider avec #152 si le concept libre est livré ou masqué pour v0.1.0 ;
+- configurer le domaine/API/redirects de production avec #161 ;
+- valider le golden path réel dans #129.
+
+Les écrans Profil (#136), Chronologie (#130), Galerie (#131) et World Map (#127) ne sont pas
+« oubliés » : ils sont explicitement différés après v0.1.0 et ne bloquent pas le premier run.
+
+Epic : #123. Coordination backend : #165.

--- a/docs/public/current-state/NEXT_ACTIONS.md
+++ b/docs/public/current-state/NEXT_ACTIONS.md
@@ -1,5 +1,5 @@
 ---
-type: actions
+type: actions-index
 visibility: public
 rag: true
 updated: 2026-07-17
@@ -7,31 +7,11 @@ updated: 2026-07-17
 
 # Next Actions
 
-## Immédiat
+Routeur de compatibilité. Ne pas y recopier les files d'attente des chantiers.
 
-1. **Finaliser #132** : relire et livrer la fin de run, l’attente de génération et le lecteur de
-   Chronique public, puis ouvrir la PR vers `develop`.
+- Priorité release commune : [[RELEASE_READINESS]]
+- Travail frontend : [[FRONTEND_NEXT]]
+- Travail backend : [[BACKEND_NEXT]]
 
-## EPIC frontend #123 — ordre recommandé
-
-2. [#135](https://github.com/AdamDjo/Grimoire-game/issues/135) — **Auth complète et conversion anonyme**.
-3. [#136](https://github.com/AdamDjo/Grimoire-game/issues/136) — **Profil, Paramètres et confidentialité**.
-4. [#130](https://github.com/AdamDjo/Grimoire-game/issues/130), [#131](https://github.com/AdamDjo/Grimoire-game/issues/131), [#127](https://github.com/AdamDjo/Grimoire-game/issues/127), puis [#129](https://github.com/AdamDjo/Grimoire-game/issues/129).
-
-## A3 — mémoire narrative, suite (après merge #111)
-
-5. [#114](https://github.com/AdamDjo/Grimoire-game/issues/114) — **pgvector / rappel sémantique** sur les `MemoryChunk`.
-6. [#117](https://github.com/AdamDjo/Grimoire-game/issues/117) — **World events (Level C)**, priorité basse (dépend du contenu design, pas du code).
-
-## Phase 1B — écrans restants
-
-7. **Backend Auberge de L'Aveugle** : remplacer les fixtures frontend de #126 par `aveugle.service.ts` et ses contrats API.
-8. **Écran Character Create (la Forge)** : 4 vocations + concept libre, peuples, attribution triptyque.
-9. **Écran World Map (Makhzen)** : carte désertique, régions, points d'intérêt.
-
-## Différé
-
-10. #101 — fallback chain multi-modèles OpenRouter (ouvert, non implémenté).
-11. Ticket dédié vulnérabilités Dependabot (3 critiques sur `develop`).
-
-> Garde-fous produit inchangés : **Velkhar only**, MVP court (vertical slice 45-70 min), lore progressif, moat backend d'abord. Voir [[PHASE-1B-BACKLOG]].
+Ordre global actuel : terminer/merger #135 et #147, déployer l'API (#161), traiter la sécurité
+(#162), puis valider le golden path réel (#129) avant la branche `release/0.1.0` (#163).

--- a/docs/public/current-state/PROJECT_STATUS.md
+++ b/docs/public/current-state/PROJECT_STATUS.md
@@ -1,5 +1,5 @@
 ---
-type: status
+type: status-index
 visibility: public
 rag: true
 source_of_truth: true
@@ -8,66 +8,37 @@ updated: 2026-07-17
 
 # Project Status
 
-## État actuel
+Index stable de l'état vivant. Ce fichier ne contient ni branche active ni journal de chantier :
+les agents frontend et backend ne doivent donc pas le modifier pendant une feature.
 
-- Projet : **GRIMOIRE — Of Ash and Salt**
-- Phase actuelle : **Phase 1B — parcours frontend Velkhar** (EPIC #123), après livraison du moteur backend et de la mémoire narrative principale.
-- Branche active : `feature/132-fin-run-chronique`.
-- Priorité active : compléter la fin de run, l’attente de génération et le lecteur public de
-  Chronique sans introduire de dépendance au futur contrat de publication backend.
-- Ordre recommandé ensuite : #135 auth complète, puis #136 profil et confidentialité.
+## Objectif actuel
 
-## Livré récemment
+Livrer **v0.1.0 — Première version jouable** : un vertical slice Velkhar déployé couvrant
+Landing → Auberge → Forge → Session → fin de run → Chronique, avec conversion anonyme vers compte.
 
-- **#134 — inventaire, fiche et menu de session** : ✅ mergée (PR #153 → `develop`). Le HUD
-  multi-univers partage désormais ses jauges, ressources, inventaire rapide et commandes, tandis
-  que Velkhar injecte ses statistiques et son équipement canonique 8+12.
-- **#149 — architecture frontend multi-univers** : ✅ mergée (PR #150 → `develop`). Velkhar
-  est colocalisé sous `(game)`, la boucle de session est partagée et les frontières ESLint
-  empêchent les dépendances inversées.
-- **#126 — Auberge de L’Aveugle** : ✅ mergée (PR #143 → `develop`). Deux flows distincts : seuil narratif avant création et hub immersif après création du personnage, fixé à `100dvh` sur desktop avec les espaces Parler, Souvenirs et Présage.
-- **#125 — Game Session pixel-perfect** : ✅ mergée (PR #148 → `develop`). Narration
-  prioritaire, choix typés, action libre, dés et conséquences, HUD compact et panneaux de session.
-- **#142 — cinématique d’entrée de l’auberge** : ✅ mergée (PR #145 → `develop`). Arrivée vidéo avant seuil/hub avec skip de session, autoplay fallback et reduced-motion.
-- **Phase 1A — landing** : ✅ mergée (#94).
-- **#124 — Character Create / Forge guidée** : ✅ mergée (PR #141 → `develop`). Le résultat temporaire est persisté côté frontend jusqu’au contrat API personnage.
-- **#128 — dashboard, reprise et navigation** : ✅ mergée (PR #139 → `develop`).
-- **#115 — Souvenirs nommés** et **#116 — Chronique de fin de run** : ✅ mergés (PR #138 et #140 → `develop`).
-- **EPIC #95 — vertical slice gamesession Velkhar** : ✅ mergée sur `develop` (PR #102, commit `9bb37a5`). Ferme #95→#100.
-- **#107 — auth Supabase** : ✅ livrée, en PR [#108](https://github.com/AdamDjo/Grimoire-game/pull/108) → `develop`. Tier anonyme (`signInAnonymously`), magic link + OAuth Google/Discord, JWT vérifié via JWKS dans `requireAuth`, cap 30 req anonymes → 403. Vérifiée live. Détail : [[../tech/AUTH]].
-- **#109 — moteur de session durci (A1+A2)** : ✅ mergé (PR #110 → `develop`). D20 + conséquences rapatriés côté backend, world-state persistant, `endReason` posé sur `GameSession`.
-- **#111 — mémoire narrative N2 (compression de scène)** : ✅ mergé (PR #118 → `develop`). Compression fire-and-forget tous les 8 tours via Mistral Small (fallback Llama 3.3), stockage `MemoryChunk`, injection des chunks récents + faits épinglés dans le prompt système.
+## Sources par domaine
 
-## Backlog A3 — mémoire narrative (après #111)
+| Besoin                     | Source de vérité       | Propriétaire d'édition            |
+| -------------------------- | ---------------------- | --------------------------------- |
+| Avancement frontend        | [[FRONTEND_STATUS]]    | chantier frontend                 |
+| Prochaines tâches frontend | [[FRONTEND_NEXT]]      | chantier frontend                 |
+| Avancement backend         | [[BACKEND_STATUS]]     | chantier backend                  |
+| Prochaines tâches backend  | [[BACKEND_NEXT]]       | chantier backend                  |
+| Préparation de release     | [[RELEASE_READINESS]]  | coordination release, après merge |
+| Routage documentaire       | [[../nav/task-router]] | maintenance docs                  |
 
-Chantier découpé en sous-tickets indépendants, tous rattachés à A3 :
+## Fondations livrées
 
-- [#113](https://github.com/AdamDjo/Grimoire-game/issues/113) — **N1, fenêtre court-terme** (3-5 derniers tours en clair). Gap confirmé : aucune implémentation actuelle, trou de continuité entre le tour 1 et le premier chunk N2 (tour 8).
-- [#114](https://github.com/AdamDjo/Grimoire-game/issues/114) — **pgvector / rappel sémantique** sur les `MemoryChunk` N2. Dépend de #111 (livré).
-- [#115](https://github.com/AdamDjo/Grimoire-game/issues/115) — **Souvenirs nommés (N3)**, persistants inter-runs. Dépend de `key_facts_pinned` (#111, livré).
-- [#116](https://github.com/AdamDjo/Grimoire-game/issues/116) — **Chronique de fin de run**. Génère un récit ~400 mots à partir de N2 + Souvenirs + `endReason`. Inclut la purge des `SceneLog` bruts post-génération (ancien scope #112, fermé et absorbé ici).
-- [#117](https://github.com/AdamDjo/Grimoire-game/issues/117) — **World events (Level C)**, scriptés manuellement, jamais IA-générés. Indépendant du reste de A3.
+- frontend : landing, Forge, Auberge UI, Game Session, inventaire/fiche/menu, fin de run,
+  Chronique et dashboard ;
+- backend : Supabase/Prisma, auth JWT, moteur de session souverain, world-state, mémoire N1/N2,
+  Souvenirs N3, Chronique et persistance du personnage ;
+- qualité : lint, type-check, tests, build, CodeQL et previews Vercel dans la CI.
 
-## Dette / non-autoritatif à durcir
+## Règle de synchronisation
 
-- #101 (fallback multi-modèles OpenRouter pour le Game Master principal) : ouvert, non implémenté.
-- 91 vulnérabilités Dependabot sur `develop` (3 critiques) — à traiter dans un ticket dédié.
-- **Cap anonyme contournable** (#107) : vider les cookies `sb-*` réinitialise le quota (nouvel `auth.users.id`). Dette V1 assumée (friction, pas sécurité). Détail : [[../tech/AUTH]].
-- **RLS Postgres** différé (#107, décision #7) : autorisation V1 = filtrage `userId` explicite côté Express.
-
-## Critères pour avancer dans la Phase 1B
-
-- #126 mergé sur `develop` avec séparation seuil/hub validée.
-- #142 mergé avec une arrivée cinématique qui précède le choix seuil/hub sans bloquer le joueur.
-- #125 Game Session reconstruite avec le UI Kit, tests et QA visuelle validés.
-- Parcours Landing → seuil → Forge → hub → Session sans cul-de-sac.
-
-## Sources liées
-
-- Prochaines actions : [[NEXT_ACTIONS]]
-- Backlog Phase 1B : [[PHASE-1B-BACKLOG]]
-- Plan gamesession 1B : [[PLAN-GAMESESSION-1B]]
-- Routeur IA : [[../nav/task-router]]
-- Canon : [[../nav/canon-index]]
-- Règles d'architecture : [[../tech/ARCHITECTURE_RULES]]
-- Authentification : [[../tech/AUTH]]
+- Une branche frontend modifie uniquement les fichiers `FRONTEND_*`.
+- Une branche backend modifie uniquement les fichiers `BACKEND_*`.
+- `RELEASE_READINESS.md` est actualisé après merge sur `develop`, jamais depuis deux branches
+  fonctionnelles concurrentes.
+- Ce fichier change seulement si l'objectif global ou la structure des sources change.

--- a/docs/public/current-state/RELEASE_READINESS.md
+++ b/docs/public/current-state/RELEASE_READINESS.md
@@ -1,0 +1,39 @@
+---
+type: release-status
+visibility: public
+rag: true
+source_of_truth: true
+owner: release-coordination
+updated: 2026-07-17
+---
+
+# Release Readiness — v0.1.0
+
+Ce fichier est mis à jour après merge sur `develop`, pas depuis une branche frontend ou backend.
+La checklist opérationnelle détaillée vit dans l'issue #163.
+
+## État au 17 juillet 2026
+
+| Bloc                    | État                 | Référence      |
+| ----------------------- | -------------------- | -------------- |
+| UI Kit                  | Livré                | #93 / PR #121  |
+| Epic frontend           | En cours             | #123           |
+| Auth/conversion anonyme | PR prête, non mergée | #135 / PR #160 |
+| Epic backend            | En cours             | #165           |
+| Auberge réelle          | En cours             | #147           |
+| Disponibilité IA        | À faire              | #101           |
+| Concept libre           | À trancher/livrer    | #152           |
+| Déploiement API         | À faire              | #161           |
+| Sécurité dépendances    | Bloquant             | #162           |
+| Golden path réel        | À faire              | #129           |
+| Checklist de livraison  | Ouverte              | #163           |
+
+## Hors scope de la première release
+
+Profil complet, Chronologie, Galerie des Souvenirs, World Map, linking multi-provider, pgvector,
+World events et échange Souvenir/lore.
+
+## Go / No-Go
+
+`NO-GO` tant que l'API n'est pas déployée, que les risques critiques ne sont pas traités et que
+le golden path #129 n'est pas vert sur l'environnement de release.

--- a/docs/public/nav/DOCS_MAP.md
+++ b/docs/public/nav/DOCS_MAP.md
@@ -14,11 +14,13 @@ source_of_truth: true
 
 ## Public
 
-- `current-state/PROJECT_STATUS.md` : phase, priorité, branche, état vivant.
-- `current-state/NEXT_ACTIONS.md` : prochaines actions courtes.
-- `plans-actifs/PHASE-1B-BACKLOG.md` : backlog futur.
-- `plans-actifs/PLAN-GAMESESSION-1B.md` : plan de reprise du chantier gamesession actif.
-- `plans-actifs/PLAN-UI-KIT-PRODUCTION.md` : plan du chantier UI-kit actif.
+- `current-state/PROJECT_STATUS.md` : index stable de l'état vivant.
+- `current-state/RELEASE_READINESS.md` : décision go/no-go et coordination v0.1.0.
+- `current-state/FRONTEND_STATUS.md` + `FRONTEND_NEXT.md` : état et file d'attente frontend.
+- `current-state/BACKEND_STATUS.md` + `BACKEND_NEXT.md` : état et file d'attente backend.
+- `current-state/NEXT_ACTIONS.md` : routeur de compatibilité, sans duplication de backlog.
+- `current-state/` : seules sources vivantes de statut, actions et release.
+- `archive/plans/` : anciens plans UI Kit, Game Session, moteur et backlog Phase 1B ; historique uniquement.
 - `nav/PRIVATE_CANON_POLICY.md` : règle public/privé.
 - `nav/RAG_RULES.md` : conventions RAG/mémoire.
 - `nav/DOCS_MAP.md` : cette carte.
@@ -28,6 +30,7 @@ source_of_truth: true
 - `project/PUBLIC_BRIEF.md` : pitch public + lore primer.
 - `design/GAME_DESIGN.md` : résumé design/gameplay.
 - `design/DESIGN_TOKENS.md` : tokens UI.
+- `design/UI_KIT.md` : composants et règles du UI Kit livré (#93 / PR #121).
 - `tech/ARCHITECTURE_RULES.md` : invariants backend/AI/frontend.
 - `tech/TECH_STACK.md` : stack active.
 - `raw/` : canon complet Velkhar (25 fichiers, public, versionné).
@@ -43,4 +46,4 @@ source_of_truth: true
 - `.claude/agents/backend-dev/agent.md` : agent dédié `apps/backend/`.
 - `.claude/agents/frontend-dev/agent.md` : agent dédié `apps/frontend/`.
 - `.claude/agents/code-reviewer/agent.md` : revue de code avant PR.
-- `.claude/skills/` : commandes slash (`status`, `implement`, `feature`, `bug`, `hotfix`, `release`, `pr`, `check`, `sync`) — chacune lit `PROJECT_STATUS.md`/`NEXT_ACTIONS.md` selon son besoin.
+- `.claude/skills/` : commandes slash (`status`, `implement`, `feature`, `bug`, `hotfix`, `release`, `pr`, `check`, `sync`) — elles doivent lire le statut du domaine concerné.

--- a/docs/public/nav/RAG_RULES.md
+++ b/docs/public/nav/RAG_RULES.md
@@ -19,7 +19,8 @@ Objectif : rendre le vault facile à indexer pour une IA sans créer de bruit ni
 
 ## Collections recommandées
 
-- `public-core` : `00-START-HERE`, status, actions, task-router, architecture rules.
+- `public-core` : `00-START-HERE`, index d'état, release readiness, statuts/actions par domaine,
+  task-router et architecture rules.
 - `public-reference` : design, tech stack, docs map, public brief.
 - `public-canon` : `docs/public/raw/`.
 - `private-plans` : plans actifs, prompts, assets, roadmap interne.
@@ -40,6 +41,7 @@ updated: 2026-07-04
 
 1. Lire `docs/00-START-HERE.md`.
 2. Lire `docs/public/current-state/PROJECT_STATUS.md`.
-3. Lire `docs/public/current-state/NEXT_ACTIONS.md`.
-4. Utiliser `docs/public/nav/task-router.md` pour choisir les fichiers ciblés.
-5. Lire le canon (`docs/public/raw/`) via `task-router.md`, seulement les fichiers ciblés par la tâche.
+3. Lire `RELEASE_READINESS.md` seulement pour une question de livraison globale.
+4. Lire les fichiers `FRONTEND_*` ou `BACKEND_*`, jamais les deux sans besoin transverse.
+5. Utiliser `docs/public/nav/task-router.md` pour choisir les fichiers ciblés.
+6. Lire le canon (`docs/public/raw/`) via `task-router.md`, seulement les fichiers ciblés par la tâche.

--- a/docs/public/nav/log.md
+++ b/docs/public/nav/log.md
@@ -139,3 +139,26 @@ Balayage de tous les fichiers contenant des liens markdown/wiki-links (`00-START
 - `task-router.md` et `apps/frontend/CLAUDE.md` référençaient encore `docs/private/plans/landing/PLAN-LANDING-CUBERTO-LEVEL.md` et `LANDING_SEO_BILINGUAL_PLAN.md` — ces fichiers n'existent plus (Phase 1A livrée, plans landing archivés). Remplacés par les entrées vers les plans actifs réels : `docs/private/plans/gamesession-1b/NOTES-IMPLEMENTATION.md` et `docs/private/plans/ui-kit/PLAN-UI-KIT-PRODUCTION.md`.
 - `TECH_STACK.md` : mention résiduelle "canon privé" corrigée en "canon (`docs/public/raw/`)" — terminologie obsolète depuis que le canon est public.
 - Tous les autres liens vérifiés (contenu lu intégralement, pas juste grep) : corrects.
+
+---
+
+## 2026-07-17 — Séparation des états frontend, backend et release
+
+Le travail parallèle frontend/backend provoquait des conflits récurrents dans `PROJECT_STATUS.md`
+et `NEXT_ACTIONS.md`. Les responsabilités documentaires sont désormais séparées :
+
+- `PROJECT_STATUS.md` devient un index stable sans branche active ;
+- `NEXT_ACTIONS.md` devient un routeur de compatibilité sans backlog dupliqué ;
+- `FRONTEND_STATUS.md` + `FRONTEND_NEXT.md` appartiennent au chantier frontend ;
+- `BACKEND_STATUS.md` + `BACKEND_NEXT.md` appartiennent au chantier backend ;
+- `RELEASE_READINESS.md` est synchronisé après merge sur `develop`, jamais depuis deux branches concurrentes ;
+- les skills et agents Codex/Claude ont été alignés sur ces frontières.
+
+---
+
+## 2026-07-17 — Clôture documentaire des chantiers UI Kit et Phase 1B
+
+L'issue UI Kit #93 est fermée et sa PR #121 est mergée. Les anciens plans UI Kit, vertical slice
+Game Session, durcissement moteur et backlog Phase 1B ont été déplacés de `plans-actifs/` vers
+`public/archive/plans/`. Le frontend v0.1 reste ouvert uniquement pour l'auth, les intégrations
+réelles, la configuration de production et le golden path ; les écrans secondaires sont post-v0.1.

--- a/docs/public/nav/task-router.md
+++ b/docs/public/nav/task-router.md
@@ -9,19 +9,22 @@ source_of_truth: true
 
 Pour chaque tâche, lire uniquement les fichiers nécessaires.
 
-| Tâche                        | Lire                                                                                                            |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Comprendre le projet         | `docs/00-START-HERE.md` + `docs/public/current-state/PROJECT_STATUS.md`                                         |
-| Savoir quoi faire maintenant | `docs/public/current-state/NEXT_ACTIONS.md`                                                                     |
-| UI/frontend                  | `docs/public/design/GAME_DESIGN.md` + `docs/public/design/DESIGN_TOKENS.md`                                     |
-| Gamesession 1B (chantier)    | `docs/public/plans-actifs/PLAN-GAMESESSION-1B.md` + `docs/private/plans/gamesession-1b/NOTES-IMPLEMENTATION.md` |
-| UI Kit (chantier)            | `docs/public/plans-actifs/PLAN-UI-KIT-PRODUCTION.md` + `docs/private/plans/ui-kit/PLAN-UI-KIT-PRODUCTION.md`    |
-| Backend/service              | `docs/public/tech/TECH_STACK.md` + `docs/public/tech/ARCHITECTURE_RULES.md`                                     |
-| Shared contracts             | `packages/shared/CLAUDE.md` + `docs/public/tech/ARCHITECTURE_RULES.md`                                          |
-| Dice/stats                   | `docs/public/raw/04-ATTRIBUTES.md` + `docs/public/raw/08-DICE-RESOLUTION.md`                                    |
-| Auberge de L'Aveugle         | `docs/public/raw/15-GAME-MASTER.md` + `docs/public/raw/14-META-WORLD.md` + `docs/public/raw/22-GLOSSARY.md`     |
-| Character Create             | `docs/public/raw/07-CHARACTER-CREATION.md` + `docs/public/raw/05-VOCATIONS.md`                                  |
-| World Map                    | `docs/public/raw/02-WORLD-BIBLE.md` + `docs/public/raw/03-FACTIONS.md`                                          |
-| Session gameplay             | `docs/public/raw/09-ACTION-LOOP.md` + `docs/public/raw/15-GAME-MASTER.md`                                       |
-| Memory/RAG gameplay          | `docs/public/raw/16-MEMORY.md` + `docs/public/nav/RAG_RULES.md`                                                 |
-| Politique privé/public       | `docs/public/nav/PRIVATE_CANON_POLICY.md`                                                                       |
+| Tâche                        | Lire                                                                                                        |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Comprendre le projet         | `docs/00-START-HERE.md` + `docs/public/current-state/PROJECT_STATUS.md`                                     |
+| Préparer une release         | `docs/public/current-state/RELEASE_READINESS.md`                                                            |
+| Travailler sur le frontend   | `docs/public/current-state/FRONTEND_STATUS.md` + `docs/public/current-state/FRONTEND_NEXT.md`               |
+| Travailler sur le backend    | `docs/public/current-state/BACKEND_STATUS.md` + `docs/public/current-state/BACKEND_NEXT.md`                 |
+| Savoir quoi faire maintenant | choisir `FRONTEND_NEXT.md` ou `BACKEND_NEXT.md` selon le chantier                                           |
+| UI/frontend                  | `docs/public/design/GAME_DESIGN.md` + `docs/public/design/DESIGN_TOKENS.md`                                 |
+| Game Session (maintenance)   | `docs/public/design/GAME_DESIGN.md` + canon Session gameplay ci-dessous                                     |
+| UI Kit (livré/maintenance)   | `docs/public/design/UI_KIT.md` + `docs/public/design/DESIGN_TOKENS.md`                                      |
+| Backend/service              | `docs/public/tech/TECH_STACK.md` + `docs/public/tech/ARCHITECTURE_RULES.md`                                 |
+| Shared contracts             | `packages/shared/CLAUDE.md` + `docs/public/tech/ARCHITECTURE_RULES.md`                                      |
+| Dice/stats                   | `docs/public/raw/04-ATTRIBUTES.md` + `docs/public/raw/08-DICE-RESOLUTION.md`                                |
+| Auberge de L'Aveugle         | `docs/public/raw/15-GAME-MASTER.md` + `docs/public/raw/14-META-WORLD.md` + `docs/public/raw/22-GLOSSARY.md` |
+| Character Create             | `docs/public/raw/07-CHARACTER-CREATION.md` + `docs/public/raw/05-VOCATIONS.md`                              |
+| World Map                    | `docs/public/raw/02-WORLD-BIBLE.md` + `docs/public/raw/03-FACTIONS.md`                                      |
+| Session gameplay             | `docs/public/raw/09-ACTION-LOOP.md` + `docs/public/raw/15-GAME-MASTER.md`                                   |
+| Memory/RAG gameplay          | `docs/public/raw/16-MEMORY.md` + `docs/public/nav/RAG_RULES.md`                                             |
+| Politique privé/public       | `docs/public/nav/PRIVATE_CANON_POLICY.md`                                                                   |

--- a/docs/public/tech/TECH_STACK.md
+++ b/docs/public/tech/TECH_STACK.md
@@ -78,7 +78,7 @@
 ## Références ciblées
 
 - État projet : [`../current-state/PROJECT_STATUS.md`](../current-state/PROJECT_STATUS.md)
-- Backlog : [`../plans-actifs/PHASE-1B-BACKLOG.md`](../plans-actifs/PHASE-1B-BACKLOG.md)
+- Prochaines actions : [`../current-state/NEXT_ACTIONS.md`](../current-state/NEXT_ACTIONS.md)
 - Design : [`../design/GAME_DESIGN.md`](../design/GAME_DESIGN.md)
 - Architecture : [`ARCHITECTURE_RULES.md`](ARCHITECTURE_RULES.md)
 - Canon : [`../nav/canon-index.md`](../nav/canon-index.md)


### PR DESCRIPTION
## Résumé
- sépare les statuts et prochaines actions frontend/backend pour éviter les conflits Codex/Claude
- transforme PROJECT_STATUS et NEXT_ACTIONS en index stables
- ajoute la readiness v0.1.0 et les règles de propriété documentaire
- archive les plans UI Kit et Phase 1B déjà livrés
- aligne les agents et skills Claude sur les nouvelles frontières

## Validation
- [x] `pnpm lint`
- [x] `git diff --check`
- [x] aucune référence active vers les anciens chemins `plans-actifs`

Closes #164