### PR TITLE
docs(status): ajouter les bloqueurs de langue v0.1

### DIFF
--- a/docs/public/current-state/BACKEND_NEXT.md
+++ b/docs/public/current-state/BACKEND_NEXT.md
@@ -12,11 +12,12 @@ updated: 2026-07-17
 ## Avant v0.1.0
 
 1. Terminer et merger #147 sans étendre le scope à l'échange Souvenir/lore.
-2. Livrer #101 pour éviter qu'un 429 OpenRouter transforme trop souvent une scène en stub.
-3. Résoudre #152 ou fournir au frontend un signal permettant de masquer le concept libre.
-4. Déployer l'API et les migrations avec #161.
-5. Traiter l'audit sécurité #162.
-6. Supporter le golden path réel #129.
+2. Implémenter #168 : locale IA navigateur validée, persistée et fallback anglais.
+3. Livrer #101 pour éviter qu'un 429 OpenRouter transforme trop souvent une scène en stub.
+4. Résoudre #152 ou fournir au frontend un signal permettant de masquer le concept libre.
+5. Déployer l'API et les migrations avec #161.
+6. Traiter l'audit sécurité #162.
+7. Supporter le golden path réel #129.
 
 ## Après v0.1.0
 

--- a/docs/public/current-state/BACKEND_STATUS.md
+++ b/docs/public/current-state/BACKEND_STATUS.md
@@ -30,6 +30,7 @@ updated: 2026-07-17
 - #147 — retirer les fixtures autoritatives de l'Auberge ;
 - #101 — fallback multi-modèles face aux 429 OpenRouter ;
 - #152 — résolution canonique du concept libre ;
+- #168 — locale navigateur BCP-47 validée et cohérence de toutes les sorties IA ;
 - #161 — hébergement API, migrations, secrets, CORS et healthcheck ;
 - #162 — vulnérabilités critiques/hautes ;
 - #129 — golden path contre les services réels.

--- a/docs/public/current-state/FRONTEND_NEXT.md
+++ b/docs/public/current-state/FRONTEND_NEXT.md
@@ -12,10 +12,12 @@ updated: 2026-07-17
 ## Avant v0.1.0
 
 1. Faire relire et merger la PR #160 qui ferme #135.
-2. Après #147, remplacer les fixtures autoritatives de l'Auberge par les contrats réels.
-3. Intégrer #152 ou masquer proprement le concept libre pour la première release.
-4. Participer à #161 pour les variables Vercel et redirects Supabase.
-5. Exécuter #129 contre l'environnement de release.
+2. Livrer #167 : interface anglaise/française, anglais principal et aucun mélange de langue.
+3. Implémenter la détection/préférence navigateur de #168 côté frontend.
+4. Après #147, remplacer les fixtures autoritatives de l'Auberge par les contrats réels.
+5. Intégrer #152 ou masquer proprement le concept libre pour la première release.
+6. Participer à #161 pour les variables Vercel et redirects Supabase.
+7. Exécuter #129 contre l'environnement de release, avec sa matrice de langues.
 
 ## Après v0.1.0
 

--- a/docs/public/current-state/FRONTEND_STATUS.md
+++ b/docs/public/current-state/FRONTEND_STATUS.md
@@ -27,6 +27,8 @@ updated: 2026-07-17
 
 ## Gaps v0.1.0
 
+- #167 — unifier l'interface en anglais/français, avec anglais principal et fallback ;
+- #168 — détecter la locale navigateur et la transmettre au contrat IA ;
 - intégrer les contrats réels de l'Auberge lorsque #147 sera livré ;
 - décider avec #152 si le concept libre est livré ou masqué pour v0.1.0 ;
 - configurer le domaine/API/redirects de production avec #161 ;

--- a/docs/public/current-state/NEXT_ACTIONS.md
+++ b/docs/public/current-state/NEXT_ACTIONS.md
@@ -13,5 +13,6 @@ Routeur de compatibilité. Ne pas y recopier les files d'attente des chantiers.
 - Travail frontend : [[FRONTEND_NEXT]]
 - Travail backend : [[BACKEND_NEXT]]
 
-Ordre global actuel : terminer/merger #135 et #147, déployer l'API (#161), traiter la sécurité
-(#162), puis valider le golden path réel (#129) avant la branche `release/0.1.0` (#163).
+Ordre global actuel : terminer/merger #135 et #147, livrer l'interface EN/FR (#167) et la locale IA
+navigateur (#168), déployer l'API (#161), traiter la sécurité (#162), puis valider le golden path
+réel (#129) avant la branche `release/0.1.0` (#163).

--- a/docs/public/current-state/RELEASE_READINESS.md
+++ b/docs/public/current-state/RELEASE_READINESS.md
@@ -19,6 +19,8 @@ La checklist opérationnelle détaillée vit dans l'issue #163.
 | UI Kit                  | Livré                | #93 / PR #121  |
 | Epic frontend           | En cours             | #123           |
 | Auth/conversion anonyme | PR prête, non mergée | #135 / PR #160 |
+| Interface EN/FR         | À faire              | #167           |
+| Langue IA navigateur    | À faire              | #168           |
 | Epic backend            | En cours             | #165           |
 | Auberge réelle          | En cours             | #147           |
 | Disponibilité IA        | À faire              | #101           |
@@ -35,5 +37,6 @@ World events et échange Souvenir/lore.
 
 ## Go / No-Go
 
-`NO-GO` tant que l'API n'est pas déployée, que les risques critiques ne sont pas traités et que
-le golden path #129 n'est pas vert sur l'environnement de release.
+`NO-GO` tant que l'interface EN/FR et la locale IA ne sont pas cohérentes, que l'API n'est pas
+déployée, que les risques critiques ne sont pas traités et que le golden path #129 n'est pas vert
+sur l'environnement de release.


### PR DESCRIPTION
## Résumé
- ajoute #167 aux priorités frontend pour une UI officielle EN/FR
- ajoute #168 aux priorités front/back pour la locale IA navigateur
- met à jour le go/no-go et l’ordre avant #129

## Décision
- anglais principal et fallback
- UI anglaise/française
- narration IA selon une locale BCP-47 validée

Closes #169