### PR TITLE
feat(#147): brancher l'Auberge de l'Aveugle à la base de données

### DIFF
--- a/apps/backend/prisma/migrations/20260717161519_add_aveugle_fields/migration.sql
+++ b/apps/backend/prisma/migrations/20260717161519_add_aveugle_fields/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "Character" ADD COLUMN     "iron" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "aveugleSeenTopics" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- AlterTable
+ALTER TABLE "Souvenir" ADD COLUMN     "anonymous" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "aveugleLoreResult" TEXT;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2,14 +2,14 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 // ---------------------------------------------------------------------------
-// Vision domaine complète (voir docs/private/raw/*.md) — NON migrée ici :
+// Vision domaine complète (voir docs/public/raw/*.md) — NON migrée ici :
 // Peuples, Vocations (catalogues statiques, pas de table), Factions/réputation,
-// Quêtes, Inventaire/Items, Chroniques (résumé fin de run). Ces modèles
-// arriveront avec les écrans qui en ont besoin (Character Create, Auberge,
-// World Map).
+// Quêtes, Inventaire/Items complet, Traces, World Events. Ces modèles
+// arriveront avec les écrans qui en ont besoin (World Map, inventaire complet).
 //
-// Migré maintenant (coeur du world-state de session) : User, Character,
-// GameSession, SceneLog, MemoryChunk, Souvenir.
+// Migré aujourd'hui (coeur du world-state de session + méta) : User, Character
+// (avec fer et topics vus de l'Aveugle), GameSession, SceneLog, MemoryChunk,
+// Souvenir (anonyme ou nommé), Chronicle.
 // ---------------------------------------------------------------------------
 
 generator client {
@@ -59,6 +59,14 @@ model Character {
 
   /// États altérés persistants (Condition[]), ex: "fever", "poisoned".
   conditions String[]
+
+  /// Fer (🪙), monnaie in-game de Velkhar. Aucune mécanique de gain/dépense
+  /// n'est encore branchée ailleurs dans le backend — champ persistant seul.
+  iron Int @default(0)
+
+  /// Ids des topics du catalogue statique de L'Aveugle déjà vus par ce joueur
+  /// (le contenu des topics reste statique côté frontend, seul l'état "vu" persiste).
+  aveugleSeenTopics String[] @default([])
 
   createdAt DateTime @default(now())
   sessions  GameSession[]
@@ -149,8 +157,19 @@ model Souvenir {
   /// SceneLog.sceneType's convention — no Prisma enum in this schema.
   type  String
 
-  /// Placeholder for the future Aveugle Souvenir-for-lore exchange (#133). Unused for now.
+  /// True for an anonymous Souvenir (generic lore fragment, spendable as
+  /// currency with L'Aveugle — 11-INVENTORY-ECONOMY.md §3). False (default)
+  /// for a named Souvenir (a specific marked act of the player, narrative
+  /// only, never spendable). The player-facing word "Souvenir" covers both
+  /// sub-types on purpose (canon); this flag is the only backend distinction.
+  anonymous Boolean @default(false)
+
+  /// True once this Souvenir has been spent with L'Aveugle in exchange for
+  /// lore (#147). Only ever set on an anonymous Souvenir.
   sharedWithAveugle Boolean @default(false)
+  /// AI-generated lore text produced when this Souvenir was spent, kept for
+  /// display history. Null until `sharedWithAveugle` is set to true.
+  aveugleLoreResult String?
 
   createdAt DateTime @default(now())
 }

--- a/apps/backend/src/ai/aveugle-validator.test.ts
+++ b/apps/backend/src/ai/aveugle-validator.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  aveugleLoreOutputSchema,
+  aveugleTalkOutputSchema,
+  validateAveugleLoreOutput,
+  validateAveugleTalkOutput,
+} from './aveugle-validator'
+
+describe('aveugleTalkOutputSchema', () => {
+  it('accepts a valid reply', () => {
+    const result = aveugleTalkOutputSchema.safeParse({ reply: 'Le vent a parlé de toi.' })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an empty reply', () => {
+    const result = aveugleTalkOutputSchema.safeParse({ reply: '' })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a reply longer than 600 characters', () => {
+    const result = aveugleTalkOutputSchema.safeParse({ reply: 'a'.repeat(601) })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a payload missing reply', () => {
+    const result = aveugleTalkOutputSchema.safeParse({})
+
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('aveugleLoreOutputSchema', () => {
+  it('accepts a valid loreResult', () => {
+    const result = aveugleLoreOutputSchema.safeParse({ loreResult: 'La brume dorée tue.' })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an empty loreResult', () => {
+    const result = aveugleLoreOutputSchema.safeParse({ loreResult: '' })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a loreResult longer than 1200 characters', () => {
+    const result = aveugleLoreOutputSchema.safeParse({ loreResult: 'a'.repeat(1201) })
+
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('validateAveugleTalkOutput', () => {
+  it('returns success with parsed data for a valid payload', () => {
+    const result = validateAveugleTalkOutput({ reply: 'Trois pièces pour le lit.' })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual({ reply: 'Trois pièces pour le lit.' })
+  })
+
+  it('returns failure for a non-object payload', () => {
+    const result = validateAveugleTalkOutput('not an object')
+
+    expect(result.success).toBe(false)
+    expect(result.data).toBeUndefined()
+  })
+})
+
+describe('validateAveugleLoreOutput', () => {
+  it('returns success with parsed data for a valid payload', () => {
+    const result = validateAveugleLoreOutput({ loreResult: 'Le sel n’oublie aucun serment.' })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual({ loreResult: 'Le sel n’oublie aucun serment.' })
+  })
+
+  it('returns failure for a payload missing loreResult', () => {
+    const result = validateAveugleLoreOutput({})
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeTruthy()
+  })
+})

--- a/apps/backend/src/ai/aveugle-validator.ts
+++ b/apps/backend/src/ai/aveugle-validator.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod'
+
+/**
+ * Zod schema for L'Aveugle's free-talk AI output (`/api/aveugle/talk`).
+ * Single short reply in canon voice — no choices, no mood, no side effects
+ * (15-GAME-MASTER.md §1.1: warm, ironic, tutoie, short desert proverbs).
+ */
+export const aveugleTalkOutputSchema = z.object({
+  reply: z.string().min(1).max(600),
+})
+
+export type AveugleTalkOutput = z.infer<typeof aveugleTalkOutputSchema>
+
+/**
+ * Zod schema for L'Aveugle's Souvenir-for-lore exchange AI output
+ * (`/api/aveugle/souvenirs/:id/spend`). The AI only produces the lore text —
+ * the exchange price and eligibility are resolved by the backend beforehand.
+ */
+export const aveugleLoreOutputSchema = z.object({
+  loreResult: z.string().min(1).max(1200),
+})
+
+export type AveugleLoreOutput = z.infer<typeof aveugleLoreOutputSchema>
+
+export interface AveugleValidationResult<T> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+/** Parses and validates raw AI free-talk output; malformed output is rejected, never passed through. */
+export function validateAveugleTalkOutput(
+  raw: unknown
+): AveugleValidationResult<AveugleTalkOutput> {
+  const parsed = aveugleTalkOutputSchema.safeParse(raw)
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues.map((i) => i.message).join('; ') }
+  }
+  return { success: true, data: parsed.data }
+}
+
+/** Parses and validates raw AI Souvenir-exchange output; malformed output is rejected, never passed through. */
+export function validateAveugleLoreOutput(
+  raw: unknown
+): AveugleValidationResult<AveugleLoreOutput> {
+  const parsed = aveugleLoreOutputSchema.safeParse(raw)
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.issues.map((i) => i.message).join('; ') }
+  }
+  return { success: true, data: parsed.data }
+}

--- a/apps/backend/src/ai/system-prompt.test.ts
+++ b/apps/backend/src/ai/system-prompt.test.ts
@@ -43,7 +43,9 @@ function souvenir(overrides: Partial<SouvenirModel>): SouvenirModel {
     title: 'The Trader Who Never Lied',
     body: 'Yarel watched the old trader take his last breath by the dry well.',
     type: 'npc-death',
+    anonymous: false,
     sharedWithAveugle: false,
+    aveugleLoreResult: null,
     createdAt: new Date(),
     ...overrides,
   }

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -51,8 +51,8 @@ app.use('/api/game', gameLimiter, requireAuth, gameRouter)
 app.use('/api/character', apiLimiter, requireAuth, characterRouter)
 app.use('/api/souvenirs', apiLimiter, requireAuth, souvenirRouter)
 app.use('/api/chronicles', apiLimiter, requireAuth, chronicleRouter)
-// Aveugle's own router applies per-route limiters (mix of read-only and AI-backed endpoints).
-app.use('/api/aveugle', requireAuth, aveugleRouter)
+// Aveugle's router also applies its own stricter per-route limiter on AI-backed endpoints.
+app.use('/api/aveugle', apiLimiter, requireAuth, aveugleRouter)
 
 // Health check
 app.get('/api/health', (_req, res) => {

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -5,6 +5,7 @@ import rateLimit from 'express-rate-limit'
 
 import { env } from './config/env'
 import { requireAuth } from './middleware/auth.middleware'
+import { aveugleRouter } from './routes/aveugle.routes'
 import { characterRouter } from './routes/character.routes'
 import { chronicleRouter } from './routes/chronicle.routes'
 import { gameRouter } from './routes/game.routes'
@@ -50,6 +51,8 @@ app.use('/api/game', gameLimiter, requireAuth, gameRouter)
 app.use('/api/character', apiLimiter, requireAuth, characterRouter)
 app.use('/api/souvenirs', apiLimiter, requireAuth, souvenirRouter)
 app.use('/api/chronicles', apiLimiter, requireAuth, chronicleRouter)
+// Aveugle's own router applies per-route limiters (mix of read-only and AI-backed endpoints).
+app.use('/api/aveugle', requireAuth, aveugleRouter)
 
 // Health check
 app.get('/api/health', (_req, res) => {

--- a/apps/backend/src/routes/aveugle.routes.test.ts
+++ b/apps/backend/src/routes/aveugle.routes.test.ts
@@ -1,0 +1,241 @@
+import express from 'express'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AddressInfo } from 'node:net'
+
+const findFirstOrThrow = vi.fn()
+vi.mock('../lib/prisma', () => ({
+  prisma: { souvenir: { findFirstOrThrow } },
+}))
+
+const getAveugleHubState = vi.fn()
+const markTopicSeen = vi.fn()
+const generateAveugleTalkResponse = vi.fn()
+const spendSouvenirForLore = vi.fn()
+const priceForExchange = vi.fn()
+
+class SouvenirNotFoundError extends Error {}
+class SouvenirNotSpendableError extends Error {}
+
+vi.mock('../services/aveugle.service', () => ({
+  getAveugleHubState,
+  markTopicSeen,
+  generateAveugleTalkResponse,
+  spendSouvenirForLore,
+  priceForExchange,
+  SouvenirNotFoundError,
+  SouvenirNotSpendableError,
+}))
+
+const { aveugleRouter } = await import('./aveugle.routes')
+
+/** Boots the router on an ephemeral port with a fixed fake auth context. */
+async function withServer(
+  auth: { userId: string; isAnonymous: boolean },
+  run: (baseUrl: string) => Promise<void>
+): Promise<void> {
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.auth = auth
+    next()
+  })
+  app.use('/api/aveugle', aveugleRouter)
+
+  const server = app.listen(0)
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()))
+  const { port } = server.address() as AddressInfo
+  try {
+    await run(`http://127.0.0.1:${port}`)
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+}
+
+const AUTH = { userId: 'user1', isAnonymous: false }
+
+beforeEach(() => {
+  findFirstOrThrow.mockReset()
+  getAveugleHubState.mockReset()
+  markTopicSeen.mockReset()
+  generateAveugleTalkResponse.mockReset()
+  spendSouvenirForLore.mockReset()
+  priceForExchange.mockReset()
+})
+
+describe('GET /hub', () => {
+  it('returns the hub state scoped to the caller', async () => {
+    getAveugleHubState.mockResolvedValue({
+      iron: 5,
+      spendableSouvenirCount: 2,
+      namedSouvenirs: [],
+      seenTopicIds: [],
+    })
+
+    await withServer(AUTH, async (baseUrl) => {
+      const res = await fetch(`${baseUrl}/api/aveugle/hub`)
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { success: boolean; data: { iron: number } }
+      expect(body.success).toBe(true)
+      expect(body.data.iron).toBe(5)
+      expect(getAveugleHubState).toHaveBeenCalledWith('user1')
+    })
+  })
+})
+
+describe('POST /topics/:topicId/seen', () => {
+  it('marks the topic seen for the caller', async () => {
+    markTopicSeen.mockResolvedValue(undefined)
+
+    await withServer(AUTH, async (baseUrl) => {
+      const res = await fetch(`${baseUrl}/api/aveugle/topics/salt-guild/seen`, { method: 'POST' })
+      expect(res.status).toBe(200)
+      expect(markTopicSeen).toHaveBeenCalledWith('user1', 'salt-guild')
+    })
+  })
+
+  it('rejects a topicId longer than 50 characters with 400', async () => {
+    await withServer(AUTH, async (baseUrl) => {
+      const res = await fetch(`${baseUrl}/api/aveugle/topics/${'a'.repeat(51)}/seen`, {
+        method: 'POST',
+      })
+      expect(res.status).toBe(400)
+      expect(markTopicSeen).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('POST /talk', () => {
+  it('rejects a missing message with 400 and never calls the service', async () => {
+    await withServer(AUTH, async (baseUrl) => {
+      const res = await fetch(`${baseUrl}/api/aveugle/talk`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+      expect(res.status).toBe(400)
+      expect(generateAveugleTalkResponse).not.toHaveBeenCalled()
+    })
+  })
+
+  it('rejects a message over 500 characters with 400', async () => {
+    await withServer(AUTH, async (baseUrl) => {
+      const res = await fetch(`${baseUrl}/api/aveugle/talk`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: 'a'.repeat(501) }),
+      })
+      expect(res.status).toBe(400)
+      expect(generateAveugleTalkResponse).not.toHaveBeenCalled()
+    })
+  })
+
+  it('returns the reply and scopes the call to the caller userId', async () => {
+    generateAveugleTalkResponse.mockResolvedValue({
+      reply: 'Le sel se souvient.',
+      isFallback: false,
+    })
+
+    await withServer(AUTH, async (baseUrl) => {
+      const res = await fetch(`${baseUrl}/api/aveugle/talk`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: 'Qui es-tu ?' }),
+      })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { data: { reply: string; isFallback: boolean } }
+      expect(body.data).toEqual({ reply: 'Le sel se souvient.', isFallback: false })
+      expect(generateAveugleTalkResponse).toHaveBeenCalledWith('user1', 'Qui es-tu ?')
+    })
+  })
+})
+
+describe('POST /souvenirs/:souvenirId/spend', () => {
+  it('rejects an invalid exchangeType with 400 and never calls the service', async () => {
+    await withServer(AUTH, async (baseUrl) => {
+      const res = await fetch(`${baseUrl}/api/aveugle/souvenirs/sv1/spend`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ exchangeType: 'not-a-real-type' }),
+      })
+      expect(res.status).toBe(400)
+      expect(spendSouvenirForLore).not.toHaveBeenCalled()
+    })
+  })
+
+  it('returns 404 when the Souvenir is not found for the caller', async () => {
+    spendSouvenirForLore.mockRejectedValue(new SouvenirNotFoundError('not found'))
+
+    await withServer(AUTH, async (baseUrl) => {
+      const res = await fetch(`${baseUrl}/api/aveugle/souvenirs/sv1/spend`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ exchangeType: 'lore-fragment' }),
+      })
+      expect(res.status).toBe(404)
+    })
+  })
+
+  it('returns 409 when the Souvenir is not spendable (named or already spent)', async () => {
+    spendSouvenirForLore.mockRejectedValue(new SouvenirNotSpendableError('not spendable'))
+
+    await withServer(AUTH, async (baseUrl) => {
+      const res = await fetch(`${baseUrl}/api/aveugle/souvenirs/sv1/spend`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ exchangeType: 'lore-fragment' }),
+      })
+      expect(res.status).toBe(409)
+    })
+  })
+
+  it('returns 502 when the AI generation fails, and the Souvenir stays unspent', async () => {
+    spendSouvenirForLore.mockRejectedValue(new Error('ai_generation_failed'))
+
+    await withServer(AUTH, async (baseUrl) => {
+      const res = await fetch(`${baseUrl}/api/aveugle/souvenirs/sv1/spend`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ exchangeType: 'lore-fragment' }),
+      })
+      expect(res.status).toBe(502)
+      expect(findFirstOrThrow).not.toHaveBeenCalled()
+    })
+  })
+
+  it('returns the lore result and updated Souvenir on success, scoped to the caller', async () => {
+    spendSouvenirForLore.mockResolvedValue({
+      loreResult: 'Un fragment de lore.',
+      souvenirId: 'sv1',
+    })
+    findFirstOrThrow.mockResolvedValue({
+      id: 'sv1',
+      userId: 'user1',
+      characterId: 'char1',
+      sessionId: 'sess1',
+      title: 'La brume dorée tue',
+      body: 'b',
+      type: 'secret-discovery',
+      anonymous: true,
+      sharedWithAveugle: true,
+      aveugleLoreResult: 'Un fragment de lore.',
+      createdAt: new Date(),
+    })
+
+    await withServer(AUTH, async (baseUrl) => {
+      const res = await fetch(`${baseUrl}/api/aveugle/souvenirs/sv1/spend`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ exchangeType: 'lore-fragment' }),
+      })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as {
+        data: { loreResult: string; souvenir: { id: string; sharedWithAveugle: boolean } }
+      }
+      expect(body.data.loreResult).toBe('Un fragment de lore.')
+      expect(body.data.souvenir.id).toBe('sv1')
+      expect(body.data.souvenir.sharedWithAveugle).toBe(true)
+      expect(spendSouvenirForLore).toHaveBeenCalledWith('user1', 'sv1', 'lore-fragment')
+    })
+  })
+})

