### PR TITLE
feat(#101): chaîne de fallback multi-modèles pour le Game Master

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -20,5 +20,11 @@ GEMINI_API_KEY=...
 
 # OpenRouter — Game Master engine (server-only, never exposed to the frontend)
 OPENROUTER_API_KEY=sk-or-...
-# Default model: a free multilingual model. Override to any OpenRouter model id.
-OPENROUTER_MODEL=meta-llama/llama-3.3-70b-instruct:free
+# Default single-model id (used by compression fallback and as a base). A free
+# multilingual model; override to any OpenRouter model id.
+OPENROUTER_MODEL=google/gemma-4-31b-it:free
+# Game Master fallback chain (#101): comma-separated model ids tried in order
+# before the deterministic stub. Leave unset to use the built-in all-free chain.
+# Free tiers cap at 20 req/min account-wide, so to keep a busy game off the stub,
+# append a cheap paid model as a last resort, e.g.:
+# OPENROUTER_GM_MODELS=google/gemma-4-31b-it:free,nvidia/nemotron-3-super-120b-a12b:free,openai/gpt-oss-20b:free,openrouter/free,qwen/qwen3.5-flash-02-23

--- a/apps/backend/src/ai/game-master.service.test.ts
+++ b/apps/backend/src/ai/game-master.service.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const hasOpenRouterKey = vi.fn()
-vi.mock('../config/env', () => ({ hasOpenRouterKey }))
+const GAME_MASTER_MODEL_CHAIN = [
+  'google/gemma-4-31b-it:free',
+  'nvidia/nemotron-3-super-120b-a12b:free',
+  'openai/gpt-oss-20b:free',
+  'openrouter/free',
+]
+vi.mock('../config/env', () => ({ hasOpenRouterKey, GAME_MASTER_MODEL_CHAIN }))
 
 const memoryChunkFindMany = vi.fn().mockResolvedValue([])
 const sceneLogFindMany = vi.fn().mockResolvedValue([])
@@ -134,5 +140,94 @@ describe('generateScene — N1 recent-turns loading', () => {
     const result = await generateScene({ character, locale: 'en', sessionId: 's1' })
 
     expect(result.source).toBe('stub')
+  })
+})
+
+describe('generateScene — multi-model fallback chain (#101)', () => {
+  beforeEach(() => {
+    hasOpenRouterKey.mockReset()
+    memoryChunkFindMany.mockClear()
+    sceneLogFindMany.mockClear()
+    souvenirFindMany.mockClear()
+    buildSystemPrompt.mockClear()
+    callOpenRouter.mockReset()
+    hasOpenRouterKey.mockReturnValue(true)
+  })
+
+  it('returns the first model that answers and does not call the next one', async () => {
+    callOpenRouter.mockResolvedValueOnce({
+      success: true,
+      content: JSON.stringify(validAiPayload),
+    })
+
+    const result = await generateScene({ character, locale: 'en', sessionId: 's1' })
+
+    expect(result.source).toBe('ai')
+    expect(callOpenRouter).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports which model produced the scene', async () => {
+    callOpenRouter.mockResolvedValueOnce({
+      success: true,
+      content: JSON.stringify(validAiPayload),
+    })
+
+    const result = await generateScene({ character, locale: 'en', sessionId: 's1' })
+
+    expect(result.model).toBe('google/gemma-4-31b-it:free')
+  })
+
+  it('advances to the next model on a 429 and succeeds there', async () => {
+    callOpenRouter
+      .mockResolvedValueOnce({ success: false, error: 'rate limited', status: 429 })
+      .mockResolvedValueOnce({ success: true, content: JSON.stringify(validAiPayload) })
+
+    const result = await generateScene({ character, locale: 'en', sessionId: 's1' })
+
+    expect(result.source).toBe('ai')
+    expect(result.model).toBe('nvidia/nemotron-3-super-120b-a12b:free')
+    expect(callOpenRouter).toHaveBeenCalledTimes(2)
+  })
+
+  it('advances past a model that returns malformed JSON', async () => {
+    callOpenRouter
+      .mockResolvedValueOnce({ success: true, content: 'not json at all' })
+      .mockResolvedValueOnce({ success: true, content: JSON.stringify(validAiPayload) })
+
+    const result = await generateScene({ character, locale: 'en', sessionId: 's1' })
+
+    expect(result.source).toBe('ai')
+    expect(callOpenRouter).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back to the stub when every model in the chain fails', async () => {
+    callOpenRouter.mockResolvedValue({ success: false, error: 'rate limited', status: 429 })
+
+    const result = await generateScene({ character, locale: 'en', sessionId: 's1' })
+
+    expect(result.source).toBe('stub')
+    expect(result.model).toBeUndefined()
+    // Four free models in the default chain, all attempted.
+    expect(callOpenRouter).toHaveBeenCalledTimes(4)
+  })
+
+  it('stops immediately on a definitive error (bad key) without trying other models', async () => {
+    callOpenRouter.mockResolvedValueOnce({ success: false, error: 'unauthorized', status: 401 })
+
+    const result = await generateScene({ character, locale: 'en', sessionId: 's1' })
+
+    expect(result.source).toBe('stub')
+    expect(callOpenRouter).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a timeout (no status) as retryable and moves to the next model', async () => {
+    callOpenRouter
+      .mockResolvedValueOnce({ success: false, error: 'OpenRouter request timed out' })
+      .mockResolvedValueOnce({ success: true, content: JSON.stringify(validAiPayload) })
+
+    const result = await generateScene({ character, locale: 'en', sessionId: 's1' })
+
+    expect(result.source).toBe('ai')
+    expect(callOpenRouter).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/backend/src/ai/game-master.service.ts
+++ b/apps/backend/src/ai/game-master.service.ts
@@ -1,7 +1,7 @@
-import { hasOpenRouterKey } from '../config/env'
+import { GAME_MASTER_MODEL_CHAIN, hasOpenRouterKey } from '../config/env'
 import { prisma } from '../lib/prisma'
 
-import { callOpenRouter } from './openrouter.provider'
+import { callOpenRouter, type OpenRouterMessage } from './openrouter.provider'
 import { buildStubScene } from './scene-stub'
 import { type AiScenePayload, validateAiScene } from './scene-validator'
 import { buildSystemPrompt, type RecentTurnSummary } from './system-prompt'
@@ -66,6 +66,55 @@ export interface GameMasterResult {
   scene: AiScenePayload
   /** How the scene was produced — useful for debugging and the front badge. */
   source: 'ai' | 'stub'
+  /** Which model in the chain produced an AI scene. Absent on the stub path. */
+  model?: string
+}
+
+/**
+ * Outcome of trying a single model: either a validated scene, or a flag telling
+ * the chain whether it's worth trying the next model. A definitive failure
+ * (bad key, malformed request) means every model would fail the same way, so we
+ * stop and fall straight to the stub instead of hammering the whole chain.
+ */
+type ModelAttempt = { ok: true; scene: AiScenePayload } | { ok: false; retryable: boolean }
+
+/**
+ * HTTP statuses that mean "this model can't answer right now, try another":
+ * 429 (rate-limited — the common `:free` case) and any 5xx (upstream/provider
+ * hiccup). Everything else (401 bad key, 400 bad request) is definitive.
+ */
+function isRetryableStatus(status: number | undefined): boolean {
+  return status === 429 || (status !== undefined && status >= 500)
+}
+
+/**
+ * Runs one model and validates its output. Transient failures (rate limit,
+ * timeout, upstream error, or malformed/invalid JSON) are retryable — the same
+ * prompt on another model may well succeed. A definitive API failure is not.
+ */
+async function tryModel(messages: OpenRouterMessage[], model: string): Promise<ModelAttempt> {
+  const result = await callOpenRouter(messages, { model })
+
+  if (!result.success || !result.content) {
+    // A timed-out or network-errored call has no status — treat as retryable.
+    const retryable = result.status === undefined || isRetryableStatus(result.status)
+    return { ok: false, retryable }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(result.content)
+  } catch {
+    // Malformed JSON is model-specific; another model may return clean JSON.
+    return { ok: false, retryable: true }
+  }
+
+  const validated = validateAiScene(parsed)
+  if (!validated.success || !validated.data) {
+    return { ok: false, retryable: true }
+  }
+
+  return { ok: true, scene: validated.data }
 }
 
 /** Turns the player's action into a validated narrative payload. */
@@ -95,7 +144,7 @@ export async function generateScene(input: GameMasterInput): Promise<GameMasterR
     loadRecentSouvenirs(input.character.userId),
   ])
 
-  const result = await callOpenRouter([
+  const messages: OpenRouterMessage[] = [
     {
       role: 'system',
       content: buildSystemPrompt(
@@ -107,26 +156,26 @@ export async function generateScene(input: GameMasterInput): Promise<GameMasterR
       ),
     },
     { role: 'user', content: buildUserPrompt(input) },
-  ])
+  ]
 
-  if (!result.success || !result.content) {
-    console.warn('[GM] AI call failed, falling back to stub:', result.error)
-    return { scene: buildStubScene(input.character, input.locale), source: 'stub' }
+  // Try each model in the fallback chain; the first valid scene wins. Only when
+  // every model fails (all rate-limited, or a definitive error) do we serve the
+  // deterministic stub — the front never receives raw AI output. See #101.
+  for (const model of GAME_MASTER_MODEL_CHAIN) {
+    const attempt = await tryModel(messages, model)
+
+    if (attempt.ok) {
+      return { scene: attempt.scene, source: 'ai', model }
+    }
+
+    if (!attempt.retryable) {
+      console.warn(`[GM] ${model} failed definitively, falling back to stub`)
+      return { scene: buildStubScene(input.character, input.locale), source: 'stub' }
+    }
+
+    console.warn(`[GM] ${model} unavailable, trying next model`)
   }
 
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(result.content)
-  } catch {
-    console.warn('[GM] AI returned non-JSON, falling back to stub')
-    return { scene: buildStubScene(input.character, input.locale), source: 'stub' }
-  }
-
-  const validated = validateAiScene(parsed)
-  if (!validated.success || !validated.data) {
-    console.warn('[GM] AI JSON failed validation, falling back to stub:', validated.error)
-    return { scene: buildStubScene(input.character, input.locale), source: 'stub' }
-  }
-
-  return { scene: validated.data, source: 'ai' }
+  console.warn('[GM] all models exhausted, falling back to stub')
+  return { scene: buildStubScene(input.character, input.locale), source: 'stub' }
 }

--- a/apps/backend/src/ai/openrouter.provider.ts
+++ b/apps/backend/src/ai/openrouter.provider.ts
@@ -10,6 +10,13 @@ export interface OpenRouterResult {
   /** Raw assistant text content (expected to be JSON). */
   content?: string
   error?: string
+  /**
+   * HTTP status of a failed request, when the failure came from the API rather
+   * than the network. Lets callers distinguish transient failures worth
+   * retrying on another model (429, 5xx) from definitive ones (401, 400).
+   * Absent on success and on network/timeout errors.
+   */
+  status?: number
 }
 
 export interface OpenRouterCallOptions {
@@ -58,7 +65,11 @@ export async function callOpenRouter(
 
     if (!response.ok) {
       // Never surface the request headers (they carry the key) — status only.
-      return { success: false, error: `OpenRouter request failed (${response.status})` }
+      return {
+        success: false,
+        error: `OpenRouter request failed (${response.status})`,
+        status: response.status,
+      }
     }
 
     const data = (await response.json()) as {

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -16,7 +16,7 @@ export const env = {
   openRouter: {
     apiKey: process.env.OPENROUTER_API_KEY ?? '',
     /** Free multilingual model by default; override with OPENROUTER_MODEL. */
-    model: process.env.OPENROUTER_MODEL ?? 'meta-llama/llama-3.3-70b-instruct:free',
+    model: process.env.OPENROUTER_MODEL ?? 'google/gemma-4-31b-it:free',
     /** Lightweight model used for N2 scene compression; override with OPENROUTER_COMPRESSION_MODEL. */
     compressionModel:
       process.env.OPENROUTER_COMPRESSION_MODEL ?? 'mistralai/mistral-small-24b-instruct:free',
@@ -25,7 +25,37 @@ export const env = {
 } as const
 
 /** Hardcoded fallback model for N2 compression if the primary model call fails. */
-export const COMPRESSION_FALLBACK_MODEL = 'meta-llama/llama-3.3-70b-instruct:free'
+export const COMPRESSION_FALLBACK_MODEL = 'google/gemma-4-31b-it:free'
+
+/**
+ * Ordered fallback chain the Game Master tries before giving up on the AI (#101).
+ * OpenRouter `:free` endpoints are frequently rate-limited (HTTP 429) and the
+ * `:free` catalog rotates, so a single model is fragile. Each model is tried in
+ * order until one returns a valid scene; only when all fail do we serve the stub.
+ *
+ * The chain is all-free by default (no cost, commercial-use OK on OpenRouter's
+ * free tier). Set `OPENROUTER_GM_MODELS` (comma-separated) to override — e.g. to
+ * append a cheap paid model such as `qwen/qwen3.5-flash-02-23` as a last resort
+ * before the stub once the account holds credit, so a busy game never degrades
+ * to a static scene. Free tiers cap at 20 req/min account-wide, so under real
+ * load a paid tail is what keeps the AI answering.
+ *
+ * Editors are deliberately varied (Google → Nvidia → OpenAI → OpenRouter's meta
+ * router) because free rate limits are per-provider: the odds of all four being
+ * throttled at once are low.
+ */
+export const GAME_MASTER_MODEL_CHAIN: readonly string[] = (
+  process.env.OPENROUTER_GM_MODELS ??
+  [
+    'google/gemma-4-31b-it:free',
+    'nvidia/nemotron-3-super-120b-a12b:free',
+    'openai/gpt-oss-20b:free',
+    'openrouter/free',
+  ].join(',')
+)
+  .split(',')
+  .map((m) => m.trim())
+  .filter((m) => m.length > 0)
 
 /** True when an OpenRouter key is configured. Never exposes the key itself. */
 export const hasOpenRouterKey = (): boolean => env.openRouter.apiKey.length > 0


### PR DESCRIPTION
## Contexte

Ferme #101. Le Game Master reposait sur un seul modèle OpenRouter `:free`, fréquemment rate-limité (429) et sujet à rotation du catalogue `:free`. Résultat : dès qu'il était indisponible, le jeu servait le stub déterministe. En plus, le modèle par défaut (`meta-llama/llama-3.3-70b-instruct:free`) était **mort** dans le catalogue, ce qui forçait le stub en permanence.

## Ce que fait la PR

- **Chaîne de fallback ordonnée** (`GAME_MASTER_MODEL_CHAIN`) : le GM essaie chaque modèle dans l'ordre, le premier qui renvoie une scène valide gagne. Chaîne all-free par défaut, surchargeable via `OPENROUTER_GM_MODELS` (ex. ajouter un modèle payant bon marché en queue de chaîne pour ne jamais dégrader sous charge).
- **Distinction retryable / définitif** : 429, 5xx, timeout et JSON invalide → on passe au modèle suivant. 401 / 400 → échec définitif, on tombe directement sur le stub sans marteler toute la chaîne.
- **`status` remonté** par le provider OpenRouter pour permettre cette distinction.
- **Modèle par défaut corrigé** (`google/gemma-4-31b-it:free`), pour la compression N2 et comme base.
- `.env.example` documenté (chaîne + exemple d'ajout d'un modèle payant).

## Éditeurs variés (Google → Nvidia → OpenAI → routeur méta)

Les rate limits `:free` sont par provider ; varier les éditeurs réduit le risque que les quatre soient throttlés en même temps.

## Tests

- 7 nouveaux tests couvrant la chaîne (premier modèle répond, 429 → suivant, JSON malformé → suivant, tous échouent → stub, 401 → stub immédiat, timeout sans status → retry).
- Suite backend complète : **185/185 verts**, type-check + lint OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)