### PR TITLE
docs(auth): documenter la conversion anonyme

### DIFF
--- a/docs/public/current-state/FRONTEND_NEXT.md
+++ b/docs/public/current-state/FRONTEND_NEXT.md
@@ -4,20 +4,19 @@ visibility: public
 rag: true
 source_of_truth: true
 owner: frontend
-updated: 2026-07-17
+updated: 2026-07-21
 ---
 
 # Frontend Next
 
 ## Avant v0.1.0
 
-1. Faire relire et merger la PR #160 qui ferme #135.
-2. Livrer #167 : interface anglaise/française, anglais principal et aucun mélange de langue.
-3. Implémenter la détection/préférence navigateur de #168 côté frontend.
-4. Après #147, remplacer les fixtures autoritatives de l'Auberge par les contrats réels.
-5. Intégrer #152 ou masquer proprement le concept libre pour la première release.
-6. Participer à #161 pour les variables Vercel et redirects Supabase.
-7. Exécuter #129 contre l'environnement de release, avec sa matrice de langues.
+1. Livrer #167 : interface anglaise/française, anglais principal et aucun mélange de langue.
+2. Implémenter la détection/préférence navigateur de #168 côté frontend.
+3. Après #147, remplacer les fixtures autoritatives de l'Auberge par les contrats réels.
+4. Intégrer #152 ou masquer proprement le concept libre pour la première release.
+5. Participer à #161 pour les variables Vercel et redirects Supabase.
+6. Exécuter #129 contre l'environnement de release, avec sa matrice de langues.
 
 ## Après v0.1.0
 

--- a/docs/public/current-state/FRONTEND_STATUS.md
+++ b/docs/public/current-state/FRONTEND_STATUS.md
@@ -4,16 +4,15 @@ visibility: public
 rag: true
 source_of_truth: true
 owner: frontend
-updated: 2026-07-17
+updated: 2026-07-21
 ---
 
 # Frontend Status
 
 ## Actif
 
-- Issue : #135 — auth complète et conversion anonyme.
-- Branche : `feature/135-auth-conversion-anonyme`.
-- PR : #160 vers `develop`, CI et preview Vercel vertes ; review/merge restant.
+- Prochain chantier frontend avant v0.1.0 : #167 — interface anglais/français.
+- #135 est mergée via PR #160 ; l'auth frontend passwordless est livrée sur `develop`.
 
 ## Livré sur develop
 
@@ -24,6 +23,9 @@ updated: 2026-07-17
 - #125 et #134 — Game Session, inventaire, fiche et menu.
 - #128 — dashboard, reprise et navigation.
 - #132 — fin de run et lecteur de Chronique.
+- #135 — auth complète et conversion anonyme : login/signup partagés, magic link
+  passwordless, conversion anonyme, récupération par renvoi de lien, prompt progressif avant
+  limite anonyme et logout dashboard.
 
 ## Gaps v0.1.0
 