--- a/apps/backend/src/routes/aveugle.routes.ts
+++ b/apps/backend/src/routes/aveugle.routes.ts
@@ -1,0 +1,180 @@
+import { type Request, type Response, Router } from 'express'
+import rateLimit from 'express-rate-limit'
+
+import { prisma } from '../lib/prisma'
+import {
+  generateAveugleTalkResponse,
+  getAveugleHubState,
+  markTopicSeen,
+  priceForExchange,
+  SouvenirNotFoundError,
+  SouvenirNotSpendableError,
+  spendSouvenirForLore,
+} from '../services/aveugle.service'
+
+import {
+  souvenirIdParamSchema,
+  spendSouvenirSchema,
+  talkToAveugleSchema,
+  topicIdParamSchema,
+} from './aveugle.schema'
+
+import type {
+  ApiResponse,
+  AveugleHubState,
+  AveugleTalkResponse,
+  Souvenir,
+  SouvenirType,
+  SpendSouvenirResponse,
+} from '@grimoire/shared'
+
+export const aveugleRouter: Router = Router()
+
+// Read-only / low-cost endpoints — no AI call involved.
+const apiLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+})
+
+// AI-backed endpoints — protect the OpenRouter budget.
+const gameLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+})
+
+/**
+ * GET /api/aveugle/hub
+ * Read-only state for the Aveugle hub screen (fer, spendable Souvenir count,
+ * named Souvenirs, topics already seen). No AI call.
+ */
+aveugleRouter.get(
+  '/hub',
+  apiLimiter,
+  async (req: Request, res: Response<ApiResponse<AveugleHubState>>) => {
+    const data = await getAveugleHubState(req.auth!.userId)
+    res.json({ success: true, data })
+  }
+)
+
+/**
+ * POST /api/aveugle/topics/:topicId/seen
+ * Idempotently marks a hub topic (static frontend catalogue) as seen.
+ */
+aveugleRouter.post(
+  '/topics/:topicId/seen',
+  apiLimiter,
+  async (req: Request<{ topicId: string }>, res: Response<ApiResponse<null>>) => {
+    const parsed = topicIdParamSchema.safeParse(req.params)
+    if (!parsed.success) {
+      res.status(400).json({
+        success: false,
+        error: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      })
+      return
+    }
+
+    await markTopicSeen(req.auth!.userId, parsed.data.topicId)
+    res.json({ success: true, data: null })
+  }
+)
+
+/**
+ * POST /api/aveugle/talk
+ * Free-form dialogue with L'Aveugle. Stateless per turn, always answers in
+ * canon voice — falls back to a static reply if the AI call fails.
+ */
+aveugleRouter.post(
+  '/talk',
+  gameLimiter,
+  async (req: Request, res: Response<ApiResponse<AveugleTalkResponse>>) => {
+    const parsed = talkToAveugleSchema.safeParse(req.body)
+    if (!parsed.success) {
+      res.status(400).json({
+        success: false,
+        error: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      })
+      return
+    }
+
+    const data = await generateAveugleTalkResponse(req.auth!.userId, parsed.data.message)
+    res.json({ success: true, data })
+  }
+)
+
+/**
+ * POST /api/aveugle/souvenirs/:souvenirId/spend
+ * Spends an anonymous (spendable) Souvenir for AI-generated lore. Refuses
+ * named Souvenirs (narrative medals) and Souvenirs the caller doesn't own.
+ */
+aveugleRouter.post(
+  '/souvenirs/:souvenirId/spend',
+  gameLimiter,
+  async (
+    req: Request<{ souvenirId: string }>,
+    res: Response<ApiResponse<SpendSouvenirResponse>>
+  ) => {
+    const params = souvenirIdParamSchema.safeParse(req.params)
+    const body = spendSouvenirSchema.safeParse(req.body)
+    if (!params.success || !body.success) {
+      res.status(400).json({
+        success: false,
+        error: [
+          ...(params.success ? [] : params.error.issues),
+          ...(body.success ? [] : body.error.issues),
+        ]
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; '),
+      })
+      return
+    }
+
+    try {
+      const result = await spendSouvenirForLore(
+        req.auth!.userId,
+        params.data.souvenirId,
+        body.data.exchangeType
+      )
+
+      const row = await prisma.souvenir.findFirstOrThrow({ where: { id: result.souvenirId } })
+
+      const souvenir: Souvenir = {
+        id: row.id,
+        userId: row.userId,
+        characterId: row.characterId,
+        sessionId: row.sessionId,
+        title: row.title,
+        body: row.body,
+        type: row.type as SouvenirType,
+        anonymous: row.anonymous,
+        sharedWithAveugle: row.sharedWithAveugle,
+        aveugleLoreResult: row.aveugleLoreResult ?? undefined,
+        createdAt: row.createdAt.toISOString(),
+      }
+
+      res.json({ success: true, data: { loreResult: result.loreResult, souvenir } })
+    } catch (err) {
+      if (err instanceof SouvenirNotFoundError) {
+        res.status(404).json({ success: false, error: err.message })
+        return
+      }
+      if (err instanceof SouvenirNotSpendableError) {
+        res.status(409).json({ success: false, error: err.message })
+        return
+      }
+      if (err instanceof Error && err.message === 'ai_generation_failed') {
+        res
+          .status(502)
+          .json({ success: false, error: 'Lore generation failed, Souvenir not spent' })
+        return
+      }
+      throw err
+    }
+  }
+)
+
+// Exported for the exchange price table the frontend may want to render.
+export { priceForExchange }

