### PR TITLE
feat(#181): conditions et Désavantage d20

### DIFF
--- a/apps/backend/prisma/migrations/20260724000000_character_active_conditions_json/migration.sql
+++ b/apps/backend/prisma/migrations/20260724000000_character_active_conditions_json/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Character" DROP COLUMN "conditions";
+ALTER TABLE "Character" ADD COLUMN "activeConditions" JSONB NOT NULL DEFAULT '[]'::jsonb;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -61,8 +61,9 @@ model Character {
   energy   Int
   calamine Int
 
-  /// États altérés persistants (ConditionId[]), ex: "fever", "poison".
-  conditions String[]
+  /// États altérés persistants (ActiveCondition[] JSON), voir @grimoire/shared.
+  /// @see docs/public/raw/06-SURVIVAL.md §2
+  activeConditions Json @default("[]")
 
   /// Fer (🪙), monnaie in-game de Velkhar. Aucune mécanique de gain/dépense
   /// n'est encore branchée ailleurs dans le backend — champ persistant seul.

--- a/apps/backend/src/ai/scene-validator.test.ts
+++ b/apps/backend/src/ai/scene-validator.test.ts
@@ -121,3 +121,74 @@ describe('aiSceneSchema — souvenir_candidate (N3, #115)', () => {
     expect(result.success).toBe(false)
   })
 })