@@ -36,5 +38,6 @@ updated: 2026-07-17
 
 Les écrans Profil (#136), Chronologie (#130), Galerie (#131) et World Map (#127) ne sont pas
 « oubliés » : ils sont explicitement différés après v0.1.0 et ne bloquent pas le premier run.
+Le linking multi-provider avancé (#159) est également différé après v0.1.0.
 
 Epic : #123. Coordination backend : #165.

--- a/docs/public/current-state/NEXT_ACTIONS.md
+++ b/docs/public/current-state/NEXT_ACTIONS.md
@@ -2,7 +2,7 @@
 type: actions-index
 visibility: public
 rag: true
-updated: 2026-07-17
+updated: 2026-07-21
 ---
 
 # Next Actions

--- a/docs/public/current-state/PROJECT_STATUS.md
+++ b/docs/public/current-state/PROJECT_STATUS.md
@@ -3,7 +3,7 @@ type: status-index
 visibility: public
 rag: true
 source_of_truth: true
-updated: 2026-07-17
+updated: 2026-07-21
 ---
 
 # Project Status

--- a/docs/public/current-state/RELEASE_READINESS.md
+++ b/docs/public/current-state/RELEASE_READINESS.md
@@ -4,7 +4,7 @@ visibility: public
 rag: true
 source_of_truth: true
 owner: release-coordination
-updated: 2026-07-17
+updated: 2026-07-21
 ---
 
 # Release Readiness — v0.1.0
@@ -12,23 +12,23 @@ updated: 2026-07-17
 Ce fichier est mis à jour après merge sur `develop`, pas depuis une branche frontend ou backend.
 La checklist opérationnelle détaillée vit dans l'issue #163.
 
-## État au 17 juillet 2026
+## État au 21 juillet 2026
 
-| Bloc                    | État                 | Référence      |
-| ----------------------- | -------------------- | -------------- |
-| UI Kit                  | Livré                | #93 / PR #121  |
-| Epic frontend           | En cours             | #123           |
-| Auth/conversion anonyme | PR prête, non mergée | #135 / PR #160 |
-| Interface EN/FR         | À faire              | #167           |
-| Langue IA navigateur    | À faire              | #168           |
-| Epic backend            | En cours             | #165           |
-| Auberge réelle          | En cours             | #147           |
-| Disponibilité IA        | À faire              | #101           |
-| Concept libre           | À trancher/livrer    | #152           |
-| Déploiement API         | À faire              | #161           |
-| Sécurité dépendances    | Bloquant             | #162           |
-| Golden path réel        | À faire              | #129           |
-| Checklist de livraison  | Ouverte              | #163           |
+| Bloc                    | État              | Référence      |
+| ----------------------- | ----------------- | -------------- |
+| UI Kit                  | Livré             | #93 / PR #121  |
+| Epic frontend           | En cours          | #123           |
+| Auth/conversion anonyme | Livré             | #135 / PR #160 |
+| Interface EN/FR         | À faire           | #167           |
+| Langue IA navigateur    | À faire           | #168           |
+| Epic backend            | En cours          | #165           |
+| Auberge réelle          | En cours          | #147           |
+| Disponibilité IA        | À faire           | #101           |
+| Concept libre           | À trancher/livrer | #152           |
+| Déploiement API         | À faire           | #161           |
+| Sécurité dépendances    | Bloquant          | #162           |
+| Golden path réel        | À faire           | #129           |
+| Checklist de livraison  | Ouverte           | #163           |
 
 ## Hors scope de la première release
 

--- a/docs/public/tech/AUTH.md
+++ b/docs/public/tech/AUTH.md
@@ -3,7 +3,7 @@ type: tech-auth
 visibility: public
 rag: true
 source_of_truth: true
-updated: 2026-07-12
+updated: 2026-07-21
 ---
 
 # Authentification (#107)
@@ -19,8 +19,22 @@ appel réseau par requête.
 3. **Connexion** : magic link email + OAuth Google + OAuth Discord.
 4. **Vérif backend** : JWT Supabase vérifié en local via JWKS (`jose`), pas d'appel réseau par requête.
 5. **Identité** : `User.id` (Prisma) = `auth.users.id` (Supabase), même UUID. L'id n'est jamais généré par Prisma.
-6. **Migration anonyme → compte** : rattachement transparent (`linkIdentity`). Câblage complet différé (voir Dette).
+6. **Migration anonyme → compte** : rattachement frontend par email ou OAuth depuis `/signup`, avec conservation explicite de la trace.
 7. **Autorisation V1** : filtrage `userId` explicite côté Express. RLS Postgres différé (dette explicite).
+
+## Flux frontend passwordless (#135)
+
+- `/login` et `/signup` partagent le composant `AuthAccessForm`.
+- Connexion email : `signInWithOtp` avec magic link, sans mot de passe.
+- Signup email sans session : `signInWithOtp` avec `shouldCreateUser: true`.
+- Conversion email depuis une session anonyme : `updateUser({ email })` avec redirect sécurisé.
+- OAuth Google/Discord :
+  - session anonyme sur `/signup` → `linkIdentity`;
+  - session absente ou non anonyme → `signInWithOAuth`.
+- Récupération d'accès : `/forgot-password` renvoie un nouveau magic link avec
+  `shouldCreateUser: false`; il n'y a pas de route `/reset-password`.
+- Callback auth : `/auth/callback` échange le code Supabase puis redirige uniquement vers
+  une destination interne validée par `getSafeInternalDestination`.
 
 ## Flux runtime
 
@@ -50,8 +64,9 @@ Backend Express  requireAuth (middleware, monté sur /api/game)
 - Limite : **`ANONYMOUS_REQUEST_LIMIT = 30`** (`auth.middleware.ts`).
 - Au-delà : `403 { success: false, error: 'Anonymous limit reached' }`. Le frontend
   bascule sur un blocage forcé (message + lien `/signup`, choix masqués).
-- Le compteur UI Zustand (`session-store.ts`) est **cosmétique** (soft-prompt) ; la
-  vérité du cap est en base, côté backend.
+- Le compteur UI Zustand (`session-store.ts`) est **cosmétique** : rappel progressif
+  à partir de 20 requêtes anonymes, puis mur dur quand le backend renvoie 403. La
+  vérité du cap reste en base, côté backend.
 
 ## Séparation des erreurs dans `requireAuth`
 
@@ -84,8 +99,9 @@ jamais seulement `typeof === 'string'`.
   **À durcir** avec un rate-limit / cap par IP (backend) **quand l'IA payante
   remplacera le stub** — c'est là que l'abus aura un coût. Fingerprint device écarté
   (RGPD/consentement + dépendance tierce). Décision prise le 2026-07-12.
-- **`linkIdentity`** anonyme → compte : hook posé, déclenchement automatique complet
-  à finaliser une fois le flux magic link/OAuth pleinement vérifié.
+- **Linking multi-provider avancé** : un utilisateur connecté doit pouvoir ajouter
+  plusieurs méthodes de connexion au même compte depuis un écran dédié. Différé en
+  [#159](https://github.com/AdamDjo/Grimoire-game/issues/159).
 - **RLS Postgres** : différé (décision #7). Autorisation V1 = filtrage `userId` Express.
 - **OAuth** : Google vérifié live. Discord à re-tester de bout en bout.
 


### PR DESCRIPTION
## Summary
- documente le flux auth frontend passwordless livré par #135 / PR #160
- met à jour l'état frontend et la release readiness après merge de #160
- retire #135 des prochaines actions et garde #159 comme linking multi-provider différé

## Test plan
- [x] pnpm exec prettier --check docs/public/tech/AUTH.md docs/public/current-state/FRONTEND_STATUS.md docs/public/current-state/FRONTEND_NEXT.md docs/public/current-state/RELEASE_READINESS.md docs/public/current-state/NEXT_ACTIONS.md docs/public/current-state/PROJECT_STATUS.md

Closes #175