--- a/apps/backend/src/routes/aveugle.schema.ts
+++ b/apps/backend/src/routes/aveugle.schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+
+export const talkToAveugleSchema = z.object({
+  message: z.string().min(1).max(500),
+})
+
+export const spendSouvenirSchema = z.object({
+  exchangeType: z.enum([
+    'lore-fragment',
+    'artifact-identification',
+    'quest-hint',
+    'region-map',
+    'moral-advice',
+  ]),
+})
+
+export const topicIdParamSchema = z.object({
+  topicId: z.string().min(1).max(50),
+})
+
+export const souvenirIdParamSchema = z.object({
+  souvenirId: z.string().min(1).max(100),
+})

--- a/apps/backend/src/routes/souvenir.routes.ts
+++ b/apps/backend/src/routes/souvenir.routes.ts
@@ -27,7 +27,9 @@ souvenirRouter.get('/', async (req: Request, res: Response<ApiResponse<Souvenir[
     title: row.title,
     body: row.body,
     type: row.type as SouvenirType,
+    anonymous: row.anonymous,
     sharedWithAveugle: row.sharedWithAveugle,
+    aveugleLoreResult: row.aveugleLoreResult ?? undefined,
     createdAt: row.createdAt.toISOString(),
   }))
 

--- a/apps/backend/src/services/aveugle.service.test.ts
+++ b/apps/backend/src/services/aveugle.service.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callOpenRouter = vi.fn()
+vi.mock('../ai/openrouter.provider', () => ({ callOpenRouter }))
+
+const characterFindFirst = vi.fn()
+const characterUpdate = vi.fn()
+const souvenirFindFirst = vi.fn()
+const souvenirFindMany = vi.fn()
+const souvenirUpdate = vi.fn()
+const souvenirFindFirstOrThrow = vi.fn()
+vi.mock('../lib/prisma', () => ({
+  prisma: {
+    character: { findFirst: characterFindFirst, update: characterUpdate },
+    souvenir: {
+      findFirst: souvenirFindFirst,
+      findMany: souvenirFindMany,
+      update: souvenirUpdate,
+      findFirstOrThrow: souvenirFindFirstOrThrow,
+    },
+  },
+}))
+
+const {
+  generateAveugleTalkResponse,
+  getAveugleHubState,
+  markTopicSeen,
+  priceForExchange,
+  SouvenirNotFoundError,
+  SouvenirNotSpendableError,
+  spendSouvenirForLore,
+} = await import('./aveugle.service')
+
+const character = {
+  id: 'char1',
+  userId: 'user1',
+  name: 'Yarel',
+  people: 'sahelin',
+  vocation: 'salt-walker',
+  iron: 12,
+  aveugleSeenTopics: ['salt-guild'],
+}
+
+beforeEach(() => {
+  callOpenRouter.mockReset()
+  characterFindFirst.mockReset().mockResolvedValue(character)
+  characterUpdate.mockReset().mockResolvedValue(character)
+  souvenirFindFirst.mockReset()
+  souvenirFindMany.mockReset().mockResolvedValue([])
+  souvenirUpdate.mockReset()
+  souvenirFindFirstOrThrow.mockReset()
+  vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+})
+
+describe('getAveugleHubState', () => {
+  it('splits named vs spendable Souvenirs and reports iron + seen topics', async () => {
+    souvenirFindMany.mockResolvedValue([
+      {
+        id: 's1',
+        userId: 'user1',
+        characterId: 'char1',
+        sessionId: 'sess1',
+        title: 'Named',
+        body: 'b',
+        type: 'npc-death',
+        anonymous: false,
+        sharedWithAveugle: false,
+        aveugleLoreResult: null,
+        createdAt: new Date(),
+      },
+      {
+        id: 's2',
+        userId: 'user1',
+        characterId: 'char1',
+        sessionId: 'sess1',
+        title: 'Anon unspent',
+        body: 'b',
+        type: 'npc-death',
+        anonymous: true,
+        sharedWithAveugle: false,
+        aveugleLoreResult: null,
+        createdAt: new Date(),
+      },
+      {
+        id: 's3',
+        userId: 'user1',
+        characterId: 'char1',
+        sessionId: 'sess1',
+        title: 'Anon spent',
+        body: 'b',
+        type: 'npc-death',
+        anonymous: true,
+        sharedWithAveugle: true,
+        aveugleLoreResult: 'lore',
+        createdAt: new Date(),
+      },
+    ])
+
+    const state = await getAveugleHubState('user1')
+
+    expect(state.iron).toBe(12)
+    expect(state.spendableSouvenirCount).toBe(1)
+    expect(state.namedSouvenirs).toHaveLength(1)
+    expect(state.namedSouvenirs[0]?.id).toBe('s1')
+    expect(state.seenTopicIds).toEqual(['salt-guild'])
+  })
+
+  it('returns zeroed defaults when the character does not exist yet', async () => {
+    characterFindFirst.mockResolvedValue(null)
+
+    const state = await getAveugleHubState('user1')
+
+    expect(state.iron).toBe(0)
+    expect(state.seenTopicIds).toEqual([])
+  })
+})
+
+describe('markTopicSeen', () => {
+  it('is a no-op when the topic was already marked seen', async () => {
+    await markTopicSeen('user1', 'salt-guild')
+
+    expect(characterUpdate).not.toHaveBeenCalled()
+  })
+
+  it('pushes the topic id when not seen yet', async () => {
+    await markTopicSeen('user1', 'calcines')
+
+    expect(characterUpdate).toHaveBeenCalledWith({
+      where: { id: 'char1' },
+      data: { aveugleSeenTopics: { push: 'calcines' } },
+    })
+  })
+
+  it('is a no-op when the character does not exist', async () => {
+    characterFindFirst.mockResolvedValue(null)
+
+    await markTopicSeen('user1', 'calcines')
+
+    expect(characterUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('generateAveugleTalkResponse', () => {
+  it('returns the AI reply on success', async () => {
+    callOpenRouter.mockResolvedValue({
+      success: true,
+      content: JSON.stringify({ reply: 'Le vent a parlé de toi.' }),
+    })
+
+    const result = await generateAveugleTalkResponse('user1', 'Qui es-tu ?')
+
+    expect(result).toEqual({ reply: 'Le vent a parlé de toi.', isFallback: false })
+  })
+
+  it('falls back to a static canon-voice reply when the AI call fails', async () => {
+    callOpenRouter.mockResolvedValue({ success: false, error: 'timeout' })
+
+    const result = await generateAveugleTalkResponse('user1', 'Qui es-tu ?')
+
+    expect(result.isFallback).toBe(true)
+    expect(result.reply.length).toBeGreaterThan(0)
+  })
+
+  it('falls back when the AI returns non-JSON', async () => {
+    callOpenRouter.mockResolvedValue({ success: true, content: 'not json' })
+
+    const result = await generateAveugleTalkResponse('user1', 'Qui es-tu ?')
+
+    expect(result.isFallback).toBe(true)
+  })
+
+  it('falls back when the AI JSON fails validation', async () => {
+    callOpenRouter.mockResolvedValue({ success: true, content: JSON.stringify({}) })
+
+    const result = await generateAveugleTalkResponse('user1', 'Qui es-tu ?')
+
+    expect(result.isFallback).toBe(true)
+  })
+
+  it('falls back without calling the AI when the character does not exist', async () => {
+    characterFindFirst.mockResolvedValue(null)
+
+    const result = await generateAveugleTalkResponse('user1', 'Qui es-tu ?')
+
+    expect(result.isFallback).toBe(true)
+    expect(callOpenRouter).not.toHaveBeenCalled()
+  })
+})
+
+describe('spendSouvenirForLore', () => {
+  const anonymousSouvenir = {
+    id: 'sv1',
+    userId: 'user1',
+    characterId: 'char1',
+    sessionId: 'sess1',
+    title: 'La brume dorée tue',
+    body: 'b',
+    type: 'secret-discovery',
+    anonymous: true,
+    sharedWithAveugle: false,
+    aveugleLoreResult: null,
+    createdAt: new Date(),
+  }
+
+  it('throws SouvenirNotFoundError when the Souvenir does not belong to the caller', async () => {
+    souvenirFindFirst.mockResolvedValue(null)
+
+    await expect(spendSouvenirForLore('user1', 'sv1', 'lore-fragment')).rejects.toThrow(
+      SouvenirNotFoundError
+    )
+    expect(callOpenRouter).not.toHaveBeenCalled()
+  })
+
+  it('throws SouvenirNotSpendableError for a named Souvenir (anonymous: false)', async () => {
+    souvenirFindFirst.mockResolvedValue({ ...anonymousSouvenir, anonymous: false })
+
+    await expect(spendSouvenirForLore('user1', 'sv1', 'lore-fragment')).rejects.toThrow(
+      SouvenirNotSpendableError
+    )
+    expect(callOpenRouter).not.toHaveBeenCalled()
+    expect(souvenirUpdate).not.toHaveBeenCalled()
+  })
+
+  it('throws SouvenirNotSpendableError for an already-spent anonymous Souvenir', async () => {
+    souvenirFindFirst.mockResolvedValue({ ...anonymousSouvenir, sharedWithAveugle: true })
+
+    await expect(spendSouvenirForLore('user1', 'sv1', 'lore-fragment')).rejects.toThrow(
+      SouvenirNotSpendableError
+    )
+    expect(callOpenRouter).not.toHaveBeenCalled()
+  })
+
+  it('persists sharedWithAveugle + aveugleLoreResult on AI success', async () => {
+    souvenirFindFirst.mockResolvedValue(anonymousSouvenir)
+    callOpenRouter.mockResolvedValue({
+      success: true,
+      content: JSON.stringify({ loreResult: 'Un fragment de lore.' }),
+    })
+
+    const result = await spendSouvenirForLore('user1', 'sv1', 'lore-fragment')
+
+    expect(result).toEqual({ loreResult: 'Un fragment de lore.', souvenirId: 'sv1' })
+    expect(souvenirUpdate).toHaveBeenCalledWith({
+      where: { id: 'sv1' },
+      data: { sharedWithAveugle: true, aveugleLoreResult: 'Un fragment de lore.' },
+    })
+  })
+
+  it('never marks the Souvenir spent when the AI call fails', async () => {
+    souvenirFindFirst.mockResolvedValue(anonymousSouvenir)
+    callOpenRouter.mockResolvedValue({ success: false, error: 'timeout' })
+
+    await expect(spendSouvenirForLore('user1', 'sv1', 'lore-fragment')).rejects.toThrow(
+      'ai_generation_failed'
+    )
+    expect(souvenirUpdate).not.toHaveBeenCalled()
+  })
+
+  it('never marks the Souvenir spent when the AI returns invalid JSON', async () => {
+    souvenirFindFirst.mockResolvedValue(anonymousSouvenir)
+    callOpenRouter.mockResolvedValue({ success: true, content: 'not json' })
+
+    await expect(spendSouvenirForLore('user1', 'sv1', 'lore-fragment')).rejects.toThrow(
+      'ai_generation_failed'
+    )
+    expect(souvenirUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('priceForExchange', () => {
+  it('matches the canon price table (11-INVENTORY-ECONOMY.md §3)', () => {
+    expect(priceForExchange('lore-fragment')).toBe(1)
+    expect(priceForExchange('artifact-identification')).toBe(1)
+    expect(priceForExchange('quest-hint')).toBe(2)
+    expect(priceForExchange('region-map')).toBe(3)
+    expect(priceForExchange('moral-advice')).toBe(1)
+  })
+})

--- a/apps/backend/src/services/aveugle.service.ts
+++ b/apps/backend/src/services/aveugle.service.ts
@@ -1,0 +1,336 @@
+import { getPeople, getVocation } from '@grimoire/shared'
+
+import {
+  type AveugleLoreOutput,
+  type AveugleTalkOutput,
+  validateAveugleLoreOutput,
+  validateAveugleTalkOutput,
+} from '../ai/aveugle-validator'
+import { callOpenRouter } from '../ai/openrouter.provider'
+import { env } from '../config/env'
+import { prisma } from '../lib/prisma'
+
+import type { AveugleExchangeType, AveugleHubState, SouvenirType } from '@grimoire/shared'
+
+const AVEUGLE_TIMEOUT_MS = 8000
+
+/**
+ * Canon phrases in L'Aveugle's voice (15-GAME-MASTER.md §1.1) — warm, ironic,
+ * tutoie, short desert proverbs. Injected as few-shot examples in every
+ * prompt so the model never drifts into "mystical old sage" or lyricism.
+ */
+const AVEUGLE_CANON_PHRASES = [
+  "Ah, tu reviens. Le sable t'a recraché, à ce que je vois. Assieds-toi, étranger. Le thé est tiède mais l'histoire sera chaude.",
+  'Le vent a parlé de toi cette nuit. Pas en bien. Pas en mal. Juste en long.',
+  'Trois pièces pour le lit. Une pour le thé. Et ton nom, gratuit — je le garderai.',
+  "Tu portes l'artefact d'un mort. Il pèse plus lourd que tu crois.",
+  "Un autre a tenté avant toi. Il n'est pas revenu. Toi non plus, peut-être.",
+]
+
+/**
+ * Static fallback replies in L'Aveugle's canon voice, returned when the AI
+ * call fails on `/api/aveugle/talk`. The player must never see a raw error —
+ * this bank guarantees a reply in voice regardless of AI availability.
+ */
+const AVEUGLE_TALK_FALLBACK_REPLIES = [
+  'Le vent me souffle mal ce soir, étranger. Redemande-moi ça, plus tard, au coin du feu.',
+  'Ma langue est aussi sèche que le sable, là, maintenant. Reviens quand le thé aura infusé.',
+  'Les mots se cachent, comme les os sous la dune. Laisse-moi le temps de les retrouver.',
+  'Pas maintenant. Même la lampe à huile a besoin de repos avant de brûler à nouveau.',
+]
+
+/** Canon price table for Souvenir-for-lore exchanges (11-INVENTORY-ECONOMY.md §3). */
+const EXCHANGE_PRICES: Record<AveugleExchangeType, number> = {
+  'lore-fragment': 1,
+  'artifact-identification': 1,
+  'quest-hint': 2,
+  'region-map': 3,
+  'moral-advice': 1,
+}
+
+const EXCHANGE_LABELS: Record<AveugleExchangeType, string> = {
+  'lore-fragment': 'Un fragment de lore générique, cohérent avec ton histoire',
+  'artifact-identification':
+    "L'identification d'un artefact (nom, histoire, faiblesse, effet d'éveil)",
+  'quest-hint': 'Un indice concret sur une quête en cours',
+  'region-map': "Une carte mentale d'une région (lieux d'intérêt)",
+  'moral-advice': 'Un conseil moral sur un dilemme (rare, casse sa neutralité habituelle)',
+}
+
+export class SouvenirNotSpendableError extends Error {}
+export class SouvenirNotFoundError extends Error {}
+
+function pickRandom<T>(items: readonly T[]): T {
+  return items[Math.floor(Math.random() * items.length)]
+}
+
+/**
+ * Pure-Prisma read of the Aveugle hub screen state (topics seen, fer, named
+ * Souvenirs, spendable Souvenir count). No AI call involved.
+ */
+export async function getAveugleHubState(userId: string): Promise<AveugleHubState> {
+  const [character, souvenirs] = await Promise.all([
+    prisma.character.findFirst({ where: { userId } }),
+    prisma.souvenir.findMany({ where: { userId }, orderBy: { createdAt: 'desc' } }),
+  ])
+
+  const namedSouvenirRows = souvenirs.filter((s) => !s.anonymous)
+  const spendableSouvenirCount = souvenirs.filter((s) => s.anonymous && !s.sharedWithAveugle).length
+
+  return {
+    iron: character?.iron ?? 0,
+    spendableSouvenirCount,
+    namedSouvenirs: namedSouvenirRows.map((s) => ({
+      id: s.id,
+      userId: s.userId,
+      characterId: s.characterId,
+      sessionId: s.sessionId,
+      title: s.title,
+      body: s.body,
+      type: s.type as SouvenirType,
+      anonymous: s.anonymous,
+      sharedWithAveugle: s.sharedWithAveugle,
+      aveugleLoreResult: s.aveugleLoreResult ?? undefined,
+      createdAt: s.createdAt.toISOString(),
+    })),
+    seenTopicIds: character?.aveugleSeenTopics ?? [],
+  }
+}
+
+/**
+ * Marks a hub topic as seen for this player (idempotent — no-op if already
+ * seen). The topic catalogue itself is a static frontend concept; only the
+ * "seen" state is persisted here. Pure Prisma, no AI call.
+ */
+export async function markTopicSeen(userId: string, topicId: string): Promise<void> {
+  const character = await prisma.character.findFirst({ where: { userId } })
+  if (!character) {
+    return
+  }
+  if (character.aveugleSeenTopics.includes(topicId)) {
+    return
+  }
+
+  await prisma.character.update({
+    where: { id: character.id },
+    data: { aveugleSeenTopics: { push: topicId } },
+  })
+}
+
+/** Builds the free-talk prompt in L'Aveugle's canon voice (15-GAME-MASTER.md §1.1). */
+function buildAveugleTalkPrompt(params: {
+  characterName: string
+  peopleLabel: string
+  vocationLabel: string
+  namedSouvenirs: { title: string; body: string }[]
+  playerMessage: string
+}): string {
+  const { characterName, peopleLabel, vocationLabel, namedSouvenirs, playerMessage } = params
+
+  return [
+    "Tu es L'Aveugle, aubergiste-prophète du Doigt-Cassé, à Velkhar.",
+    '',
+    '[IDENTITÉ]',
+    'Aubergiste-prophète, pas magicien. Tu connais le sable, le vent, le sel, la cendre, le thé tiède, les os blanchis, la lampe à huile, la porte.',
+    '',
+    '[VOIX]',
+    'Chaud, ironique, sage paysan. Tu tutoies toujours. Tu parles en proverbes désertiques courts.',
+    '',
+    '[PHRASES CANONIQUES (exemples de ton style, ne pas recopier telles quelles)]',
+    ...AVEUGLE_CANON_PHRASES.map((phrase) => `- « ${phrase} »`),
+    '',
+    '[INTERDITS]',
+    'Jamais lyrique. Jamais "vieux sage mystérieux". Jamais d\'emoji. Jamais de méta-commentaire.',
+    '',
+    '[LE VOYAGEUR EN FACE DE TOI]',
+    `Nom : ${characterName}`,
+    `Peuple : ${peopleLabel}`,
+    `Vocation : ${vocationLabel}`,
+    namedSouvenirs.length > 0
+      ? `Souvenirs marquants que tu te rappelles de lui : ${namedSouvenirs
+          .map((s) => s.title)
+          .join('; ')}`
+      : 'Tu ne te souviens encore de rien de marquant sur lui.',
+    '',
+    '[CE QUE LE VOYAGEUR TE DIT]',
+    playerMessage,
+    '',
+    '[INSTRUCTION]',
+    'Réponds STRICTEMENT en JSON : { "reply": "..." }. Une réplique courte (2-4 phrases), en voix de L\'Aveugle uniquement.',
+  ].join('\n')
+}
+
+async function tryGenerateTalk(prompt: string): Promise<AveugleTalkOutput | null> {
+  const result = await callOpenRouter([{ role: 'user', content: prompt }], {
+    model: env.openRouter.model,
+    timeoutMs: AVEUGLE_TIMEOUT_MS,
+  })
+  if (!result.success || !result.content) {
+    return null
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(result.content)
+  } catch {
+    return null
+  }
+
+  const validated = validateAveugleTalkOutput(parsed)
+  return validated.success && validated.data ? validated.data : null
+}
+
+/**
+ * Generates L'Aveugle's reply to a free-form player message. Stateless per
+ * canon (#147 spec): the context is rebuilt from DB on every call, no message
+ * history table. Never returns a raw AI error to the player — on failure,
+ * falls back to a static canon-voice reply picked at random.
+ */
+export async function generateAveugleTalkResponse(
+  userId: string,
+  playerMessage: string
+): Promise<{ reply: string; isFallback: boolean }> {
+  const character = await prisma.character.findFirst({ where: { userId } })
+
+  if (!character) {
+    return { reply: pickRandom(AVEUGLE_TALK_FALLBACK_REPLIES), isFallback: true }
+  }
+
+  const [people, vocation, namedSouvenirRows] = await Promise.all([
+    Promise.resolve(getPeople(character.people)),
+    Promise.resolve(getVocation(character.vocation)),
+    prisma.souvenir.findMany({
+      where: { userId, anonymous: false },
+      orderBy: { createdAt: 'desc' },
+      take: 3,
+    }),
+  ])
+
+  const prompt = buildAveugleTalkPrompt({
+    characterName: character.name,
+    peopleLabel: people?.name.fr ?? character.people,
+    vocationLabel: vocation?.name.fr ?? character.vocation,
+    namedSouvenirs: namedSouvenirRows.map((s) => ({ title: s.title, body: s.body })),
+    playerMessage,
+  })
+
+  const output = await tryGenerateTalk(prompt)
+  if (!output) {
+    console.warn(`[Aveugle] talk generation failed for user ${userId}, using static fallback`)
+    return { reply: pickRandom(AVEUGLE_TALK_FALLBACK_REPLIES), isFallback: true }
+  }
+
+  return { reply: output.reply, isFallback: false }
+}
+
+/** Builds the Souvenir-for-lore exchange prompt (11-INVENTORY-ECONOMY.md §3). */
+function buildAveugleLorePrompt(params: {
+  characterName: string
+  peopleLabel: string
+  vocationLabel: string
+  exchangeType: AveugleExchangeType
+  spentSouvenirTitle: string
+}): string {
+  const { characterName, peopleLabel, vocationLabel, exchangeType, spentSouvenirTitle } = params
+
+  return [
+    "Tu es L'Aveugle, aubergiste-prophète du Doigt-Cassé, à Velkhar. Un voyageur t'échange un Souvenir contre du savoir.",
+    '',
+    '[VOIX]',
+    'Chaud, ironique, sage paysan. Tu tutoies toujours. Proverbes désertiques courts. Jamais lyrique, jamais "vieux sage mystérieux".',
+    '',
+    '[LE VOYAGEUR]',
+    `Nom : ${characterName}`,
+    `Peuple : ${peopleLabel}`,
+    `Vocation : ${vocationLabel}`,
+    `Souvenir échangé : ${spentSouvenirTitle}`,
+    '',
+    '[CE QUI EST DEMANDÉ]',
+    EXCHANGE_LABELS[exchangeType],
+    '',
+    '[INSTRUCTION]',
+    'Réponds STRICTEMENT en JSON : { "loreResult": "..." }. 2-6 phrases, cohérentes avec le canon de Velkhar, jamais de stat ni de décision mécanique.',
+  ].join('\n')
+}
+
+async function tryGenerateLore(prompt: string): Promise<AveugleLoreOutput | null> {
+  const result = await callOpenRouter([{ role: 'user', content: prompt }], {
+    model: env.openRouter.model,
+    timeoutMs: AVEUGLE_TIMEOUT_MS,
+  })
+  if (!result.success || !result.content) {
+    return null
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(result.content)
+  } catch {
+    return null
+  }
+
+  const validated = validateAveugleLoreOutput(parsed)
+  return validated.success && validated.data ? validated.data : null
+}
+
+export interface SpendSouvenirResult {
+  loreResult: string
+  souvenirId: string
+}
+
+/**
+ * Spends an anonymous (spendable) Souvenir for AI-generated lore. Refuses
+ * outright if the Souvenir doesn't belong to `userId`, doesn't exist, is
+ * already spent, or — critically — is a named Souvenir (`anonymous: false`):
+ * named Souvenirs are narrative medals, never spendable (11-INVENTORY-ECONOMY
+ * §3). The Souvenir is only marked spent and `aveugleLoreResult` only written
+ * if the AI call succeeds — a failed AI call never costs the player their
+ * Souvenir.
+ */
+export async function spendSouvenirForLore(
+  userId: string,
+  souvenirId: string,
+  exchangeType: AveugleExchangeType
+): Promise<SpendSouvenirResult> {
+  const souvenir = await prisma.souvenir.findFirst({ where: { id: souvenirId, userId } })
+  if (!souvenir) {
+    throw new SouvenirNotFoundError('Souvenir not found')
+  }
+  if (!souvenir.anonymous || souvenir.sharedWithAveugle) {
+    throw new SouvenirNotSpendableError(
+      'This Souvenir is not spendable — only anonymous, unspent Souvenirs can be exchanged for lore'
+    )
+  }
+
+  const character = await prisma.character.findFirst({ where: { userId: souvenir.userId } })
+
+  const prompt = buildAveugleLorePrompt({
+    characterName: character?.name ?? 'le voyageur',
+    peopleLabel: character ? (getPeople(character.people)?.name.fr ?? character.people) : 'inconnu',
+    vocationLabel: character
+      ? (getVocation(character.vocation)?.name.fr ?? character.vocation)
+      : 'inconnue',
+    exchangeType,
+    spentSouvenirTitle: souvenir.title,
+  })
+
+  const output = await tryGenerateLore(prompt)
+  if (!output) {
+    console.warn(
+      `[Aveugle] lore exchange generation failed for souvenir ${souvenirId}, Souvenir not spent`
+    )
+    throw new Error('ai_generation_failed')
+  }
+
+  await prisma.souvenir.update({
+    where: { id: souvenirId },
+    data: { sharedWithAveugle: true, aveugleLoreResult: output.loreResult },
+  })
+
+  return { loreResult: output.loreResult, souvenirId }
+}
+
+/** Canon price (in spendable Souvenirs) for a given exchange type. */
+export function priceForExchange(exchangeType: AveugleExchangeType): number {
+  return EXCHANGE_PRICES[exchangeType]
+}

--- a/docs/public/current-state/BACKEND_NEXT.md
+++ b/docs/public/current-state/BACKEND_NEXT.md
@@ -4,14 +4,15 @@ visibility: public
 rag: true
 source_of_truth: true
 owner: backend
-updated: 2026-07-17
+updated: 2026-07-21
 ---
 
 # Backend Next
 
 ## Avant v0.1.0
 
-1. Terminer et merger #147 sans étendre le scope à l'échange Souvenir/lore.
+1. Merger [PR #174](https://github.com/AdamDjo/Grimoire-game/pull/174) (#147) — sans étendre le
+   scope à l'échange Souvenir/lore (#133, différé).
 2. Implémenter #168 : locale IA navigateur validée, persistée et fallback anglais.
 3. Livrer #101 pour éviter qu'un 429 OpenRouter transforme trop souvent une scène en stub.
 4. Résoudre #152 ou fournir au frontend un signal permettant de masquer le concept libre.

--- a/docs/public/current-state/BACKEND_STATUS.md
+++ b/docs/public/current-state/BACKEND_STATUS.md
@@ -4,17 +4,15 @@ visibility: public
 rag: true
 source_of_truth: true
 owner: backend
-updated: 2026-07-17
+updated: 2026-07-21
 ---
 
 # Backend Status
 
 ## Actif
 
-- Issue : #147 — brancher l'Auberge de L'Aveugle à la base et aux contrats API.
-- Branche connue : `feature/147-auberge-aveugle-backend`.
-- Le ticket reste volontairement unique pendant son chantier actif pour éviter un redécoupage
-  concurrent ; il est suivi par l'epic backend #165.
+- Aucun chantier backend en cours : #147 est terminé et attend la revue/merge de
+  [PR #174](https://github.com/AdamDjo/Grimoire-game/pull/174) → `develop`.
 
 ## Livré sur develop
 
@@ -25,9 +23,14 @@ updated: 2026-07-17
 - #115 et #116 — Souvenirs nommés et Chronique de fin de run.
 - #154 et #155 — gestion des erreurs asynchrones et délimitation du texte libre dans le prompt.
 
+## En attente de merge
+
+- #147 — Auberge de L'Aveugle branchée à la base et aux contrats API (`aveugle.service.ts`,
+  `aveugle.routes.ts`, hub/talk/spend). [PR #174](https://github.com/AdamDjo/Grimoire-game/pull/174)
+  → `develop`, 152/152 tests, type-check et lint clean.
+
 ## Gaps v0.1.0
 
-- #147 — retirer les fixtures autoritatives de l'Auberge ;
 - #101 — fallback multi-modèles face aux 429 OpenRouter ;
 - #152 — résolution canonique du concept libre ;
 - #168 — locale navigateur BCP-47 validée et cohérence de toutes les sorties IA ;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,7 @@ export * from "./types/session.types";
 export * from "./types/api.types";
 export * from "./types/souvenir.types";
 export * from "./types/chronicle.types";
+export * from "./types/aveugle.types";
 
 // Constants
 export * from "./constants/localized";

--- a/packages/shared/src/types/aveugle.types.ts
+++ b/packages/shared/src/types/aveugle.types.ts
@@ -1,0 +1,52 @@
+/**
+ * The Aveugle's Inn ("Le Doigt-Cassé") — hub state and exchanges with
+ * L'Aveugle, the innkeeper-prophet. Player-facing wording always says
+ * "Souvenirs" (canon), even though the backend distinguishes anonymous
+ * (spendable) from named (narrative only) Souvenirs internally.
+ * @see 15-GAME-MASTER.md §1.1, 11-INVENTORY-ECONOMY.md §3
+ */
+
+import type { Souvenir } from "./souvenir.types";
+
+/** State of the Aveugle hub screen for the authenticated player's character. */
+export interface AveugleHubState {
+  /** Fer (🪙) currently held by the character. */
+  iron: number;
+  /** Count of anonymous (spendable) Souvenirs still available. */
+  spendableSouvenirCount: number;
+  /** Named Souvenirs the player has earned so far, most recent first. */
+  namedSouvenirs: Souvenir[];
+  /** Topic ids from the frontend's static catalogue already seen by this player. */
+  seenTopicIds: string[];
+}
+
+export interface AveugleTalkRequest {
+  /** Free-form message the player addresses to L'Aveugle. */
+  message: string;
+}
+
+export interface AveugleTalkResponse {
+  /** L'Aveugle's reply, always in canon voice — AI-generated or a static fallback. */
+  reply: string;
+  /** True when the reply came from the static fallback bank (AI call failed). */
+  isFallback: boolean;
+}
+
+/** The canon exchange catalogue a spendable Souvenir can be traded for. @see 11-INVENTORY-ECONOMY.md §3 */
+export type AveugleExchangeType =
+  | "lore-fragment"
+  | "artifact-identification"
+  | "quest-hint"
+  | "region-map"
+  | "moral-advice";
+
+export interface SpendSouvenirRequest {
+  exchangeType: AveugleExchangeType;
+}
+
+export interface SpendSouvenirResponse {
+  /** The AI-generated lore text produced by the exchange. */
+  loreResult: string;
+  /** The spent Souvenir, updated (`sharedWithAveugle: true`). */
+  souvenir: Souvenir;
+}

--- a/packages/shared/src/types/souvenir.types.ts
+++ b/packages/shared/src/types/souvenir.types.ts
@@ -14,6 +14,16 @@ export interface Souvenir {
   title: string;
   body: string;
   type: SouvenirType;
+  /**
+   * True for an anonymous Souvenir (generic lore fragment, spendable as
+   * currency with L'Aveugle). False for a named Souvenir (a specific marked
+   * act of the player, narrative only, never spendable). The player-facing
+   * word "Souvenir" covers both sub-types on purpose (canon).
+   * @see 11-INVENTORY-ECONOMY.md §3
+   */
+  anonymous: boolean;
   sharedWithAveugle: boolean;
+  /** AI-generated lore text produced when this Souvenir was spent with L'Aveugle. */
+  aveugleLoreResult?: string;
   createdAt: string;
 }


### PR DESCRIPTION
## Résumé

- Ajoute le hub Aveugle (fer, Souvenirs dépensables/nommés, sujets vus), le dialogue libre avec fallback statique en voix canon, et l'échange Souvenir anonyme contre lore.
- Nouveau champ `Character.iron` (Fer, ressource canon) et `Souvenir.anonymous` (distingue Souvenir anonyme dépensable vs Souvenir nommé narratif — même mot côté joueur, distinction interne uniquement).
- Présages (`follow-smoke`/`avoid-bells`) volontairement exclus : pas de base canon.

## Endpoints

- `GET /api/aveugle/hub` — état du hub (lecture seule)
- `POST /api/aveugle/topics/:topicId/seen` — marque un sujet vu (idempotent)
- `POST /api/aveugle/talk` — dialogue libre, fallback statique si l'IA échoue
- `POST /api/aveugle/souvenirs/:souvenirId/spend` — échange un Souvenir anonyme contre du lore (404 si absent, 409 si non dépensable, 502 si l'IA échoue — jamais dépensé sur échec IA)

## Notes de conception

- Rate limiting appliqué par route à l'intérieur de `aveugle.routes.ts` (mix lecture-seule / IA), plutôt qu'un limiter unique au montage.
- Le seed "Souvenir-cadeau du prologue" supposé exister (#146) n'a pas été retrouvé dans le code — rien à rétro-marquer.

## Test plan

- [x] `pnpm test --filter @grimoire/backend --filter @grimoire/shared` — 152/152 tests passent
- [x] `pnpm type-check --filter @grimoire/backend --filter @grimoire/shared` — clean
- [x] `pnpm lint --filter @grimoire/backend --filter @grimoire/shared` — clean

Closes #147