+
+describe('aiSceneSchema — apply_condition (#181)', () => {
+  it('accepts a payload with no apply_condition at all (most turns)', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Yarel keeps walking.',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a valid [IA-PROPOSÉE] condition id', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Yarel wades through the poisonous marsh.',
+      apply_condition: { id: 'poison', reason: 'waded through the poisonous marsh unprotected' },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a [BACKEND] condition id (fever) proposed by the AI', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Something happened.',
+      apply_condition: { id: 'fever', reason: 'trying to sneak in a backend condition' },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a [BACKEND] condition id (wound) proposed by the AI', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Something happened.',
+      apply_condition: { id: 'wound', reason: 'trying to sneak in a backend condition' },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an unknown condition id', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Something happened.',
+      apply_condition: { id: 'not-a-real-condition', reason: 'made up condition' },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an apply_condition missing reason', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Something happened.',
+      apply_condition: { id: 'poison' },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an apply_condition with an empty reason', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Something happened.',
+      apply_condition: { id: 'poison', reason: '' },
+    })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/backend/src/ai/scene-validator.ts
+++ b/apps/backend/src/ai/scene-validator.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { isValidAiConditionId } from '../game-rules/conditions'
+
 /**
  * Zod schema for the raw narrative payload the AI is allowed to produce.
  * The AI writes prose and choice labels only — never rules, stats, or ids.
@@ -39,6 +41,26 @@ export const aiSouvenirCandidateSchema = z.object({
 
 export type AiSouvenirCandidate = z.infer<typeof aiSouvenirCandidateSchema>
 
+/**
+ * Zod schema for the optional per-turn [IA-PROPOSÉE] condition proposal (#181).
+ * The AI may only propose conditions from the `family: 'ia'` whitelist
+ * (poison, freeze, stun, blindness, marsh_disease, cendre_corrupt,
+ * shaken_reason, petrification) — `[BACKEND]` conditions (fever, wound) are
+ * applied automatically server-side and can never be proposed here. The
+ * backend still re-validates the id against `isValidAiConditionId` before
+ * ever applying it (this schema rejects unknown ids up front, but a stale
+ * whitelist copy or renamed id must never silently pass through).
+ * @see docs/public/raw/06-SURVIVAL.md §2 "Les deux familles de conditions"
+ */
+export const aiApplyConditionSchema = z.object({
+  id: z.string().min(1).refine(isValidAiConditionId, {
+    message: 'Unknown or non-AI-proposable condition id',
+  }),
+  reason: z.string().min(1).max(280),
+})
+
+export type AiApplyCondition = z.infer<typeof aiApplyConditionSchema>
+
 export const aiSceneSchema = z.object({
   narrative: z.string().min(1).max(4000),
   sceneType: z.enum(['exploration', 'combat', 'dialog', 'event', 'shop', 'rest']),
@@ -52,6 +74,8 @@ export const aiSceneSchema = z.object({
   turnSummary: z.string().min(1).max(200),
   /** Optional named-Souvenir candidate for this turn (N3 memory, #115). Some models emit `null` instead of omitting the field. */
   souvenir_candidate: aiSouvenirCandidateSchema.nullish().transform((v) => v ?? undefined),
+  /** Optional [IA-PROPOSÉE] condition proposal for this turn (#181). Some models emit `null` instead of omitting the field. */
+  apply_condition: aiApplyConditionSchema.nullish().transform((v) => v ?? undefined),
 })
 
 export type AiScenePayload = z.infer<typeof aiSceneSchema>

--- a/apps/backend/src/ai/system-prompt.ts
+++ b/apps/backend/src/ai/system-prompt.ts
@@ -1,4 +1,4 @@
-import { localeDisplayName } from '@grimoire/shared'
+import { CONDITIONS, getConditionDefinition, localeDisplayName } from '@grimoire/shared'
 
 import type { MemoryChunkModel, SouvenirModel } from '../generated/prisma/models'
 import type { Character, Locale } from '@grimoire/shared'
@@ -78,6 +78,44 @@ function buildSouvenirsSection(souvenirs: SouvenirModel[]): string[] {
 }
 
 /**
+ * Builds the [IA-PROPOSÉE] conditions section: the character's currently
+ * active conditions (so the AI never re-proposes a duplicate) and the full
+ * whitelist of condition ids the AI is allowed to propose via
+ * `apply_condition`. `[BACKEND]` conditions (fever, wound) are applied
+ * automatically server-side and are deliberately excluded from the whitelist
+ * shown here — the AI cannot propose them.
+ * @see docs/public/raw/06-SURVIVAL.md §2 "Les deux familles de conditions"
+ */
+function buildConditionsSection(character: Character, locale: Locale): string[] {
+  const nameKey = locale === 'fr' ? 'fr' : 'en'
+
+  const active = character.stats.conditions
+  const activeLines = active.map((condition) => {
+    const name = getConditionDefinition(condition.id)?.name[nameKey] ?? condition.id
+    return `- ${name} (id: "${condition.id}")`
+  })
+
+  const proposable = CONDITIONS.filter((condition) => condition.family === 'ia')
+  const whitelistLines = proposable.map(
+    (condition) => `- "${condition.id}": ${condition.name[nameKey]}`
+  )
+
+  return [
+    '',
+    active.length > 0
+      ? `Currently active conditions on the player: ${activeLines.join('; ')}.`
+      : 'The player currently has no active conditions.',
+    '',
+    'You may optionally propose ONE new condition via apply_condition when the',
+    'narrative and biome clearly justify it (e.g. wading through a poisonous',
+    'marsh, a freezing blizzard, a stunning blow). Never propose a condition',
+    'already active on the player. Only propose ids from this exact whitelist —',
+    'any other id is rejected:',
+    ...whitelistLines,
+  ]
+}
+
+/**
  * Builds the Game Master system prompt.
  * The AI writes narration and choice labels only; the backend owns all rules,
  * dice, stats, and canon consistency. Canon brand terms are NOT re-translated —
@@ -108,6 +146,7 @@ export function buildSystemPrompt(
     ...buildMemorySection(memoryChunks),
     ...buildRecentTurnsSection(recentTurns),
     ...buildSouvenirsSection(souvenirs),
+    ...buildConditionsSection(character, locale),
     '',
     'Respond with a single JSON object and nothing else, matching exactly:',
     '{',
@@ -117,6 +156,7 @@ export function buildSystemPrompt(
     '  "choices": [{ "text": string, "type": "action"|"dialog"|"combat"|"flee"|"use_item"|"skill", "riskLevel"?: "safe"|"low"|"medium"|"high"|"deadly" }],',
     '  "turnSummary": string,',
     '  "souvenir_candidate"?: { "title_suggestion": string, "body": string, "type": "npc-death"|"moral-choice"|"secret-discovery"|"boss-victory"|"strong-promise" }',
+    '  "apply_condition"?: { "id": string, "reason": string }',
     '}',
     '',
     'turnSummary: a short factual sentence (max 200 characters) condensing what just',
@@ -128,5 +168,10 @@ export function buildSystemPrompt(
     'choice was made, a secret was discovered, a boss was defeated, or a strong promise',
     'was sworn. title_suggestion: 4-15 words, evocative. body: 30-70 tokens, third person,',
     'describing the moment concretely (not restating narrative style).',
+    '',
+    'apply_condition: OPTIONAL, omit on most turns. Only include it when the',
+    'narrative event you just wrote clearly and directly causes one of the',
+    'whitelisted conditions above. reason: one short sentence explaining why',
+    '(e.g. "crossed the poisonous marsh without protection").',
   ].join('\n')
 }

--- a/apps/backend/src/game-rules/conditions.test.ts
+++ b/apps/backend/src/game-rules/conditions.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  applyAiCondition,
+  applyBackendConditions,
+  clearResolvedBackendConditions,
+  computeDisadvantage,
+  isValidAiConditionId,
+  tickConditions,
+} from './conditions'
+
+import type { ActiveCondition, SurvivalStats } from '@grimoire/shared'
+
+const full = (overrides: Partial<SurvivalStats> = {}): SurvivalStats => ({
+  hp: 12,
+  maxHp: 12,
+  thirst: 100,
+  hunger: 100,
+  energy: 100,
+  calamine: 0,
+  ...overrides,
+})
+
+const condition = (overrides: Partial<ActiveCondition> = {}): ActiveCondition => ({
+  id: 'poison',
+  source: 'ai',
+  appliedAtTurn: 1,
+  expiresRule: { type: 'until_cured' },
+  ...overrides,
+})
+
+describe('applyBackendConditions', () => {
+  it('applies fever when hunger hits 0 (06-SURVIVAL §2)', () => {
+    const next = applyBackendConditions(
+      [],
+      { survival: full({ hunger: 0 }), woundingHit: false },
+      3
+    )
+    expect(next.some((c) => c.id === 'fever')).toBe(true)
+  })
+
+  it('applies fever when thirst hits 0', () => {
+    const next = applyBackendConditions(
+      [],
+      { survival: full({ thirst: 0 }), woundingHit: false },
+      3
+    )
+    expect(next.some((c) => c.id === 'fever')).toBe(true)
+  })
+
+  it('does not apply fever when both gauges are above 0', () => {
+    const next = applyBackendConditions([], { survival: full(), woundingHit: false }, 3)
+    expect(next.some((c) => c.id === 'fever')).toBe(false)
+  })
+
+  it('applies wound on a wounding hit', () => {
+    const next = applyBackendConditions([], { survival: full({ hp: 0 }), woundingHit: true }, 5)
+    const wound = next.find((c) => c.id === 'wound')
+    expect(wound).toBeDefined()
+    expect(wound?.source).toBe('backend')
+    expect(wound?.appliedAtTurn).toBe(5)
+  })
+
+  it('never duplicates an already-active condition', () => {
+    const existing = [condition({ id: 'fever', source: 'backend' })]
+    const next = applyBackendConditions(
+      existing,
+      { survival: full({ hunger: 0 }), woundingHit: false },
+      4
+    )
+    expect(next.filter((c) => c.id === 'fever')).toHaveLength(1)
+  })
+})
+
+describe('clearResolvedBackendConditions', () => {
+  it('clears fever once hunger and thirst are both back above 0', () => {
+    const active = [condition({ id: 'fever', source: 'backend' })]
+    const next = clearResolvedBackendConditions(active, full())
+    expect(next).toHaveLength(0)
+  })
+
+  it('keeps fever while hunger or thirst is still at 0', () => {
+    const active = [condition({ id: 'fever', source: 'backend' })]
+    const next = clearResolvedBackendConditions(active, full({ hunger: 0 }))
+    expect(next).toHaveLength(1)
+  })
+
+  it('leaves non-fever conditions untouched', () => {
+    const active = [condition({ id: 'wound', source: 'backend' })]
+    const next = clearResolvedBackendConditions(active, full())
+    expect(next).toHaveLength(1)
+  })
+})
+
+describe('tickConditions', () => {
+  it('applies poison damage per turn (06-SURVIVAL §2)', () => {
+    const result = tickConditions([condition({ id: 'poison' })], full(), 2)
+    expect(result.survival.hp).toBe(11)
+    expect(result.lethal).toBe(false)
+  })
+
+  it('clamps hp at 0 and flags lethal', () => {
+    const result = tickConditions([condition({ id: 'poison' })], full({ hp: 0 }), 2)
+    expect(result.survival.hp).toBe(0)
+    expect(result.lethal).toBe(true)
+  })
+
+  it('a condition can kill the character over time (Definition of Done #181)', () => {
+    let survival = full({ hp: 1 })
+    let conditions = [condition({ id: 'poison', appliedAtTurn: 1 })]
+    const tick1 = tickConditions(conditions, survival, 2)
+    survival = tick1.survival
+    conditions = tick1.conditions
+    expect(tick1.lethal).toBe(true)
+    expect(survival.hp).toBe(0)
+  })
+
+  it('expires a "turns"-ruled condition once its count has elapsed', () => {
+    const active = [
+      condition({ id: 'stun', appliedAtTurn: 1, expiresRule: { type: 'turns', count: 2 } }),
+    ]
+    const stillActive = tickConditions(active, full(), 2)
+    expect(stillActive.conditions).toHaveLength(1)
+    const expired = tickConditions(active, full(), 3)
+    expect(expired.conditions).toHaveLength(0)
+  })
+
+  it('leaves "until_cured" conditions active regardless of turn number', () => {
+    const active = [
+      condition({ id: 'freeze', appliedAtTurn: 1, expiresRule: { type: 'until_cured' } }),
+    ]
+    const result = tickConditions(active, full(), 50)
+    expect(result.conditions).toHaveLength(1)
+  })
+})
+
+describe('computeDisadvantage', () => {
+  it('returns undefined with no active conditions', () => {
+    expect(computeDisadvantage([], 'fr')).toBeUndefined()
+  })
+
+  it('returns undefined when no active condition is severe', () => {
+    expect(computeDisadvantage([condition({ id: 'poison' })], 'fr')).toBeUndefined()
+  })
+
+  it('returns a cause in French when locale is fr', () => {
+    const result = computeDisadvantage([condition({ id: 'wound', source: 'backend' })], 'fr')
+    expect(result).toBeDefined()
+    expect(result?.cause).toContain('Blessure')
+  })
+
+  it('returns a cause in English when locale is en (#181 locale fix)', () => {
+    const result = computeDisadvantage([condition({ id: 'wound', source: 'backend' })], 'en')
+    expect(result).toBeDefined()
+    expect(result?.cause).toContain('Wound')
+    expect(result?.cause).not.toContain('Blessure')
+  })
+
+  it('is non-cumulative: multiple severe conditions still yield a single result', () => {
+    const active = [
+      condition({ id: 'wound', source: 'backend' }),
+      condition({ id: 'fever', source: 'backend' }),
+    ]
+    const result = computeDisadvantage(active, 'fr')
+    expect(result).toBeDefined()
+    expect(result?.cause).toContain('Blessure')
+    expect(result?.cause).toContain('Fièvre')
+  })
+})
+
+describe('isValidAiConditionId', () => {
+  it('accepts an IA-PROPOSÉE family id', () => {
+    expect(isValidAiConditionId('poison')).toBe(true)
+  })
+
+  it('rejects a BACKEND-only family id', () => {
+    expect(isValidAiConditionId('fever')).toBe(false)
+    expect(isValidAiConditionId('wound')).toBe(false)
+  })
+
+  it('rejects an unknown id (AI cannot invent conditions)', () => {
+    expect(isValidAiConditionId('made_up_condition')).toBe(false)
+  })
+})
+
+describe('applyAiCondition', () => {
+  it('adds a new AI-sourced condition', () => {
+    const next = applyAiCondition([], 'poison', 7)
+    expect(next).toHaveLength(1)
+    expect(next[0]).toMatchObject({ id: 'poison', source: 'ai', appliedAtTurn: 7 })
+  })
+
+  it('does not duplicate an already-active condition', () => {
+    const existing = [condition({ id: 'poison' })]
+    const next = applyAiCondition(existing, 'poison', 9)
+    expect(next).toHaveLength(1)
+  })
+})

--- a/apps/backend/src/game-rules/conditions.ts
+++ b/apps/backend/src/game-rules/conditions.ts
@@ -1,0 +1,146 @@
+import { CONDITIONS, getConditionDefinition } from '@grimoire/shared'
+
+import type { ActiveCondition, ConditionId, Locale, SurvivalStats } from '@grimoire/shared'
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, value))
+
+const hasCondition = (conditions: ActiveCondition[], id: ConditionId): boolean =>
+  conditions.some((condition) => condition.id === id)
+
+/**
+ * [BACKEND] conditions applied automatically on threshold crossing, never proposed by the AI.
+ * @see docs/public/raw/06-SURVIVAL.md §2 "Les deux familles de conditions"
+ */
+export interface BackendConditionTriggerInput {
+  survival: SurvivalStats
+  /** True when this turn's HP loss brought the character to 0 and they were revived, or a combat critical hit landed. */
+  woundingHit: boolean
+}
+
+/**
+ * Applies backend-family conditions (`fever`, `wound`) that should now be active given the
+ * current turn's state, without duplicating ones already present.
+ */
+export function applyBackendConditions(
+  conditions: ActiveCondition[],
+  { survival, woundingHit }: BackendConditionTriggerInput,
+  turnNumber: number
+): ActiveCondition[] {
+  const next = [...conditions]
+
+  const feverTriggered = survival.hunger <= 0 || survival.thirst <= 0
+  if (feverTriggered && !hasCondition(next, 'fever')) {
+    next.push({
+      id: 'fever',
+      source: 'backend',
+      appliedAtTurn: turnNumber,
+      expiresRule: { type: 'until_cured' },
+    })
+  }
+
+  if (woundingHit && !hasCondition(next, 'wound')) {
+    next.push({
+      id: 'wound',
+      source: 'backend',
+      appliedAtTurn: turnNumber,
+      expiresRule: { type: 'until_cured' },
+    })
+  }
+
+  return next
+}
+
+/**
+ * Removes a condition once its cure condition is no longer met (e.g. fever clears once
+ * hunger and thirst are both back above 0). Conditions with `expiresRule: "until_cured"` and
+ * no matching auto-clear rule here persist until an explicit cure (rest, item, etc.).
+ */
+export function clearResolvedBackendConditions(
+  conditions: ActiveCondition[],
+  survival: SurvivalStats
+): ActiveCondition[] {
+  const feverShouldClear = survival.hunger > 0 && survival.thirst > 0
+  return conditions.filter((condition) => !(condition.id === 'fever' && feverShouldClear))
+}
+
+export interface TickConditionsResult {
+  conditions: ActiveCondition[]
+  survival: SurvivalStats
+  /** True when a condition's per-turn damage brought HP to 0 this tick. */
+  lethal: boolean
+}
+
+/**
+ * Applies per-turn condition damage (e.g. poison) and expires conditions whose `turns` rule
+ * has elapsed. Pure and deterministic — combat vs out-of-combat poison rate is not yet
+ * distinguished (out of scope for #181; canon 06-SURVIVAL §2 splits it, revisit with combat turns).
+ */
+export function tickConditions(
+  conditions: ActiveCondition[],
+  survival: SurvivalStats,
+  turnNumber: number
+): TickConditionsResult {
+  let hp = survival.hp
+
+  for (const condition of conditions) {
+    const definition = getConditionDefinition(condition.id)
+    if (definition?.damagePerTurn) {
+      hp = clamp(hp - definition.damagePerTurn, 0, survival.maxHp)
+    }
+  }
+
+  const remaining = conditions.filter((condition) => {
+    if (condition.expiresRule.type !== 'turns') return true
+    return turnNumber - condition.appliedAtTurn < condition.expiresRule.count
+  })
+
+  return {
+    conditions: remaining,
+    survival: { ...survival, hp },
+    lethal: hp <= 0,
+  }
+}
+
+/**
+ * Whether any active condition imposes Désavantage right now, and why (for player-facing
+ * transparency). Non-cumulative: multiple severe conditions still yield a single cause string.
+ * @see docs/public/raw/08-DICE-RESOLUTION.md §5
+ */
+export function computeDisadvantage(
+  conditions: ActiveCondition[],
+  locale: Locale
+): { cause: string } | undefined {
+  const nameKey = locale === 'fr' ? 'fr' : 'en'
+  const severe = conditions.filter(
+    (condition) => getConditionDefinition(condition.id)?.disadvantage
+  )
+  if (severe.length === 0) return undefined
+
+  const names = severe.map(
+    (condition) => getConditionDefinition(condition.id)?.name[nameKey] ?? condition.id
+  )
+  return { cause: names.join(', ') }
+}
+
+/**
+ * Validates an AI-proposed [IA-PROPOSÉE] condition against the canon whitelist. Plausibility
+ * (narrative/biome context) is judged by the caller — this only checks the id is a known,
+ * AI-proposable condition id (06-SURVIVAL §2).
+ */
+export function isValidAiConditionId(id: string): id is ConditionId {
+  const definition = CONDITIONS.find((condition) => condition.id === id)
+  return definition?.family === 'ia'
+}
+
+export function applyAiCondition(
+  conditions: ActiveCondition[],
+  id: ConditionId,
+  turnNumber: number
+): ActiveCondition[] {
+  if (hasCondition(conditions, id)) return conditions
+  return [
+    ...conditions,
+    { id, source: 'ai', appliedAtTurn: turnNumber, expiresRule: { type: 'until_cured' } },
+  ]
+}

--- a/apps/backend/src/game-rules/consequences.test.ts
+++ b/apps/backend/src/game-rules/consequences.test.ts
@@ -33,6 +33,9 @@ describe('resolveChoice', () => {
       attributes: ATTRIBUTES,
       survival: survival(),
       choice: choice({ riskLevel: 'safe' }),
+      activeConditions: [],
+      turnNumber: 1,
+      locale: 'en',
     })
     expect(result.diceRoll).toBeUndefined()
     expect(result.gameOver).toBe(false)
@@ -45,6 +48,9 @@ describe('resolveChoice', () => {
       attributes: ATTRIBUTES,
       survival: survival(),
       choice: choice({ riskLevel: 'medium' }),
+      activeConditions: [],
+      turnNumber: 1,
+      locale: 'en',
       rng: fixedRoll(20), // forced success
     })
     expect(result.diceRoll?.success).toBe(true)
@@ -57,6 +63,9 @@ describe('resolveChoice', () => {
       attributes: ATTRIBUTES,
       survival: survival(),
       choice: choice({ type: 'combat', riskLevel: 'high' }),
+      activeConditions: [],
+      turnNumber: 1,
+      locale: 'en',
       rng: fixedRoll(1), // natural 1 → forced failure
     })
     expect(result.diceRoll?.success).toBe(false)
@@ -69,6 +78,9 @@ describe('resolveChoice', () => {
       attributes: ATTRIBUTES,
       survival: survival(),
       choice: choice({ type: 'flee', riskLevel: 'high' }),
+      activeConditions: [],
+      turnNumber: 1,
+      locale: 'en',
       rng: fixedRoll(1), // natural 1 → forced failure
     })
     expect(result.diceRoll?.success).toBe(false)
@@ -81,6 +93,9 @@ describe('resolveChoice', () => {
       attributes: ATTRIBUTES,
       survival: survival(),
       choice: choice({ type: 'dialog', riskLevel: 'deadly' }),
+      activeConditions: [],
+      turnNumber: 1,
+      locale: 'en',
       rng: fixedRoll(1), // natural 1 → forced failure
     })
     expect(result.diceRoll?.success).toBe(false)
@@ -94,10 +109,108 @@ describe('resolveChoice', () => {
       attributes: ATTRIBUTES,
       survival: survival({ hp: 4 }), // deadly failure loses 20 → clamps to 0
       choice: choice({ type: 'combat', riskLevel: 'deadly' }),
+      activeConditions: [],
+      turnNumber: 1,
+      locale: 'en',
       rng: fixedRoll(1),
     })
     expect(result.updatedSurvival.hp).toBe(0)
     expect(result.gameOver).toBe(true)
     expect(result.consequences.gameOver).toBe(true)
+  })
+
+  it("ticks an active condition's per-turn damage before rolling", () => {
+    const result = resolveChoice({
+      attributes: ATTRIBUTES,
+      survival: survival(),
+      choice: choice({ riskLevel: 'safe' }),
+      activeConditions: [
+        { id: 'poison', source: 'ai', appliedAtTurn: 1, expiresRule: { type: 'until_cured' } },
+      ],
+      turnNumber: 2,
+      locale: 'en',
+    })
+    expect(result.updatedSurvival.hp).toBe(11)
+    expect(result.consequences.survivalChanges?.hp).toBe(-1)
+  })
+
+  it('a lethal condition tick ends the game before any roll happens', () => {
+    const result = resolveChoice({
+      attributes: ATTRIBUTES,
+      survival: survival({ hp: 1 }),
+      choice: choice({ type: 'combat', riskLevel: 'deadly' }),
+      activeConditions: [
+        { id: 'poison', source: 'ai', appliedAtTurn: 1, expiresRule: { type: 'until_cured' } },
+      ],
+      turnNumber: 2,
+      locale: 'en',
+    })
+    expect(result.gameOver).toBe(true)
+    expect(result.updatedSurvival.hp).toBe(0)
+    expect(result.diceRoll).toBeUndefined()
+  })
+
+  it('rolls with Désavantage when a severe condition is active (canon 08-DICE §5)', () => {
+    let calls = 0
+    const rolls = [18, 1] // advantage would keep 18, disadvantage keeps 1
+    const rng = () => (rolls[calls++] - 1) / 20
+    const result = resolveChoice({
+      attributes: ATTRIBUTES,
+      survival: survival(),
+      choice: choice({ type: 'combat', riskLevel: 'medium' }),
+      activeConditions: [
+        { id: 'wound', source: 'backend', appliedAtTurn: 1, expiresRule: { type: 'until_cured' } },
+      ],
+      turnNumber: 2,
+      locale: 'fr',
+      rng,
+    })
+    expect(result.diceRoll?.roll).toBe(1)
+    expect(result.diceRoll?.rollMode).toBe('disadvantage')
+    expect(result.diceRoll?.disadvantageCause).toContain('Blessure')
+  })
+
+  it('rolls the disadvantageCause in English when session locale is en (#181 locale fix)', () => {
+    let calls = 0
+    const rolls = [18, 1]
+    const rng = () => (rolls[calls++] - 1) / 20
+    const result = resolveChoice({
+      attributes: ATTRIBUTES,
+      survival: survival(),
+      choice: choice({ type: 'combat', riskLevel: 'medium' }),
+      activeConditions: [
+        { id: 'wound', source: 'backend', appliedAtTurn: 1, expiresRule: { type: 'until_cured' } },
+      ],
+      turnNumber: 2,
+      locale: 'en',
+      rng,
+    })
+    expect(result.diceRoll?.disadvantageCause).toContain('Wound')
+    expect(result.diceRoll?.disadvantageCause).not.toContain('Blessure')
+  })
+
+  it('applies wound on a combat critical failure (natural 1)', () => {
+    const result = resolveChoice({
+      attributes: ATTRIBUTES,
+      survival: survival(),
+      choice: choice({ type: 'combat', riskLevel: 'medium' }),
+      activeConditions: [],
+      turnNumber: 3,
+      locale: 'en',
+      rng: fixedRoll(1),
+    })
+    expect(result.updatedConditions.some((c) => c.id === 'wound')).toBe(true)
+  })
+
+  it('applies fever automatically once hunger or thirst hits 0', () => {
+    const result = resolveChoice({
+      attributes: ATTRIBUTES,
+      survival: survival({ hunger: TURN_DRAIN.hunger }), // drains to exactly 0 this turn
+      choice: choice({ riskLevel: 'safe' }),
+      activeConditions: [],
+      turnNumber: 4,
+      locale: 'en',
+    })
+    expect(result.updatedConditions.some((c) => c.id === 'fever')).toBe(true)
   })
 })

