### PR TITLE
docs(#179): contrat moteur survie v2 dans le canon

### DIFF
--- a/docs/public/plans/gameplay-survie-v2.md
+++ b/docs/public/plans/gameplay-survie-v2.md
@@ -1,0 +1,195 @@
+# Plan — Gameplay Survie v2 (tension + synergie rétention)
+
+> Issu du grilling du 2026-07-21. 11 décisions validées.
+> Répartition : **Claude = backend + shared** (worktree `-claude`). **Codex = tout l'UI** (main folder, on n'y touche pas).
+> Règle absolue : le canon `docs/public/raw/*.md` précède le code. Ticket #0 met le canon à jour AVANT toute implémentation.
+
+---
+
+## Les 3 bugs/manques de départ (rappel)
+
+1. **On ne meurt jamais** → seuls `combat`/`flee` en échec retirent des PV ([consequences.ts:107](apps/backend/src/game-rules/consequences.ts)). Aucune condition (poison, fièvre, blessure) n'existe. Calamine jamais alimentée.
+2. **La blade disparaît** → `updatedInventory: []` codé en dur ([session.service.ts:434](apps/backend/src/services/session.service.ts)). Inventaire jamais persisté.
+3. **Jauges trop molles / pas de tension** → drain lent (intentionnel canon), mais rien ne pèse mécaniquement, calamine morte.
+
+**Diagnostic UI bonus** : le HUD affiche `attributes.breath`/`ash` en **barres** alors que ce sont des scores fixes ; et les PV existent mais sont nommés "Blood" (collision avec l'attribut SANG). → réglé côté Codex.
+
+---
+
+## Les 11 décisions actées
+
+| #   | Décision                                                                                                                                               |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | Moteur de conséquences riche **d'abord**, danger IA ensuite                                                                                            |
+| 2   | Conditions **hybride strict** : mécaniques/seuil = backend seul / narratives = IA propose `applyCondition` + backend valide (whitelist + plausibilité) |
+| 3   | Effets **complets** : dégâts/tour + malus au d20 via **Désavantage** (canon `08-DICE §5`), pas de malus plat                                           |
+| 4   | HUD = **jauges variables seulement** (PV clair + soif/faim/fatigue/calamine) ; attributs → fiche perso ; **UI = ticket Codex**                         |
+| 5   | Calamine **vivante** : sources narratives canon validées dès maintenant (`applyCondition`) ; artefact = plus tard ; **pas de drain passif**            |
+| 6   | Inventaire = **acquisition + usage/équipement** (`itemGained`, consommer, équiper, `ItemEffect`) ; pas d'économie                                      |
+| 7   | Soin = consommables + **action de repos** (court/feu, taux canon `06 §3`) ; risque de repos différé                                                    |
+| 8   | Danger IA = **(a) prompt musclé** cette passe ; acte-backend = ticket futur                                                                            |
+| 9   | **Découpage par système**, ordonné par dépendance                                                                                                      |
+| 10  | **Ticket #0 Canon** en tout premier                                                                                                                    |
+| 11  | **Fil rouge synergie** : chaque mécanique nourrit la Chronique/Souvenirs existants + fin spéciale Calciné                                              |
+
+**État rétention (audité) :** Chronique ✅ complète (back+front), Souvenirs ✅ complets, méta-monde évolutif ❌ (hors périmètre). On ne refait rien de la rétention — on la **branche** aux nouvelles mécaniques.
+
+---
+
+## Les tickets (ordre = dépendances)
+
+Chaque ticket : 1 issue GitHub → 1 branche depuis `develop` → 1 PR vers `develop`. Tickets Claude = backend/shared. Ticket final = Codex/UI.
+
+---
+
+### 🎯 Ticket #0 — Canon : graver la survie v2
+
+**Objectif** : mettre à jour les `.md` pour que le code s'appuie sur un canon stable.
+
+**Fichiers** :
+
+- `docs/public/raw/06-SURVIVAL.md` §2 → marquer chaque condition **[BACKEND]** (mécanique/seuil) ou **[IA-PROPOSÉE]** (narrative/environnementale). §4 → lister explicitement les sources narratives de Calamine autorisées (lumière archontique, magie excessive, contact corrompu, Veilleurs). §3 → figer les taux de repos exacts.
+- `docs/public/raw/08-DICE-RESOLUTION.md` §5 → confirmer que les conditions sévères imposent **Désavantage** (déjà écrit ; on le rend normatif pour le moteur).
+- `docs/public/raw/11-INVENTORY-ECONOMY.md` → noter le périmètre v2 (acquisition + usage, pas d'économie).
+- `docs/public/raw/15-GAME-MASTER.md` → documenter le **contrat des champs IA** : `applyCondition`, `itemGained` (schéma, whitelist, règles de validation).
+- `docs/public/raw/09-ACTION-LOOP.md` §7 → ajouter la **fin spéciale Calciné** comme `endReason` distinct.
+
+**Pas de code.** PR canon-only.
+
+---
+
+### 🧱 Ticket #1 — Shared : contrats & types
+
+**Objectif** : figer le contrat avant toute implémentation (débloque tout le reste).
+
+**Fichiers** `packages/shared/src/` :
+
+- `types/character.types.ts` → ajouter `ActiveCondition` (id, type, source, appliedAtTurn, expiresRule) et l'inclure dans le state perso.
+- `types/inventory.types.ts` → contrat `itemGained` (l'objet que l'IA signale).
+- `types/scene.types.ts` → étendre la réponse IA : `applyCondition?`, `itemGained?`, `restRequested?`.
+- Nouveau `constants/conditions.ts` → table canon des conditions (effet, dégâts/tour, désavantage O/N, famille backend|ia, soin).
+- `index.ts` → réexports.
+
+**Tests** : `type-check --filter shared`.
+
+**PR** → develop.
+
+---
+
+### ⚔️ Ticket #2 — Conditions + malus d20 (le cœur de la tension)
+
+**Objectif** : les conditions existent, persistent, et **pèsent** (dégâts/tour + Désavantage).
+
+**Fichiers** `apps/backend/src/` :
+
+- `game-rules/conditions.ts` (nouveau) → applique/tick/retire les conditions ; famille BACKEND appliquée par seuils (fièvre si faim/soif=0, blessure si PV≤seuil).
+- `game-rules/dice.ts` → intégrer **Désavantage** (2d20 garder le pire) quand une condition sévère est active (canon `08 §5`).
+- `game-rules/consequences.ts` → brancher le tick des conditions par tour ; famille IA-PROPOSÉE validée ici (whitelist + plausibilité biome/contexte) avant application.
+- `ai/scene-validator.ts` → accepter/valider `applyCondition`.
+- `ai/system-prompt.ts` → expliquer à l'IA quand proposer une condition narrative.
+- `services/session.service.ts` → persister les conditions actives (schéma Prisma : champ JSON `activeConditions` sur Character, migration via MCP Supabase).
+- **Fil rouge** : mort par condition → `endReason` correct pour la Chronique.
+
+**Tests** : `conditions.test.ts`, `dice.test.ts` (désavantage), `consequences.test.ts` (tick + validation IA).
+
+**PR** → develop.
+
+---
+
+### 🔮 Ticket #3 — Calamine vivante
+
+**Objectif** : la Calamine monte (sources narratives canon), applique ses paliers, et tue à 100 (fin Calciné).
+
+**Fichiers** :
+
+- `game-rules/consequences.ts` / `conditions.ts` → paliers Calamine (Stade 1/2/3), delta via `applyCondition` validé.
+- `services/session.service.ts` → à 100 → `endReason='calcined'`, fin de run + Chronique fin spéciale.
+- `ai/system-prompt.ts` → sources autorisées.
+- **Fil rouge** : `endReason='calcined'` → Chronicle sait le raconter (« Tu es devenu ce que tu chassais »).
+
+**Tests** : paliers, transformation à 100, validation source.
+
+**PR** → develop.
+
+---
+
+### 🎒 Ticket #4 — Inventaire : acquisition + usage (répare le bug #2)
+
+**Objectif** : la blade apparaît, s'équipe, se consomme, applique ses effets.
+
+**Fichiers** :
+
+- Schéma Prisma → persistance inventaire (migration MCP Supabase).
+- `services/inventory.service.ts` (nouveau) → acquisition (`itemGained` validé), consommation (`ItemEffect`: heal, calamineReduction, retire condition), équipement (slots canon `11 §1`).
+- `ai/scene-validator.ts` → valider `itemGained`.
+- `services/session.service.ts` → remplacer `updatedInventory: []` par le vrai état ; exposer les 4 catégories canon (équipement/sac/artefact/trousseau) que le front connaît déjà (`velkhar-inventory-model.ts`).
+- **Fil rouge** : fournit les **moyens de soin** des conditions du #2 (antidote, gourde, bandage).
+
+**Tests** : acquisition, sac plein, consommation d'effets, équipement.
+
+**PR** → develop.
+
+---
+
+### 🛌 Ticket #5 — Repos (referme la boucle de survie)
+
+**Objectif** : action de repos (court/feu) résolue backend aux taux canon.
+
+**Fichiers** :
+
+- `game-rules/rest.ts` (nouveau) → court (+~20% fatigue), feu (+~60% fatigue/faim/soif, −10 calamine) — canon `06 §3`.
+- `ai/scene-validator.ts` + `system-prompt.ts` → l'IA propose le repos comme choix (`restRequested`).
+- `services/session.service.ts` → applique le repos, narre la scène calme.
+- Risque de repos (embuscade) = **différé**.
+
+**Tests** : taux de récupération, clamp, −10 calamine au feu.
+
+**PR** → develop.
+
+---
+
+### 📣 Ticket #6 — Prompt danger (crescendo, sans état d'acte)
+
+**Objectif** : l'IA génère assez de danger physique, monte les enjeux au fil du run.
+
+**Fichiers** :
+
+- `ai/system-prompt.ts` → varier l'intensité, pivots physiques réguliers (combat/flee/sauvegarde), enjeux qui montent. **Sans** état d'acte persisté.
+- Acte-backend calculé = **ticket futur** (backlog).
+
+**Tests** : n/a (prompt) — vérif manuelle en session.
+
+**PR** → develop.
+
+---
+
+### 🎨 Ticket #7 — UI (CODEX, main folder — pas Claude)
+
+**Objectif** : refléter les nouvelles données. Décrit le contrat exposé par le backend (les tickets #1-#5).
+
+**Périmètre** (à passer à Codex) :
+
+- HUD : **jauges variables seulement** (PV clairement nommé + soif/faim/fatigue/calamine). Attributs SANG/SOUFFLE/CENDRE **sortis du HUD** → fiche perso, en scores fixes (chiffre + modificateur), plus de barres.
+- Affichage des **conditions actives** (icônes + tooltip effet).
+- Panneau **inventaire** rempli (4 catégories canon) + actions consommer/équiper.
+- Indicateur **Désavantage** sur l'encart de dé quand une condition l'impose.
+- Écran de fin **Calciné** (réutilise `ChronicleEndExperience`).
+
+**Contrat backend fourni** : `hp/maxHp`, `activeConditions[]`, `inventory` (4 catégories), `endReason` incluant `calcined`.
+
+---
+
+## Ordre de livraison
+
+```
+#0 Canon (docs) ──► #1 Shared ──► #2 Conditions ──► #3 Calamine
+                                        │
+                                        ├──► #4 Inventaire ──► #5 Repos
+                                        │
+                                        └──► #6 Prompt danger
+                                              │
+                                              └──► #7 UI (Codex, parallèle possible dès #1 figé)
+```
+
+Fil rouge synergie (#11) intégré dans #2, #3, #4.
+Méta-monde évolutif (crochet 3) = **hors périmètre**, chantier futur.

--- a/docs/public/raw/06-SURVIVAL.md
+++ b/docs/public/raw/06-SURVIVAL.md
@@ -57,20 +57,35 @@ Au-delà des jauges, le perso peut subir des **conditions** — altérations tem
 
 ### Types de conditions
 
-| Condition                  | Cause                                | Effet                                  | Durée                     |
-| -------------------------- | ------------------------------------ | -------------------------------------- | ------------------------- |
-| 🔥 **Fièvre**              | Faim/soif à 0, maladie, marais       | -2 à tous les jets                     | Jusqu'au soin             |
-| 💀 **Empoisonnement**      | Créature, poison, eau corrompue      | -1d4 PV/tour (combat), -1 hors combat  | Jusqu'au soin             |
-| 🩸 **Blessure**            | Combat (réduit à 0 PV ou proche)     | -1 aux jets SANG, limite le portage    | Jusqu'au repos long       |
-| 🧊 **Gel**                 | Nuit dans le désert, haute montagne  | -1 SOUFFLE, malus mouvement            | Jusqu'à source de chaleur |
-| 🌀 **Étourdissement**      | Coup à la tête, explosion            | Perte d'un tour (combat)               | Court                     |
-| 😵 **Cécité temporaire**   | Ventre-Gris, lumière archontique     | -2 SOUFFLE (perception)                | Court                     |
-| 🤢 **Maladie des marais**  | Marais de Lekh                       | -1 à tous, fatigue double              | Long, soin spécifique     |
-| 🔮 **Cendre-corrompu**     | Magie excessive (Tisse-Verbe)        | Progresse vers Calamine                | Voir §4                   |
-| 🧠 **Raison ébranlée**     | Trauma, mort d'un proche, révélation | -1 CENDRE, hallucinations              | Variable                  |
-| 🪨 **Pétrification lente** | Veilleur archontique                 | Malus progressifs → mort si non soigné | Mortel                    |
+| id (moteur)      | Condition                  | Cause                                | Effet                                     | Durée                     | Source      |
+| ---------------- | -------------------------- | ------------------------------------ | ----------------------------------------- | ------------------------- | ----------- |
+| `fever`          | 🔥 **Fièvre**              | Faim/soif à 0, maladie, marais       | Désavantage à tous les jets               | Jusqu'au soin             | **BACKEND** |
+| `poison`         | 💀 **Empoisonnement**      | Créature, poison, eau corrompue      | -1d4 PV/tour (combat), -1 hors combat     | Jusqu'au soin             | IA-PROPOSÉE |
+| `wound`          | 🩸 **Blessure**            | Combat (réduit à 0 PV ou proche)     | Désavantage aux jets SANG, limite portage | Jusqu'au repos long       | **BACKEND** |
+| `freeze`         | 🧊 **Gel**                 | Nuit dans le désert, haute montagne  | -1 SOUFFLE, malus mouvement               | Jusqu'à source de chaleur | IA-PROPOSÉE |
+| `stun`           | 🌀 **Étourdissement**      | Coup à la tête, explosion            | Perte d'un tour (combat)                  | Court                     | IA-PROPOSÉE |
+| `blindness`      | 😵 **Cécité temporaire**   | Ventre-Gris, lumière archontique     | Désavantage SOUFFLE (perception)          | Court                     | IA-PROPOSÉE |
+| `marsh_disease`  | 🤢 **Maladie des marais**  | Marais de Lekh                       | Désavantage à tous, fatigue double        | Long, soin spécifique     | IA-PROPOSÉE |
+| `cendre_corrupt` | 🔮 **Cendre-corrompu**     | Magie excessive (Tisse-Verbe)        | Progresse vers Calamine                   | Voir §4                   | IA-PROPOSÉE |
+| `shaken_reason`  | 🧠 **Raison ébranlée**     | Trauma, mort d'un proche, révélation | -1 CENDRE, hallucinations                 | Variable                  | IA-PROPOSÉE |
+| `petrification`  | 🪨 **Pétrification lente** | Veilleur archontique                 | Malus progressifs → mort si non soigné    | Mortel                    | IA-PROPOSÉE |
 
 🟢 _Le joueur peut subir plusieurs conditions simultanément — mais le MJ IA évite l'empilement punitif._
+
+### Les deux familles de conditions (contrat moteur)
+
+Le backend possède toutes les règles (cf. `15-GAME-MASTER §0`). Les conditions se répartissent en deux familles selon **qui décide de leur application** :
+
+- **[BACKEND]** — appliquée **automatiquement par le moteur** sur franchissement d'un seuil mesurable. L'IA ne les propose jamais ; elle les **narre** seulement une fois appliquées.
+  - `fever` : déclenchée quand `faim ≤ 0` **ou** `soif ≤ 0`.
+  - `wound` : déclenchée quand le perso tombe à `PV ≤ 0` puis est ramené (inconscience survécue), ou sur un coup critique en combat.
+- **[IA-PROPOSÉE]** — l'IA **propose** l'application via le champ `applyCondition` (cf. `15-GAME-MASTER §4.5`), le backend la **valide** (whitelist d'ids ci-dessus + plausibilité biome/contexte) avant de l'appliquer. Exemple : `poison` n'est acceptée que si le contexte narratif la justifie (créature venimeuse, eau corrompue, piège).
+
+🟢 _Règle : une condition non présente dans la table ci-dessus (id inconnu) est **rejetée** par le backend. L'IA ne peut pas inventer de condition._
+
+### Traduction mécanique de l'effet « désavantage »
+
+Les conditions sévères n'appliquent **pas** de malus plat au d20. Elles imposent le **Désavantage** (2d20, garder le pire) — le mécanisme canon décrit dans `08-DICE-RESOLUTION §5`. Cela remplace toute lecture « -1 / -2 au jet » de la table pour l'implémentation moteur : le moteur applique le désavantage, l'affichage indique au joueur pourquoi.
 
 ---
 
@@ -101,6 +116,20 @@ Le joueur peut **se reposer** pour restaurer les jauges. Trois types de repos :
 
 🟢 _Le repos est l'occasion de scènes calmes — dialogue PNJ, contemplation, choix réfléchi._
 
+### Taux de repos (contrat moteur)
+
+Valeurs normatives appliquées par le backend (`game-rules/rest.ts`). Toutes les jauges sont clampées à `[0, 100]`.
+
+| Type de repos    | id moteur | Fatigue | Faim | Soif | PV                         | Calamine | Risque       |
+| ---------------- | --------- | ------- | ---- | ---- | -------------------------- | -------- | ------------ |
+| 🛌 Repos court   | `short`   | +20     | —    | —    | +1d4 (si bandages)         | —        | différé (V2) |
+| 🔥 Repos au feu  | `fire`    | +60     | +60  | +60  | +1d4 + mod SANG (bandages) | −10      | différé (V2) |
+| 🏠 Repos auberge | `inn`     | +100    | +100 | +100 | 100 % (complet)            | −10      | nul (payant) |
+
+- « +60 faim/soif » ne s'applique **que si le perso a des provisions** (nourriture/eau en inventaire) — sinon la récupération faim/soif est nulle.
+- Le **risque de repos** (embuscade, rencontre nocturne) est **différé à un ticket V2** : en V1 le repos est sûr.
+- L'IA **propose** le repos via `restRequested` (cf. `15-GAME-MASTER §4.5`) ; le backend applique les taux ci-dessus et fait narrer une scène calme.
+
 ---
 
 ## 4. La Cendre et la Calamine
@@ -127,6 +156,26 @@ La magie n'est jamais gratuite (voir `02-WORLD-BIBLE.md`). **Tout usage d'artefa
 - 🟢 **Artefact purificateur** (rare) : -50 Cendre une fois
 
 🟢 _Tout aventurier qui touche aux artefacts gère un compte à rebours. Le Tisse-Verbe vit ce dilemme à chaque scène (éveiller = puissance immédiate, Calamine plus proche), les autres vocations ne le rencontrent qu'aux moments où elles décident d'activer un artefact trouvé._
+
+### Sources d'accumulation de Cendre (contrat moteur)
+
+La Cendre **ne monte jamais toute seule** : pas de drain passif par tour. Elle augmente uniquement sur un **événement source** identifié. Le backend applique le delta ; l'IA ne peut le **proposer** (via `applyCondition` avec `id: "cendre_corrupt"`) que si le contexte correspond à l'une des sources canon ci-dessous — sinon le delta est **rejeté**.
+
+| Source                                           | Delta indicatif | Qui déclenche         |
+| ------------------------------------------------ | --------------- | --------------------- |
+| 🔮 Usage d'artefact — pouvoir de base            | +5              | BACKEND (résolution)  |
+| 🔮 Éveil d'artefact (Tisse-Verbe)                | +10             | BACKEND (résolution)  |
+| ☀️ Exposition à la **lumière archontique**       | +5 à +15        | IA-PROPOSÉE (validée) |
+| 🌫️ Contact avec une créature/lieu **corrompu**   | +5 à +10        | IA-PROPOSÉE (validée) |
+| 👁️ Regard/présence d'un **Veilleur archontique** | +10 à +20       | IA-PROPOSÉE (validée) |
+| 🩸 Rituel/magie **excessive** hors artefact      | +5 à +15        | IA-PROPOSÉE (validée) |
+
+- Le backend **plafonne** un delta IA-proposé à +20 par tour (garde-fou anti-abus).
+- Toute source hors de cette liste → delta **ignoré** (l'IA reste libre de narrer, mais la jauge ne bouge pas).
+
+### Paliers de Calamine (contrat moteur)
+
+Le backend applique les effets de palier automatiquement dès franchissement du seuil (cf. table §4 « jauge de Cendre »). À **100**, la transformation en Calciné est **immédiate et non réversible** → fin de run avec `endReason: "calcined"` (cf. `09-ACTION-LOOP §7`). Pas d'héritage transmis (artefact corrompu).
 
 ---
 

--- a/docs/public/raw/08-DICE-RESOLUTION.md
+++ b/docs/public/raw/08-DICE-RESOLUTION.md
@@ -132,6 +132,15 @@ Certaines situations donnent **avantage** (lancer 2d20, garder le meilleur) ou *
 
 🟢 _Avantage/désavantage = la principale façon dont l'équipement, les conditions et la préparation influencent les dés._
 
+### Désavantage par condition (contrat moteur)
+
+Le moteur (`game-rules/dice.ts`) applique le **Désavantage** automatiquement quand **au moins une condition sévère active** l'impose. Une condition « sévère » est marquée `disadvantage: true` dans la table canon des conditions (`06-SURVIVAL §2`).
+
+- Implémentation : `roll = min(d20, d20)` (2 tirages, on garde le pire) dès qu'une condition sévère est active pour l'attribut concerné.
+- Le désavantage **ne se cumule pas** : plusieurs conditions sévères = toujours un seul désavantage (2d20 garder le pire), jamais 3d20. C'est un état booléen, pas un empilement.
+- Avantage et Désavantage s'**annulent** : si le contexte donne un avantage et une condition un désavantage, le jet redevient un simple d20.
+- Le résultat exposé au joueur (transparence BG3, §4) indique explicitement « Désavantage » et sa cause (la condition).
+
 ---
 
 ## 6. Compétences et attributs

--- a/docs/public/raw/09-ACTION-LOOP.md
+++ b/docs/public/raw/09-ACTION-LOOP.md
@@ -226,6 +226,19 @@ Le joueur **décide** quand son histoire est finie. Pas le système.
 
 Si la Cendre atteint 100 → transformation en Calciné → le perso devient un monstre du bestiaire. Run terminé, Chronique générée avec **fin spéciale** ("Tu es devenu ce que tu chassais"). Pas d'héritage transmis (l'artefact est corrompu).
 
+### Contrat moteur — `endReason`
+
+Chaque fin de run porte un `endReason` distinct, transmis à la Chronique (`17-RUN-CHRONICLE`, `chronicle.service.ts`) pour adapter le récit :
+
+| `endReason` | Déclencheur                                         | Héritage                             |
+| ----------- | --------------------------------------------------- | ------------------------------------ |
+| `inn`       | Fin choisie à l'auberge (L'Aveugle)                 | transmis                             |
+| `death`     | Mort effective à 0 PV (l'IA tranche l'inconscience) | transmis                             |
+| `abandon`   | Abandon du perso (inactivité ou clic explicite)     | transmis                             |
+| `calcined`  | Calamine atteint 100 → transformation en Calciné    | **non transmis** (artefact corrompu) |
+
+🟢 _`calcined` est la seule fin sans héritage. La Chronique reçoit ce `endReason` et bascule sur la fin spéciale « Tu es devenu ce que tu chassais »._
+
 ---
 
 ## 8. Risques & garde-fous

--- a/docs/public/raw/11-INVENTORY-ECONOMY.md
+++ b/docs/public/raw/11-INVENTORY-ECONOMY.md
@@ -4,6 +4,18 @@
 
 ---
 
+> **⚙️ Périmètre d'implémentation — Survie v2 (2026-07)**
+> Ce fichier décrit l'économie **cible complète**. Le chantier Survie v2 n'en implémente qu'un **sous-ensemble** :
+>
+> - ✅ **Acquisition** d'objets (l'IA signale un objet trouvé via `itemGained`, cf. `15-GAME-MASTER §4.5` → le backend le persiste dans les 4 catégories §1).
+> - ✅ **Usage / consommation** (appliquer un `ItemEffect` : soin, réduction de Calamine, retrait de condition).
+> - ✅ **Équipement** dans les 8 slots §1.
+> - ⏳ **Différé** (hors périmètre v2) : or 🪙 in-game (§2), marché/négociation (§7), banque de L'Aveugle (§6), artisanat (§8), tiers de rareté économiques (§4), dégradation d'héritage (§5).
+>
+> Autrement dit : v2 branche la **possession et l'usage** des objets, **pas** l'économie monétaire.
+
+---
+
 ## 0. Principe
 
 GRIMOIRE a une économie à **deux niveaux** — l'un meurt avec le perso, l'autre persiste à travers les runs. C'est ce qui rend le roguelike "strict" (tu peux tout perdre) **supportable** : le joueur sait qu'il rebâtira, et ce qui compte vraiment (Souvenirs, artefact, écho) traverse la mort.

--- a/docs/public/raw/15-GAME-MASTER.md
+++ b/docs/public/raw/15-GAME-MASTER.md
@@ -185,6 +185,59 @@ Si l'IA ne répond pas en 12 sec → annulation + bascule modèle suivant dans l
 
 Maximum **2 retries** par tour. Au-delà → fallback à un texte générique pré-écrit (banque de 20 transitions neutres par mood, ex : _« Le silence retombe. L'instant attend ta décision. »_). Préférable à un crash visible.
 
+### 4.5 — Champs mécaniques proposés par l'IA (contrat Survie v2)
+
+L'IA **narre**, mais elle peut **signaler** au moteur qu'un événement mécanique devrait se produire. Elle ne l'applique jamais elle-même : elle remplit un champ optionnel, le **backend décide** (validation + application). Trois champs optionnels s'ajoutent au schéma de sortie (§4.1) :
+
+```ts
+{
+  // ... narration, choices, mood, npcs_present ...
+
+  // L'IA propose une condition narrative (poison, gel, cécité...).
+  // Backend valide : id ∈ whitelist (06-SURVIVAL §2) ET plausibilité biome/contexte.
+  applyCondition?: {
+    id: string,            // ex: "poison" — DOIT être un id canon (06-SURVIVAL §2)
+    reason: string,        // justification narrative courte (piste de plausibilité)
+    calamineDelta?: number // uniquement si id="cendre_corrupt" ; plafonné à +20 (06-SURVIVAL §4)
+  },
+
+  // L'IA signale un objet trouvé par le joueur.
+  // Backend valide : catégorie connue, sac non plein, cohérence tier/contexte, puis persiste.
+  itemGained?: {
+    name: string,
+    category: "equipment" | "bag" | "artifact" | "key",  // 4 catégories (11-INVENTORY §1)
+    slot?: string,         // si category="equipment" : un des 8 slots canon
+    effect?: {             // si consommable / utilitaire (ItemEffect)
+      healAmount?: number,
+      calamineReduction?: number,
+      removesCondition?: string,  // id canon d'une condition à retirer
+      damage?: string,            // dé de dégâts, ex "1d8"
+      attributeModifiers?: Record<string, number>
+    },
+    description?: string
+  },
+
+  // L'IA signale que le joueur demande à se reposer.
+  // Backend applique les taux canon (06-SURVIVAL §3) — l'IA ne calcule pas la récup.
+  restRequested?: {
+    type: "short" | "fire" | "inn"
+  }
+}
+```
+
+**Règles de validation backend (rejet silencieux si non conforme — la narration reste, l'effet est ignoré)** :
+
+| Champ            | Check                                                                  | Si fail                 |
+| ---------------- | ---------------------------------------------------------------------- | ----------------------- |
+| `applyCondition` | `id` ∈ whitelist canon (06-SURVIVAL §2) **et** famille = IA-PROPOSÉE   | Condition non appliquée |
+| `applyCondition` | plausibilité contexte/biome (poison ⇒ créature/eau corrompue, etc.)    | Condition non appliquée |
+| `applyCondition` | `calamineDelta` : source ∈ liste canon (06-SURVIVAL §4), `≤ +20`       | Delta borné ou ignoré   |
+| `itemGained`     | `category` connue, sac non plein (cap 12), `slot` valide si équipement | Objet non ajouté        |
+| `itemGained`     | `effect.removesCondition` / `id` référencé ∈ whitelist canon           | Effet réduit / ignoré   |
+| `restRequested`  | `type` ∈ {short, fire, inn}                                            | Repos ignoré            |
+
+🟢 _Principe inchangé (§0) : l'IA **propose**, le backend **dispose**. Ces champs ne cassent pas la règle d'or — ils la formalisent. Le moteur reste la seule autorité sur les stats, l'inventaire et les conséquences._
+
 ---
 
 ## §5 — Budget de tokens par tour


### PR DESCRIPTION
## Objectif

Ticket #0 du chantier **Gameplay Survie v2** : formaliser dans le canon la couche normative "moteur" nécessaire avant tout code, sans réécrire la prose existante (edits purement additifs).

Closes #179

## Fichiers canon modifiés

| Fichier | Ajout |
|---|---|
| `06-SURVIVAL.md` | Colonnes `id (moteur)` + `Source` sur la table conditions (10 ids), 2 familles **[BACKEND]** vs **[IA-PROPOSÉE]**, traduction du désavantage, §3 taux de repos (`short`/`fire`/`inn`), §4 sources de Cendre + paliers Calamine (100 → `calcined`) |
| `08-DICE-RESOLUTION.md` | §5 désavantage par condition = `min(d20,d20)`, non-cumulatif, s'annule avec avantage |
| `09-ACTION-LOOP.md` | §7 contrat `endReason` (`inn`/`death`/`abandon`/`calcined`) — calciné = seule fin sans trousseau |
| `11-INVENTORY-ECONOMY.md` | Note périmètre Survie v2 (acquisition + usage + équipement ; différé : or/marché/craft) |
| `15-GAME-MASTER.md` | §4.5 contrat des champs IA (`applyCondition`/`itemGained`/`restRequested`) + table de validation backend |

Ajout également du plan de chantier versionné : `docs/public/plans/gameplay-survie-v2.md`.

## Hors périmètre (volontairement non modifiés)

- `PROJECT_STATUS.md` : ne change que si l'objectif global change (règle du fichier).
- `BACKEND_NEXT.md` : modifiable uniquement sur une branche backend, pas sur ce ticket canon.
- `ARCHITECTURE_RULES.md` : les invariants "AI = prose only" et "sorties IA validées backend" couvrent déjà le contrat.

## Suite

Débloque #180 (Shared) → #181 (Conditions+d20) → #182 (Calamine) → #183 (Inventaire) → #184 (Repos) → #185 (Prompt danger) → #186 (UI, Codex).