--- a/apps/backend/src/game-rules/consequences.ts
+++ b/apps/backend/src/game-rules/consequences.ts
@@ -1,13 +1,21 @@
+import {
+  applyBackendConditions,
+  clearResolvedBackendConditions,
+  computeDisadvantage,
+  tickConditions,
+} from './conditions'
 import { rollCheck } from './dice'
 import { applyTurnDrain } from './survival'
 
 import type {
+  ActiveCondition,
   Attribute,
   Attributes,
   Choice,
   ChoiceConsequence,
   DiceRoll,
   Difficulty,
+  Locale,
   SurvivalStats,
 } from '@grimoire/shared'
 
@@ -57,12 +65,22 @@ export interface ResolveChoiceInput {
   attributes: Attributes
   survival: SurvivalStats
   choice: Choice
+  /** Conditions active before this turn resolves. */
+  activeConditions: ActiveCondition[]
+  /** Turn number this choice resolves on — stamps newly-applied conditions and drives expiry. */
+  turnNumber: number
+  /** Session locale — determines the language of the Désavantage cause string (#168 source of truth). */
+  locale: Locale
+  /** Context grants advantage this turn (prepared plan, adapted item, ally help, exploited weakness). */
+  advantage?: boolean
   /** Injected for deterministic tests. Defaults to Math.random. */
   rng?: () => number
 }
 
 export interface ResolveChoiceResult {
   updatedSurvival: SurvivalStats
+  /** Conditions active after this turn's ticks, applications and clears. */
+  updatedConditions: ActiveCondition[]
   /** Present only when the choice was risky enough to roll. */
   diceRoll?: DiceRoll
   /** Mechanical consequences applied this turn, for logging and the client. */
@@ -73,14 +91,20 @@ export interface ResolveChoiceResult {
 
 /**
  * Resolves a player's choice mechanically. Pure given `rng`:
- * applies the per-turn survival drain, rolls a d20 for risky choices, and
- * subtracts HP on failure. The backend is the sole source of truth here —
- * the AI only narrates the outcome.
+ * applies the per-turn survival drain, ticks active conditions (damage/turn, expiry),
+ * rolls a d20 (with Désavantage when a severe condition is active) for risky choices, and
+ * subtracts HP on failure. The backend is the sole source of truth here — the AI only
+ * narrates the outcome.
+ * @see docs/public/raw/06-SURVIVAL.md §2, docs/public/raw/08-DICE-RESOLUTION.md §5
  */
 export function resolveChoice({
   attributes,
   survival,
   choice,
+  activeConditions,
+  turnNumber,
+  locale,
+  advantage,
   rng = Math.random,
 }: ResolveChoiceInput): ResolveChoiceResult {
   const risk: Difficulty = choice.riskLevel ?? 'safe'
@@ -94,26 +118,71 @@ export function resolveChoice({
     },
   }
 
-  if (!ROLL_RISKS.has(risk)) {
-    return { updatedSurvival: drained, consequences, gameOver: false }
+  const tick = tickConditions(activeConditions, drained, turnNumber)
+  let conditions = clearResolvedBackendConditions(tick.conditions, tick.survival)
+  const survivalAfterTick = tick.survival
+  if (survivalAfterTick.hp !== drained.hp) {
+    consequences.survivalChanges = {
+      ...consequences.survivalChanges,
+      hp: survivalAfterTick.hp - drained.hp,
+    }
   }
 
-  const diceRoll = rollCheck(attributes, ATTRIBUTE_BY_TYPE[choice.type], risk, rng)
+  if (tick.lethal) {
+    consequences.gameOver = true
+    return {
+      updatedSurvival: survivalAfterTick,
+      updatedConditions: conditions,
+      consequences,
+      gameOver: true,
+    }
+  }
+
+  if (!ROLL_RISKS.has(risk)) {
+    conditions = applyBackendConditions(
+      conditions,
+      { survival: survivalAfterTick, woundingHit: false },
+      turnNumber
+    )
+    return {
+      updatedSurvival: survivalAfterTick,
+      updatedConditions: conditions,
+      consequences,
+      gameOver: false,
+    }
+  }
+
+  const disadvantage = computeDisadvantage(conditions, locale)
+  const diceRoll = rollCheck(attributes, ATTRIBUTE_BY_TYPE[choice.type], risk, rng, {
+    advantage,
+    disadvantage,
+  })
 
   // Canon: combat and sauvegarde (flee) draw blood on failure. A failed
   // persuasion/exploration/skill check stays a narrative complication (the AI
   // narrates it), never an HP penalty.
-  let hp = drained.hp
+  let hp = survivalAfterTick.hp
+  const isCombatCrit = choice.type === 'combat' && diceRoll.critical === 'failure'
   if (!diceRoll.success && PHYSICAL_RISK_TYPES.has(choice.type)) {
-    hp = clamp(drained.hp - PHYSICAL_FAILURE_HP_LOSS[risk], 0, drained.maxHp)
-    consequences.survivalChanges = { ...consequences.survivalChanges, hp: hp - drained.hp }
+    hp = clamp(survivalAfterTick.hp - PHYSICAL_FAILURE_HP_LOSS[risk], 0, survivalAfterTick.maxHp)
+    consequences.survivalChanges = {
+      ...consequences.survivalChanges,
+      hp: (consequences.survivalChanges?.hp ?? 0) + (hp - survivalAfterTick.hp),
+    }
   }
 
-  const updatedSurvival: SurvivalStats = { ...drained, hp }
+  const updatedSurvival: SurvivalStats = { ...survivalAfterTick, hp }
+  const woundingHit = hp <= 0 || isCombatCrit
+  conditions = applyBackendConditions(
+    conditions,
+    { survival: updatedSurvival, woundingHit },
+    turnNumber
+  )
+
   const gameOver = hp <= 0
   if (gameOver) {
     consequences.gameOver = true
   }
 
-  return { updatedSurvival, diceRoll, consequences, gameOver }
+  return { updatedSurvival, updatedConditions: conditions, diceRoll, consequences, gameOver }
 }

--- a/apps/backend/src/game-rules/dice.test.ts
+++ b/apps/backend/src/game-rules/dice.test.ts
@@ -42,4 +42,63 @@ describe('rollCheck', () => {
     expect(below.critical).toBeNull()
     expect(below.success).toBe(false)
   })
+
+  it('defaults to rollMode "normal" with no advantage/disadvantage', () => {
+    const result = rollCheck(ATTRIBUTES, 'blood', 'medium', fixedRoll(10))
+    expect(result.rollMode).toBe('normal')
+    expect(result.disadvantageCause).toBeUndefined()
+  })
+
+  it('disadvantage rolls 2d20 and keeps the worst (canon 08-DICE §5)', () => {
+    // sequence: first roll 18, second roll 5 → keep 5.
+    let calls = 0
+    const rolls = [18, 5]
+    const rng = () => (rolls[calls++] - 1) / 20
+    const result = rollCheck(ATTRIBUTES, 'blood', 'medium', rng, {
+      disadvantage: { cause: 'wound' },
+    })
+    expect(result.roll).toBe(5)
+    expect(result.rollMode).toBe('disadvantage')
+    expect(result.disadvantageCause).toBe('wound')
+  })
+
+  it('advantage rolls 2d20 and keeps the best', () => {
+    let calls = 0
+    const rolls = [5, 18]
+    const rng = () => (rolls[calls++] - 1) / 20
+    const result = rollCheck(ATTRIBUTES, 'blood', 'medium', rng, { advantage: true })
+    expect(result.roll).toBe(18)
+    expect(result.rollMode).toBe('advantage')
+  })
+
+  it('multiple severe conditions never stack beyond a single disadvantage (non-cumulative)', () => {
+    // Only one extra roll is consumed regardless of how many conditions impose disadvantage —
+    // proven by exhausting the rng sequence after 2 values.
+    const rolls = [18, 5]
+    let calls = 0
+    const rng = () => {
+      if (calls >= rolls.length) throw new Error('rng called more than twice')
+      return (rolls[calls++] - 1) / 20
+    }
+    const result = rollCheck(ATTRIBUTES, 'blood', 'medium', rng, {
+      disadvantage: { cause: 'wound, fever' },
+    })
+    expect(result.roll).toBe(5)
+  })
+
+  it('advantage and disadvantage cancel out to a plain d20', () => {
+    let calls = 0
+    const rolls = [18, 5]
+    const rng = () => {
+      if (calls >= 1) throw new Error('rng should only be called once when cancelled out')
+      return (rolls[calls++] - 1) / 20
+    }
+    const result = rollCheck(ATTRIBUTES, 'blood', 'medium', rng, {
+      advantage: true,
+      disadvantage: { cause: 'wound' },
+    })
+    expect(result.roll).toBe(18)
+    expect(result.rollMode).toBe('normal')
+    expect(result.disadvantageCause).toBeUndefined()
+  })
 })

--- a/apps/backend/src/game-rules/dice.ts
+++ b/apps/backend/src/game-rules/dice.ts
@@ -10,14 +10,35 @@ import {
 export type { Difficulty, DiceRoll }
 export { DIFFICULTY_TARGET }
 
-/** Rolls 1d20, adds the attribute modifier, and compares to the difficulty target. */
+export interface RollCheckOptions {
+  /** Context grants advantage (prepared plan, adapted item, ally help, exploited weakness). */
+  advantage?: boolean
+  /** A severe active condition imposes disadvantage. Cause is the condition name, for transparency. */
+  disadvantage?: { cause: string }
+}
+
+/**
+ * Rolls 1d20 (or 2d20 keep best/worst under advantage/disadvantage), adds the attribute
+ * modifier, and compares to the difficulty target.
+ * @see docs/public/raw/08-DICE-RESOLUTION.md §5 (Avantage et Désavantage)
+ */
 export function rollCheck(
   attributes: Attributes,
   attribute: Attribute,
   difficulty: Difficulty,
-  rng: () => number = Math.random
+  rng: () => number = Math.random,
+  options: RollCheckOptions = {}
 ): DiceRoll {
-  const roll = 1 + Math.floor(rng() * 20)
+  // Advantage and disadvantage cancel out — a single d20, per canon §5.
+  const hasAdvantage = Boolean(options.advantage) && !options.disadvantage
+  const hasDisadvantage = Boolean(options.disadvantage) && !options.advantage
+
+  const rollOnce = () => 1 + Math.floor(rng() * 20)
+  const first = rollOnce()
+  const second = hasAdvantage || hasDisadvantage ? rollOnce() : null
+  const roll =
+    second === null ? first : hasAdvantage ? Math.max(first, second) : Math.min(first, second)
+
   const modifier = attributeModifier(attributes[attribute])
   const total = roll + modifier
   const target = DIFFICULTY_TARGET[difficulty]
@@ -27,5 +48,22 @@ export function rollCheck(
   // Natural 20 always succeeds, natural 1 always fails (canon d20 convention).
   const success = critical === 'success' ? true : critical === 'failure' ? false : total >= target
 
-  return { roll, modifier, total, target, success, critical }
+  const rollMode: DiceRoll['rollMode'] = hasAdvantage
+    ? 'advantage'
+    : hasDisadvantage
+      ? 'disadvantage'
+      : 'normal'
+
+  return {
+    roll,
+    modifier,
+    total,
+    target,
+    success,
+    critical,
+    rollMode,
+    ...(hasDisadvantage && options.disadvantage
+      ? { disadvantageCause: options.disadvantage.cause }
+      : {}),
+  }
 }

--- a/apps/backend/src/services/aveugle.service.test.ts
+++ b/apps/backend/src/services/aveugle.service.test.ts
@@ -290,7 +290,7 @@ describe('Aveugle locale wiring (#168)', () => {
 
     await generateAveugleTalkResponse('user1', 'Quién eres?')
 
-    expect(lastPrompt()).toContain('Write the reply in European Spanish')
+    expect(lastPrompt()).toContain('Write your reply in European Spanish')
   })
 
   it('prefers the active session locale over the account preference', async () => {
@@ -303,7 +303,7 @@ describe('Aveugle locale wiring (#168)', () => {
 
     await generateAveugleTalkResponse('user1', 'Qui es-tu ?')
 
-    expect(lastPrompt()).toContain('Write the reply in French')
+    expect(lastPrompt()).toContain('Write your reply in French')
   })
 
   it('falls back to the account preference when no session is active', async () => {
@@ -315,7 +315,7 @@ describe('Aveugle locale wiring (#168)', () => {
 
     await generateAveugleTalkResponse('user1', 'Wer bist du?')
 
-    expect(lastPrompt()).toContain('Write the reply in German')
+    expect(lastPrompt()).toContain('Write your reply in German')
   })
 
   it('defaults the talk prompt to English when no locale is known', async () => {
@@ -326,7 +326,7 @@ describe('Aveugle locale wiring (#168)', () => {
 
     await generateAveugleTalkResponse('user1', 'Who are you?')
 
-    expect(lastPrompt()).toContain('Write the reply in English')
+    expect(lastPrompt()).toContain('Write your reply in English')
   })
 
   it('serves an English fallback reply for a non-French locale on AI failure', async () => {
@@ -372,7 +372,7 @@ describe('Aveugle locale wiring (#168)', () => {
 
     await spendSouvenirForLore('user1', 'sv1', 'lore-fragment')
 
-    expect(lastPrompt()).toContain('Write the loreResult in French')
+    expect(lastPrompt()).toContain('Write your reply in French')
   })
 })
 

--- a/apps/backend/src/services/aveugle.service.ts
+++ b/apps/backend/src/services/aveugle.service.ts
@@ -176,6 +176,10 @@ function buildAveugleTalkPrompt(params: {
 
   return [
     "Tu es L'Aveugle, aubergiste-prophète du Doigt-Cassé, à Velkhar.",
+    // Language instruction comes early (#168/#181 fix): a model that only sees
+    // it after a long French voice block may ignore it and answer in French
+    // regardless of the player's locale.
+    `Write your reply in ${languageName}. Keep this instruction even though the rest of this prompt is in French. English is the default.`,
     '',
     '[IDENTITÉ]',
     'Aubergiste-prophète, pas magicien. Tu connais le sable, le vent, le sel, la cendre, le thé tiède, les os blanchis, la lampe à huile, la porte.',
@@ -204,10 +208,7 @@ function buildAveugleTalkPrompt(params: {
     '',
     '[INSTRUCTION]',
     'Réponds STRICTEMENT en JSON : { "reply": "..." }. Une réplique courte (2-4 phrases), en voix de L\'Aveugle uniquement.',
-    // The canon phrases above define L'Aveugle's VOICE (warm, ironic, tutoie,
-    // desert proverbs); this final line sets the OUTPUT language (#168). The
-    // voice stays; only the language of the reply follows the player's locale.
-    `Write the reply in ${languageName}. Keep L'Aveugle's voice — warm, ironic, informal, short desert proverbs. English is the default.`,
+    `Reminder: write the reply in ${languageName}.`,
   ].join('\n')
 }
 
@@ -298,6 +299,8 @@ function buildAveugleLorePrompt(params: {
 
   return [
     "Tu es L'Aveugle, aubergiste-prophète du Doigt-Cassé, à Velkhar. Un voyageur t'échange un Souvenir contre du savoir.",
+    // Language instruction comes early (#168/#181 fix): see buildAveugleTalkPrompt above.
+    `Write your reply in ${languageName}. Keep this instruction even though the rest of this prompt is in French. English is the default.`,
     '',
     '[VOIX]',
     'Chaud, ironique, sage paysan. Tu tutoies toujours. Proverbes désertiques courts. Jamais lyrique, jamais "vieux sage mystérieux".',
@@ -313,7 +316,7 @@ function buildAveugleLorePrompt(params: {
     '',
     '[INSTRUCTION]',
     'Réponds STRICTEMENT en JSON : { "loreResult": "..." }. 2-6 phrases, cohérentes avec le canon de Velkhar, jamais de stat ni de décision mécanique.',
-    `Write the loreResult in ${languageName}. Keep L'Aveugle's voice. English is the default.`,
+    `Reminder: write the loreResult in ${languageName}.`,
   ].join('\n')
 }
 

--- a/apps/backend/src/services/character.service.test.ts
+++ b/apps/backend/src/services/character.service.test.ts
@@ -88,7 +88,7 @@ describe('createCharacter', () => {
         hunger: 100,
         energy: 100,
         calamine: 0,
-        conditions: [],
+        activeConditions: [],
       },
     })
     expect(character).toMatchObject({ name: 'Kael Vane', vocation: 'shadow-blade' })

--- a/apps/backend/src/services/character.service.ts
+++ b/apps/backend/src/services/character.service.ts
@@ -83,7 +83,7 @@ export async function createCharacter(
         hunger: 100,
         energy: 100,
         calamine: 0,
-        conditions: [],
+        activeConditions: [],
       },
     })
   } catch (err) {

--- a/apps/backend/src/services/session.service.condition.test.ts
+++ b/apps/backend/src/services/session.service.condition.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const transaction = vi.fn().mockResolvedValue(undefined)
+const sceneLogCreate = vi.fn()
+const characterUpdate = vi.fn()
+const gameSessionUpdate = vi.fn()
+vi.mock('../lib/prisma', () => ({
+  prisma: {
+    $transaction: transaction,
+    sceneLog: { create: sceneLogCreate, findMany: vi.fn().mockResolvedValue([]) },
+    character: { update: characterUpdate },
+    gameSession: { update: gameSessionUpdate },
+  },
+}))
+
+const resolveChoice = vi.fn()
+vi.mock('../game-rules/consequences', () => ({ resolveChoice }))
+
+const generateScene = vi.fn()
+vi.mock('../ai/game-master.service', () => ({ generateScene }))
+
+const assembleScene = vi.fn()
+vi.mock('./scene-assembler', () => ({ assembleScene }))
+
+vi.mock('./memory.service', () => ({ compressScene: vi.fn().mockResolvedValue(undefined) }))
+
+const { resolveTurn } = await import('./session.service')
+
+import type { Character as DbCharacter, GameSession } from '../generated/prisma/client'
+
+const character = {
+  id: 'char1',
+  userId: 'user1',
+  name: 'Yarel of the Salt Roads',
+  people: 'sahelin',
+  vocation: 'salt-walker',
+  blood: 10,
+  breath: 10,
+  ash: 10,
+  hp: 20,
+  maxHp: 20,
+  thirst: 100,
+  hunger: 100,
+  energy: 100,
+  calamine: 0,
+  activeConditions: [],
+  createdAt: new Date(),
+} as unknown as DbCharacter
+
+function session(turnNumber: number): GameSession {
+  return {
+    id: 's1',
+    characterId: 'char1',
+    turnNumber,
+    location: 'Calamine',
+    locale: 'en',
+    status: 'active',
+    endReason: null,
+    createdAt: new Date(),
+  } as unknown as GameSession
+}
+
+const choice = {
+  id: 'c1',
+  text: 'wade into the marsh',
+  type: 'action' as const,
+  riskLevel: 'medium' as const,
+}
+
+/** Reads the `data` payload passed to the mocked `character.update` call. */
+function lastCharacterUpdateData(): { activeConditions: unknown } {
+  const call = characterUpdate.mock.calls.at(-1) as
+    | [{ data: { activeConditions: unknown } }]
+    | undefined
+  if (!call) throw new Error('character.update was not called')
+  return call[0].data
+}
+
+describe('resolveTurn — AI-proposed condition persistence (#181)', () => {
+  beforeEach(() => {
+    transaction.mockClear()
+    characterUpdate.mockClear()
+
+    resolveChoice.mockReturnValue({
+      updatedSurvival: { hp: 20, maxHp: 20, thirst: 95, hunger: 95, energy: 95, calamine: 0 },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    assembleScene.mockReturnValue({
+      sceneType: 'exploration',
+      location: 'The Marsh',
+      narrative: 'text',
+      choices: [],
+    })
+  })
+
+  it('merges a valid IA-family condition proposal into the persisted activeConditions', async () => {
+    generateScene.mockResolvedValue({
+      scene: { apply_condition: { id: 'marsh_disease', reason: 'waded through the marsh' } },
+      source: 'ai',
+    })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    expect(lastCharacterUpdateData().activeConditions).toEqual([
+      { id: 'marsh_disease', source: 'ai', appliedAtTurn: 4, expiresRule: { type: 'until_cured' } },
+    ])
+  })
+
+  it('rejects a BACKEND-family id proposed by the AI (never a valid AI proposal)', async () => {
+    generateScene.mockResolvedValue({
+      scene: { apply_condition: { id: 'fever', reason: 'trying to sneak in a backend condition' } },
+      source: 'ai',
+    })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    expect(lastCharacterUpdateData().activeConditions).toEqual([])
+  })
+
+  it('leaves conditions untouched when the AI omits apply_condition', async () => {
+    generateScene.mockResolvedValue({ scene: {}, source: 'ai' })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    expect(lastCharacterUpdateData().activeConditions).toEqual([])
+  })
+
+  it('does not duplicate a condition the character already has active', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: { hp: 20, maxHp: 20, thirst: 95, hunger: 95, energy: 95, calamine: 0 },
+      updatedConditions: [
+        { id: 'poison', source: 'ai', appliedAtTurn: 1, expiresRule: { type: 'until_cured' } },
+      ],
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({
+      scene: { apply_condition: { id: 'poison', reason: 'still in the poisonous marsh' } },
+      source: 'ai',
+    })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    expect(lastCharacterUpdateData().activeConditions).toEqual([
+      { id: 'poison', source: 'ai', appliedAtTurn: 1, expiresRule: { type: 'until_cured' } },
+    ])
+  })
+})

--- a/apps/backend/src/services/session.service.ts
+++ b/apps/backend/src/services/session.service.ts
@@ -1,4 +1,5 @@
 import {
+  type ActiveCondition,
   type Attributes,
   type Choice,
   type Locale,
@@ -10,6 +11,7 @@ import {
 
 import { generateScene } from '../ai/game-master.service'
 import { persistedChoicesSchema } from '../ai/scene-validator'
+import { applyAiCondition, isValidAiConditionId } from '../game-rules/conditions'
 import { resolveChoice } from '../game-rules/consequences'
 import { prisma } from '../lib/prisma'
 
@@ -51,10 +53,11 @@ function buildSeedCharacter(): {
   }
 }
 
-/** Reads a DB character row into the shared attribute/survival shapes. */
+/** Reads a DB character row into the shared attribute/survival/conditions shapes. */
 function readCharacter(character: DbCharacter): {
   attributes: Attributes
   survival: SurvivalStats
+  activeConditions: ActiveCondition[]
 } {
   return {
     attributes: { blood: character.blood, breath: character.breath, ash: character.ash },
@@ -66,6 +69,7 @@ function readCharacter(character: DbCharacter): {
       energy: character.energy,
       calamine: character.calamine,
     },
+    activeConditions: character.activeConditions as unknown as ActiveCondition[],
   }
 }
 
@@ -159,7 +163,7 @@ export async function getOrCreateSession(
         hunger: 100,
         energy: 100,
         calamine: 0,
-        conditions: [],
+        activeConditions: [],
       },
     })
   }
@@ -228,10 +232,10 @@ export async function buildOpeningScene(context: SessionContext): Promise<SceneR
   }
 
   const { session, character } = context
-  const { attributes, survival } = readCharacter(character)
+  const { attributes, survival, activeConditions } = readCharacter(character)
 
   const gm = await generateScene({
-    character: toGmCharacter(character, attributes, survival),
+    character: toGmCharacter(character, attributes, survival, activeConditions),
     // Locale is resolved and persisted at session creation — the DB is the
     // source of truth, never the per-request client value (#168).
     locale: session.locale,
@@ -324,12 +328,24 @@ export interface ResolveTurnInput {
  */
 export async function resolveTurn(input: ResolveTurnInput): Promise<SceneResponse> {
   const { session, character, choice, chosenActionText, freeAction } = input
-  const { attributes, survival } = readCharacter(character)
+  const { attributes, survival, activeConditions } = readCharacter(character)
 
-  const resolution = resolveChoice({ attributes, survival, choice })
+  const resolution = resolveChoice({
+    attributes,
+    survival,
+    choice,
+    activeConditions,
+    turnNumber: session.turnNumber,
+    locale: session.locale,
+  })
 
   const gm = await generateScene({
-    character: toGmCharacter(character, attributes, resolution.updatedSurvival),
+    character: toGmCharacter(
+      character,
+      attributes,
+      resolution.updatedSurvival,
+      resolution.updatedConditions
+    ),
     // Persisted session locale is the source of truth (#168).
     locale: session.locale,
     sessionId: session.id,
@@ -338,6 +354,17 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
   })
 
   const nextTurn = session.turnNumber + 1
+
+  // The AI may propose ONE [IA-PROPOSÉE] condition caused by what it just
+  // narrated (#181). The schema already restricts the id to family "ia", but
+  // isValidAiConditionId is re-checked here as the backend's own authority —
+  // the AI decides nothing, it only proposes.
+  const proposedCondition = gm.scene.apply_condition
+  const finalConditions =
+    proposedCondition && isValidAiConditionId(proposedCondition.id)
+      ? applyAiCondition(resolution.updatedConditions, proposedCondition.id, nextTurn)
+      : resolution.updatedConditions
+
   const scene = assembleScene({
     payload: gm.scene,
     sessionId: session.id,
@@ -371,6 +398,7 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
         hunger: resolution.updatedSurvival.hunger,
         energy: resolution.updatedSurvival.energy,
         calamine: resolution.updatedSurvival.calamine,
+        activeConditions: finalConditions as unknown as object,
       },
     }),
     prisma.gameSession.update({
@@ -394,7 +422,7 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
         await compressScene(
           session.id,
           recentTurns,
-          toGmCharacter(character, attributes, resolution.updatedSurvival),
+          toGmCharacter(character, attributes, resolution.updatedSurvival, finalConditions),
           scene.location
         )
       } catch (err) {
@@ -496,14 +524,19 @@ export async function abandonSession(
 }
 
 /** Assembles the shared `Character` shape the Game Master prompt expects. */
-function toGmCharacter(character: DbCharacter, attributes: Attributes, survival: SurvivalStats) {
+function toGmCharacter(
+  character: DbCharacter,
+  attributes: Attributes,
+  survival: SurvivalStats,
+  activeConditions: ActiveCondition[] = []
+) {
   return {
     id: character.id,
     userId: character.userId,
     name: character.name,
     people: character.people,
     vocation: character.vocation,
-    stats: { attributes, survival, conditions: [] as never[] },
+    stats: { attributes, survival, conditions: activeConditions },
     createdAt: character.createdAt.toISOString(),
   }
 }

--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.tsx
@@ -93,8 +93,8 @@ function consequenceMessages(response: SceneResponse | null, copy: ConsequenceCo
 export function VelkharSession({ initialCharacter, locale }: VelkharSessionProps) {
   const uiLocale = useLocale()
   const t = useTranslations('Session')
-  // La langue de narration reste distincte de la locale UI : une valeur fournie
-  // par le parcours de jeu gagne, sinon le navigateur alimente le fallback #168.
+  // La langue de narration priorise : locale fournie par le parcours de jeu,
+  // puis le choix explicite du switcher en jeu, puis le navigateur (#168, #181).
   const [detectedLocale] = useState<Locale | undefined>(() => detectBrowserLocale())
   const effectiveLocale = locale ?? detectedLocale
   const [freeAction, setFreeAction] = useState('')
@@ -108,6 +108,7 @@ export function VelkharSession({ initialCharacter, locale }: VelkharSessionProps
     api: gameSessionApi,
     initialWorldState: initialCharacter.stats.survival,
     locale: effectiveLocale,
+    explicitLocale: uiLocale as Locale,
     reduceWorldState,
     resumeHref: `${VELKHAR_WORLD.routes.session}/resume`,
   })

--- a/apps/frontend/src/features/game-session/api/game-session-api.ts
+++ b/apps/frontend/src/features/game-session/api/game-session-api.ts
@@ -42,19 +42,30 @@ async function readEndResponse(response: Response): Promise<GameSessionEndRespon
   return body.data
 }
 
+export interface CreateSessionLocaleInput {
+  /** Browser-detected narration language, used as a fallback (#168). */
+  locale?: Locale
+  /** Deliberate in-game language choice (language switcher); wins over `locale` (#181). */
+  explicitLocale?: Locale
+}
+
 /**
  * Creates (or resumes) the player's active session and returns its opening
- * scene with the persisted world-state. `locale` is the browser-detected
- * narration language; the backend normalizes it, applies its own precedence
- * and falls back to English, so `undefined` is fine (#168).
+ * scene with the persisted world-state. The backend normalizes both locales,
+ * prioritizes `explicitLocale` over the browser-detected `locale` and falls
+ * back to English, so an empty input is fine (#168, #181).
  */
-export async function createSession<TResponse extends GameSessionResponse = GameSessionResponse>(
-  locale?: Locale
-): Promise<TResponse> {
+export async function createSession<TResponse extends GameSessionResponse = GameSessionResponse>({
+  locale,
+  explicitLocale,
+}: CreateSessionLocaleInput = {}): Promise<TResponse> {
   const response = await fetch('/api/game/session', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(locale ? { locale } : {}),
+    body: JSON.stringify({
+      ...(locale ? { locale } : {}),
+      ...(explicitLocale ? { explicitLocale } : {}),
+    }),
   })
 
   return readSceneResponse<TResponse>(response)

--- a/apps/frontend/src/features/game-session/hooks/use-game-session.ts
+++ b/apps/frontend/src/features/game-session/hooks/use-game-session.ts
@@ -20,6 +20,8 @@ interface UseGameSessionOptions<TWorldState, TResponse extends GameSessionRespon
   initialWorldState: TWorldState
   /** Browser-detected narration language; resolved and persisted server-side (#168). */
   locale?: Locale
+  /** Deliberate in-game language choice (language switcher); wins over `locale` (#181). */
+  explicitLocale?: Locale
   reduceWorldState: (previous: TWorldState, response: TResponse) => TWorldState
   resumeHref: string
 }
@@ -42,6 +44,7 @@ export function useGameSession<TWorldState, TResponse extends GameSessionRespons
   api,
   initialWorldState,
   locale,
+  explicitLocale,
   reduceWorldState,
   resumeHref,
 }: UseGameSessionOptions<TWorldState, TResponse>): UseGameSessionResult<TWorldState, TResponse> {
@@ -116,12 +119,12 @@ export function useGameSession<TWorldState, TResponse extends GameSessionRespons
   const openSession = useCallback(async () => {
     setState((current) => ({ ...current, error: null, loading: true }))
     try {
-      applyResponse(await api.createSession(locale))
+      applyResponse(await api.createSession({ locale, explicitLocale }))
       lastAttemptRef.current = null
     } catch (error) {
       handleRequestError(error)
     }
-  }, [api, applyResponse, handleRequestError, locale])
+  }, [api, applyResponse, handleRequestError, locale, explicitLocale])
 
   const submitAction = useCallback(
     async (action: PendingGameAction) => {

--- a/apps/frontend/src/features/game-session/model/game-session.types.ts
+++ b/apps/frontend/src/features/game-session/model/game-session.types.ts
@@ -1,4 +1,4 @@
-import type { Locale } from '@grimoire/shared'
+import type { CreateSessionLocaleInput } from '../api/game-session-api'
 
 export type GameSessionRiskLevel = 'safe' | 'low' | 'medium' | 'high' | 'deadly'
 
@@ -66,7 +66,7 @@ export interface PendingGameAction {
 
 export interface GameSessionApi<TResponse extends GameSessionResponse = GameSessionResponse> {
   abandonSession: (sessionId: string) => Promise<GameSessionEndResponse>
-  createSession: (locale?: Locale) => Promise<TResponse>
+  createSession: (input?: CreateSessionLocaleInput) => Promise<TResponse>
   postGameAction: (input: {
     sessionId: string
     choiceId?: string

--- a/docs/public/current-state/BACKEND_NEXT.md
+++ b/docs/public/current-state/BACKEND_NEXT.md
@@ -5,7 +5,7 @@ rag: true
 source_of_truth: true
 owner: backend
 default_agent: claude
-updated: 2026-07-23
+updated: 2026-07-24
 ---
 
 # Backend Next
@@ -13,7 +13,7 @@ updated: 2026-07-23
 ## Phase 1 — pré-déploiement
 
 1. ~~#180~~ — figer les contrats shared Survie v2 : livré (PR #196).
-2. #181 et #183 — livrer en séquence les conditions/Désavantage et l'inventaire réel.
+2. ~~#181~~ — conditions et Désavantage : livré (PR #198). #183 — inventaire réel reste à livrer.
 3. #182 et #184 — brancher la Calamine/fin Calciné et l'action de repos.
 4. #185 — renforcer le danger IA une fois les conséquences mécaniques disponibles.
 5. ~~#101~~ — fiabiliser les modèles : livré (PR #191).
@@ -24,7 +24,7 @@ updated: 2026-07-23
 
 Ordre de dépendance :
 
-`(#181 + #183) → (#182 + #184) → #185 → (#152 + #162) → #161 → #129`
+`#183 → (#182 + #184) → #185 → (#152 + #162) → #161 → #129`
 
 ## Post-déploiement
 

--- a/docs/public/current-state/BACKEND_STATUS.md
+++ b/docs/public/current-state/BACKEND_STATUS.md
@@ -24,10 +24,11 @@ updated: 2026-07-24
 - #189 — mémoire projet, routage Claude/Codex et garde-fous `current-state`.
 - #101 / PR #191 — fallback multi-modèles face aux erreurs OpenRouter.
 - #180 / PR #196 — contrats partagés Survie v2 (`ConditionId`, `ActiveCondition`, `itemGained`).
+- #181 / PR #198 — conditions persistées, Désavantage au d20 et priorité langue explicite du
+  switcher en jeu sur la détection navigateur.
 
 ## Pré-déploiement restant
 
-- #181 — conditions persistées et Désavantage au d20.
 - #183 — acquisition, consommation et équipement de l'inventaire réel.
 - #182 — paliers de Calamine et fin spéciale `calcined`.
 - #184 — repos court/feu et récupération canonique.

--- a/docs/public/current-state/FRONTEND_NEXT.md
+++ b/docs/public/current-state/FRONTEND_NEXT.md
@@ -13,7 +13,7 @@ updated: 2026-07-24
 ## Phase 1 — pré-déploiement
 
 1. #186 — afficher le HUD Survie v2, les conditions, l'inventaire réel, le Désavantage et la fin
-   Calciné ; dépend de ~~#180~~ (livré, PR #196) et #181-#184.
+   Calciné ; dépend de ~~#180~~ (livré, PR #196), ~~#181~~ (livré, PR #198) et #182-#184.
 2. #152 — livrer le flow du concept libre ou masquer l'option sans cul-de-sac pour la V1.
 3. #161 — configurer `NEXT_PUBLIC_API_URL`, le domaine final et les redirects Supabase.
 4. #129 — exécuter les golden paths anonyme, conversion et résilience en EN/FR.

--- a/docs/public/current-state/FRONTEND_STATUS.md
+++ b/docs/public/current-state/FRONTEND_STATUS.md
@@ -26,11 +26,13 @@ updated: 2026-07-24
 - #189 — mémoire projet, routage Claude/Codex et garde-fous `current-state`.
 - #188 — Auberge branchée sur les contrats réels `hub`, `talk` et `spend`, avec états de
   résilience et reprise anonyme/authentifiée.
+- #181 / PR #198 — priorité langue explicite du switcher en jeu sur la détection navigateur pour
+  la narration IA (le HUD Survie v2 consommant conditions/Désavantage reste #186).
 
 ## Pré-déploiement restant
 
 - #186 — livrer l'UI Survie v2 après stabilisation des contrats ~~#180~~ (livré, PR #196) et des
-  endpoints #181-#184.
+  endpoints ~~#181~~ (livré, PR #198), #182-#184.
 - #152 — intégrer la résolution du concept libre ou masquer proprement l'option en V1.
 - #161 — configurer l'API de production et les redirects Supabase côté frontend.
 - #129 — valider le golden path réel EN/FR, l'accessibilité et le responsive.

--- a/docs/public/current-state/RELEASE_READINESS.md
+++ b/docs/public/current-state/RELEASE_READINESS.md
@@ -26,22 +26,22 @@ merge. La checklist opérationnelle détaillée vit dans l'issue #163.
 | Mémoire et état du projet      | Livré | #189           |
 | Disponibilité IA (fallback GM) | Livré | #101 / PR #191 |
 | Contrats shared Survie v2      | Livré | #180 / PR #196 |
+| Conditions et Désavantage      | Livré | #181 / PR #198 |
 
 ## Phase 1 — pré-déploiement
 
-| Bloc                      | État       | Référence |
-| ------------------------- | ---------- | --------- |
-| Conditions et Désavantage | À faire    | #181      |
-| Calamine et fin Calciné   | À faire    | #182      |
-| Inventaire réel           | À faire    | #183      |
-| Action de repos           | À faire    | #184      |
-| Danger IA                 | À faire    | #185      |
-| UI Survie v2              | À faire    | #186      |
-| Concept libre             | À trancher | #152      |
-| Sécurité dépendances      | Bloquant   | #162      |
-| Déploiement API           | À faire    | #161      |
-| Golden path réel          | À faire    | #129      |
-| Checklist de livraison    | Ouverte    | #163      |
+| Bloc                    | État       | Référence |
+| ----------------------- | ---------- | --------- |
+| Calamine et fin Calciné | À faire    | #182      |
+| Inventaire réel         | À faire    | #183      |
+| Action de repos         | À faire    | #184      |
+| Danger IA               | À faire    | #185      |
+| UI Survie v2            | À faire    | #186      |
+| Concept libre           | À trancher | #152      |
+| Sécurité dépendances    | Bloquant   | #162      |
+| Déploiement API         | À faire    | #161      |
+| Golden path réel        | À faire    | #129      |
+| Checklist de livraison  | Ouverte    | #163      |
 
 ## Post-déploiement
 

--- a/packages/shared/src/types/dice.types.ts
+++ b/packages/shared/src/types/dice.types.ts
@@ -19,6 +19,12 @@ export const DIFFICULTY_TARGET: Record<Difficulty, number> = {
   deadly: 16,
 };
 
+/**
+ * Roll mode, per canon 08-DICE §5. "normal" = 1d20. "advantage"/"disadvantage" = 2d20,
+ * keep best/worst. Advantage and disadvantage cancel out to "normal" when both apply.
+ */
+export type RollMode = "normal" | "advantage" | "disadvantage";
+
 export interface DiceRoll {
   roll: number;
   modifier: number;
@@ -27,4 +33,8 @@ export interface DiceRoll {
   success: boolean;
   /** Natural 20 / natural 1 flags for narration flavor. */
   critical: "success" | "failure" | null;
+  /** Roll mode actually applied, after advantage/disadvantage cancellation. */
+  rollMode: RollMode;
+  /** Why disadvantage applied (e.g. the condition name), for player-facing transparency. Unset when rollMode is not "disadvantage". */
+  disadvantageCause?: string;
 }


### PR DESCRIPTION
## Résumé
- Système de conditions (`game-rules/conditions.ts`) : familles BACKEND (seuils) et IA-PROPOSÉE (whitelist + validation), apply/tick/remove
- Désavantage au d20 (2d20 garder le pire) quand une condition sévère est active (canon 08 §5), avec `disadvantageCause` localisé (fr/en)
- Validation IA (`scene-validator.ts`) et instructions de prompt (`system-prompt.ts`) pour proposer une condition narrative
- Persistance des conditions actives sur `Character` (migration Prisma `activeConditions` JSON, appliquée via MCP Supabase)
- Fix locale L'Aveugle : instruction de langue déplacée en tête de prompt (au lieu d'être noyée après un long bloc de voix FR)
- Fix propagation de langue : le choix de langue du switcher en jeu (`explicitLocale`) était calculé côté frontend mais jamais transmis au backend — seule la langue navigateur l'était. Le backend priorisait déjà `explicitLocale` > navigateur, il manquait le branchement `game-session-api.ts` → `use-game-session.ts` → `VelkharSession.tsx`

## Phase et domaine
- **Phase** : predeploy
- **Domaine** : backend, ai, frontend
- **Propriétaire** : Claude (backend/shared/ai), fix ponctuel frontend inclus (propagation locale)

## Tests
- `pnpm test --filter @grimoire/backend` (230/230 passés)
- `pnpm type-check --filter @grimoire/backend` (clean)
- `pnpm type-check --filter @grimoire/frontend` (clean)
- `npx vitest run` ciblé sur `VelkharSession.test.tsx` + `game-session` (10/10 passés)
- Lint clean sur les fichiers modifiés

Closes #181