### PR TITLE
feat(#182): paliers de Calamine et fin Calciné

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -92,7 +92,7 @@ model GameSession {
   /// normalisé). Persistée pour que la reprise garde la même langue (#168).
   locale     String   @default("en")
   status     String   @default("active") // active | ended
-  /// Why the session ended (death | inn | abandon). Null while active. Bridge to A3.
+  /// Why the session ended (death | inn | abandon | calcined). Null while active. Bridge to A3.
   endReason  String?
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
@@ -196,7 +196,7 @@ model Chronicle {
   characterId String
   sessionId   String
 
-  /// Why the run ended (death | inn | abandon), copied from GameSession.endReason.
+  /// Why the run ended (death | inn | abandon | calcined), copied from GameSession.endReason.
   endReason String
 
   title        String

--- a/apps/backend/src/ai/scene-validator.ts
+++ b/apps/backend/src/ai/scene-validator.ts
@@ -50,13 +50,16 @@ export type AiSouvenirCandidate = z.infer<typeof aiSouvenirCandidateSchema>
  * backend still re-validates the id against `isValidAiConditionId` before
  * ever applying it (this schema rejects unknown ids up front, but a stale
  * whitelist copy or renamed id must never silently pass through).
- * @see docs/public/raw/06-SURVIVAL.md §2 "Les deux familles de conditions"
+ * `calamineDelta` is only meaningful when `id === "cendre_corrupt"` (#182) —
+ * capped at +20/turn by `clampCalamineDelta`, ignored for every other id.
+ * @see docs/public/raw/06-SURVIVAL.md §2 "Les deux familles de conditions", §4 "La Cendre et la Calamine"
  */
 export const aiApplyConditionSchema = z.object({
   id: z.string().min(1).refine(isValidAiConditionId, {
     message: 'Unknown or non-AI-proposable condition id',
   }),
   reason: z.string().min(1).max(280),
+  calamineDelta: z.number().finite().optional(),
 })
 
 export type AiApplyCondition = z.infer<typeof aiApplyConditionSchema>

--- a/apps/backend/src/ai/system-prompt.ts
+++ b/apps/backend/src/ai/system-prompt.ts
@@ -112,6 +112,18 @@ function buildConditionsSection(character: Character, locale: Locale): string[] 
     'already active on the player. Only propose ids from this exact whitelist —',
     'any other id is rejected:',
     ...whitelistLines,
+    '',
+    'Special case — "cendre_corrupt" (Calamine): only propose this id, with a',
+    'calamineDelta, when the scene you just wrote depicts ONE of these canon',
+    'sources (any other cause is ignored by the backend, gauge does not move):',
+    '- Exposure to archontic light: delta 5 to 15',
+    '- Contact with a corrupted creature or place: delta 5 to 10',
+    '- The gaze or presence of an archontic Watcher: delta 10 to 20',
+    '- Excessive ritual or magic use outside an artifact: delta 5 to 15',
+    'The backend caps the applied delta at +20/turn regardless of what you send.',
+    'Never invent a delta for any other condition id, and never let the gauge',
+    'rise without one of these sources actually happening in the narrative —',
+    'Calamine never rises on its own.',
   ]
 }
 
@@ -156,7 +168,7 @@ export function buildSystemPrompt(
     '  "choices": [{ "text": string, "type": "action"|"dialog"|"combat"|"flee"|"use_item"|"skill", "riskLevel"?: "safe"|"low"|"medium"|"high"|"deadly" }],',
     '  "turnSummary": string,',
     '  "souvenir_candidate"?: { "title_suggestion": string, "body": string, "type": "npc-death"|"moral-choice"|"secret-discovery"|"boss-victory"|"strong-promise" }',
-    '  "apply_condition"?: { "id": string, "reason": string }',
+    '  "apply_condition"?: { "id": string, "reason": string, "calamineDelta"?: number }',
     '}',
     '',
     'turnSummary: a short factual sentence (max 200 characters) condensing what just',
@@ -172,6 +184,8 @@ export function buildSystemPrompt(
     'apply_condition: OPTIONAL, omit on most turns. Only include it when the',
     'narrative event you just wrote clearly and directly causes one of the',
     'whitelisted conditions above. reason: one short sentence explaining why',
-    '(e.g. "crossed the poisonous marsh without protection").',
+    '(e.g. "crossed the poisonous marsh without protection"). calamineDelta is',
+    'only meaningful when id is "cendre_corrupt" — see the Calamine sources',
+    'above; omit it for every other condition id.',
   ].join('\n')
 }

--- a/apps/backend/src/game-rules/conditions.test.ts
+++ b/apps/backend/src/game-rules/conditions.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from 'vitest'
 import {
   applyAiCondition,
   applyBackendConditions,
+  applyCalamineDelta,
+  calamineTier,
+  clampCalamineDelta,
   clearResolvedBackendConditions,
   computeDisadvantage,
   isValidAiConditionId,
@@ -194,5 +197,78 @@ describe('applyAiCondition', () => {
     const existing = [condition({ id: 'poison' })]
     const next = applyAiCondition(existing, 'poison', 9)
     expect(next).toHaveLength(1)
+  })
+})
+
+describe('calamineTier (06-SURVIVAL §4)', () => {
+  it('is "none" from 0 to 24', () => {
+    expect(calamineTier(0)).toBe('none')
+    expect(calamineTier(24)).toBe('none')
+  })
+
+  it('is "stage1" from 25 to 49', () => {
+    expect(calamineTier(25)).toBe('stage1')
+    expect(calamineTier(49)).toBe('stage1')
+  })
+
+  it('is "stage2" from 50 to 74', () => {
+    expect(calamineTier(50)).toBe('stage2')
+    expect(calamineTier(74)).toBe('stage2')
+  })
+
+  it('is "stage3" from 75 to 99', () => {
+    expect(calamineTier(75)).toBe('stage3')
+    expect(calamineTier(99)).toBe('stage3')
+  })
+
+  it('is "dead" at 100 (transformation into Calciné)', () => {
+    expect(calamineTier(100)).toBe('dead')
+  })
+
+  it('stays "dead" above 100 (defensive, gauge is clamped elsewhere)', () => {
+    expect(calamineTier(150)).toBe('dead')
+  })
+})
+
+describe('clampCalamineDelta', () => {
+  it('passes through a delta within the cap', () => {
+    expect(clampCalamineDelta(15)).toBe(15)
+  })
+
+  it('caps a delta above +20 (anti-abuse guard, 06-SURVIVAL §4)', () => {
+    expect(clampCalamineDelta(35)).toBe(20)
+  })
+
+  it('drops a non-positive delta — no canon source lowers Calamine here', () => {
+    expect(clampCalamineDelta(0)).toBe(0)
+    expect(clampCalamineDelta(-10)).toBe(0)
+  })
+
+  it('drops a non-finite delta', () => {
+    expect(clampCalamineDelta(Number.NaN)).toBe(0)
+    expect(clampCalamineDelta(Number.POSITIVE_INFINITY)).toBe(0)
+  })
+})
+
+describe('applyCalamineDelta', () => {
+  it('adds a bounded delta to the gauge', () => {
+    const next = applyCalamineDelta(full({ calamine: 10 }), 15)
+    expect(next.calamine).toBe(25)
+  })
+
+  it('caps the applied delta at +20 even if a larger value is passed', () => {
+    const next = applyCalamineDelta(full({ calamine: 10 }), 999)
+    expect(next.calamine).toBe(30)
+  })
+
+  it('clamps the gauge at 100', () => {
+    const next = applyCalamineDelta(full({ calamine: 90 }), 20)
+    expect(next.calamine).toBe(100)
+  })
+
+  it('leaves survival untouched (same reference) when delta is dropped', () => {
+    const survival = full({ calamine: 10 })
+    const next = applyCalamineDelta(survival, -5)
+    expect(next).toBe(survival)
   })
 })

--- a/apps/backend/src/game-rules/conditions.ts
+++ b/apps/backend/src/game-rules/conditions.ts
@@ -144,3 +144,45 @@ export function applyAiCondition(
     { id, source: 'ai', appliedAtTurn: turnNumber, expiresRule: { type: 'until_cured' } },
   ]
 }
+
+/** Max Calamine gained from a single AI-proposed source in one turn. @see docs/public/raw/06-SURVIVAL.md §4 */
+export const CALAMINE_DELTA_CAP = 20
+
+/** Calamine tiers (06-SURVIVAL §4). `dead` is the 100 transformation threshold, not a narrative tier. */
+export type CalamineTier = 'none' | 'stage1' | 'stage2' | 'stage3' | 'dead'
+
+/**
+ * The canon tier for a given Calamine value: 0-24 none, 25-49 stage 1,
+ * 50-74 stage 2, 75-99 stage 3, 100 = transformation (Calciné).
+ */
+export function calamineTier(calamine: number): CalamineTier {
+  if (calamine >= 100) return 'dead'
+  if (calamine >= 75) return 'stage3'
+  if (calamine >= 50) return 'stage2'
+  if (calamine >= 25) return 'stage1'
+  return 'none'
+}
+
+/**
+ * Bounds an AI-proposed Calamine delta to the canon cap, dropping non-positive
+ * or non-finite values. There is no passive drain and no canon source lowers
+ * Calamine via `apply_condition` — only positive deltas from a validated
+ * narrative source are meaningful here.
+ * @see docs/public/raw/06-SURVIVAL.md §4
+ */
+export function clampCalamineDelta(delta: number): number {
+  if (!Number.isFinite(delta) || delta <= 0) return 0
+  return Math.min(delta, CALAMINE_DELTA_CAP)
+}
+
+/**
+ * Applies a bounded Calamine delta to survival stats, clamped to [0, 100].
+ * Only `cendre_corrupt` proposals carry a meaningful delta — callers must
+ * check the condition id before calling this (see `resolveTurn` in
+ * `session.service.ts`, applied post-hoc once the AI proposal is known).
+ */
+export function applyCalamineDelta(survival: SurvivalStats, delta: number): SurvivalStats {
+  const bounded = clampCalamineDelta(delta)
+  if (bounded === 0) return survival
+  return { ...survival, calamine: clamp(survival.calamine + bounded, 0, 100) }
+}

--- a/apps/backend/src/services/chronicle.service.test.ts
+++ b/apps/backend/src/services/chronicle.service.test.ts
@@ -156,6 +156,32 @@ describe('generateChronicle', () => {
     expect(sceneLogDeleteMany).not.toHaveBeenCalled()
   })
 
+  it('narrates a calcined ending with its dedicated label, not undefined (#182)', async () => {
+    gameSessionFindUnique.mockResolvedValue({ ...baseSession, endReason: 'calcined' })
+    callOpenRouter.mockResolvedValue({ success: true, content: JSON.stringify(validOutput) })
+
+    const result = await generateChronicle('s1')
+
+    expect(result).toEqual({ generated: true })
+    expect(chronicleCreate).toHaveBeenCalledWith({
+      data: {
+        userId: 'user1',
+        characterId: 'char1',
+        sessionId: 's1',
+        endReason: 'calcined',
+        title: validOutput.title,
+        bodyMarkdown: validOutput.body_markdown,
+        mood: validOutput.mood,
+        keyMoments: validOutput.key_moments,
+        tagline: validOutput.tagline,
+      },
+    })
+    const [messages] = callOpenRouter.mock.calls[0] as [{ content: string }[]]
+    const prompt = messages[0].content
+    expect(prompt).not.toContain('undefined')
+    expect(prompt).toContain('Calciné')
+  })
+
   it('deduplicates pinned facts across memory chunks', async () => {
     memoryChunkFindMany.mockResolvedValue([
       { summary: 'A', keyFactsPinned: ['Artifact obtained: shrine relic'] },

--- a/apps/backend/src/services/chronicle.service.ts
+++ b/apps/backend/src/services/chronicle.service.ts
@@ -53,6 +53,8 @@ function buildChroniclePrompt(context: ChronicleContext): string {
     death: 'Mort en cours de run',
     inn: 'Choix de fin volontaire à l’auberge, face à L’Aveugle',
     abandon: 'Abandon du personnage (inactivité ou clic explicite)',
+    calcined:
+      'Calamine à son comble : le personnage est devenu ce qu’il chassait, transformé en Calciné',
   }
 
   return [

--- a/apps/backend/src/services/session.service.condition.test.ts
+++ b/apps/backend/src/services/session.service.condition.test.ts
@@ -24,6 +24,9 @@ vi.mock('./scene-assembler', () => ({ assembleScene }))
 
 vi.mock('./memory.service', () => ({ compressScene: vi.fn().mockResolvedValue(undefined) }))
 
+const generateChronicle = vi.fn().mockResolvedValue({ generated: true })
+vi.mock('./chronicle.service', () => ({ generateChronicle }))
+
 const { resolveTurn } = await import('./session.service')
 
 import type { Character as DbCharacter, GameSession } from '../generated/prisma/client'
@@ -68,11 +71,20 @@ const choice = {
 }
 
 /** Reads the `data` payload passed to the mocked `character.update` call. */
-function lastCharacterUpdateData(): { activeConditions: unknown } {
+function lastCharacterUpdateData(): { activeConditions: unknown; calamine?: number } {
   const call = characterUpdate.mock.calls.at(-1) as
-    | [{ data: { activeConditions: unknown } }]
+    | [{ data: { activeConditions: unknown; calamine?: number } }]
     | undefined
   if (!call) throw new Error('character.update was not called')
+  return call[0].data
+}
+
+/** Reads the `data` payload passed to the mocked `gameSession.update` call. */
+function lastGameSessionUpdateData(): { status?: string; endReason?: string | null } {
+  const call = gameSessionUpdate.mock.calls.at(-1) as
+    | [{ data: { status?: string; endReason?: string | null } }]
+    | undefined
+  if (!call) throw new Error('gameSession.update was not called')
   return call[0].data
 }
 
@@ -146,5 +158,139 @@ describe('resolveTurn — AI-proposed condition persistence (#181)', () => {
     expect(lastCharacterUpdateData().activeConditions).toEqual([
       { id: 'poison', source: 'ai', appliedAtTurn: 1, expiresRule: { type: 'until_cured' } },
     ])
+  })
+})
+
+describe('resolveTurn — Calamine sources and transformation (#182)', () => {
+  beforeEach(() => {
+    transaction.mockClear()
+    characterUpdate.mockClear()
+    gameSessionUpdate.mockClear()
+    generateChronicle.mockClear()
+
+    assembleScene.mockReturnValue({
+      sceneType: 'exploration',
+      location: 'The Marsh',
+      narrative: 'text',
+      choices: [],
+    })
+  })
+
+  it('applies a validated cendre_corrupt delta to the Calamine gauge', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: { hp: 20, maxHp: 20, thirst: 95, hunger: 95, energy: 95, calamine: 10 },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({
+      scene: {
+        apply_condition: {
+          id: 'cendre_corrupt',
+          reason: 'exposed to archontic light',
+          calamineDelta: 15,
+        },
+      },
+      source: 'ai',
+    })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    expect(lastCharacterUpdateData().calamine).toBe(25)
+  })
+
+  it('caps the applied delta at +20/turn even if the AI proposes more', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: { hp: 20, maxHp: 20, thirst: 95, hunger: 95, energy: 95, calamine: 0 },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({
+      scene: {
+        apply_condition: {
+          id: 'cendre_corrupt',
+          reason: 'watcher presence',
+          calamineDelta: 999,
+        },
+      },
+      source: 'ai',
+    })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    expect(lastCharacterUpdateData().calamine).toBe(20)
+  })
+
+  it('ignores a calamineDelta attached to a non-cendre_corrupt proposal', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: { hp: 20, maxHp: 20, thirst: 95, hunger: 95, energy: 95, calamine: 10 },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({
+      scene: {
+        apply_condition: { id: 'poison', reason: 'venomous bite', calamineDelta: 50 },
+      },
+      source: 'ai',
+    })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    expect(lastCharacterUpdateData().calamine).toBe(10)
+  })
+
+  it('leaves the gauge untouched when the AI omits apply_condition (no passive drain)', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: { hp: 20, maxHp: 20, thirst: 95, hunger: 95, energy: 95, calamine: 40 },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({ scene: {}, source: 'ai' })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    expect(lastCharacterUpdateData().calamine).toBe(40)
+  })
+
+  it('transforms into Calciné at 100: ends the session with endReason "calcined"', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: { hp: 20, maxHp: 20, thirst: 95, hunger: 95, energy: 95, calamine: 85 },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({
+      scene: {
+        apply_condition: {
+          id: 'cendre_corrupt',
+          reason: 'excessive ritual magic',
+          calamineDelta: 20,
+        },
+      },
+      source: 'ai',
+    })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    expect(lastCharacterUpdateData().calamine).toBe(100)
+    expect(lastGameSessionUpdateData()).toMatchObject({ status: 'ended', endReason: 'calcined' })
+    expect(generateChronicle).toHaveBeenCalledWith('s1')
+  })
+
+  it('reports "death" over "calcined" when HP-death and Calamine=100 happen the same turn', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: { hp: 0, maxHp: 20, thirst: 95, hunger: 95, energy: 95, calamine: 100 },
+      updatedConditions: [],
+      consequences: { gameOver: true },
+      gameOver: true,
+    })
+    generateScene.mockResolvedValue({ scene: {}, source: 'ai' })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    expect(lastGameSessionUpdateData()).toMatchObject({ status: 'ended', endReason: 'death' })
   })
 })

--- a/apps/backend/src/services/session.service.ts
+++ b/apps/backend/src/services/session.service.ts
@@ -11,7 +11,12 @@ import {
 
 import { generateScene } from '../ai/game-master.service'
 import { persistedChoicesSchema } from '../ai/scene-validator'
-import { applyAiCondition, isValidAiConditionId } from '../game-rules/conditions'
+import {
+  applyAiCondition,
+  applyCalamineDelta,
+  calamineTier,
+  isValidAiConditionId,
+} from '../game-rules/conditions'
 import { resolveChoice } from '../game-rules/consequences'
 import { prisma } from '../lib/prisma'
 
@@ -360,10 +365,22 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
   // isValidAiConditionId is re-checked here as the backend's own authority —
   // the AI decides nothing, it only proposes.
   const proposedCondition = gm.scene.apply_condition
-  const finalConditions =
-    proposedCondition && isValidAiConditionId(proposedCondition.id)
-      ? applyAiCondition(resolution.updatedConditions, proposedCondition.id, nextTurn)
-      : resolution.updatedConditions
+  const isValidProposal = proposedCondition && isValidAiConditionId(proposedCondition.id)
+  const finalConditions = isValidProposal
+    ? applyAiCondition(resolution.updatedConditions, proposedCondition.id, nextTurn)
+    : resolution.updatedConditions
+
+  // #182: only "cendre_corrupt" carries a Calamine effect — a validated source,
+  // bounded to +20/turn, no passive drain (06-SURVIVAL §4). 100 is a hard,
+  // non-reversible transformation into Calciné, checked after HP-death so a
+  // simultaneous lethal HP hit still reports as 'death'.
+  const calamineDelta =
+    isValidProposal && proposedCondition.id === 'cendre_corrupt'
+      ? (proposedCondition.calamineDelta ?? 0)
+      : 0
+  const finalSurvival = applyCalamineDelta(resolution.updatedSurvival, calamineDelta)
+  const calcined = !resolution.gameOver && calamineTier(finalSurvival.calamine) === 'dead'
+  const gameOver = resolution.gameOver || calcined
 
   const scene = assembleScene({
     payload: gm.scene,
@@ -372,7 +389,11 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
     consequences: resolution.consequences,
   })
 
-  const endReason: SessionEndReason | null = resolution.gameOver ? 'death' : null
+  const endReason: SessionEndReason | null = resolution.gameOver
+    ? 'death'
+    : calcined
+      ? 'calcined'
+      : null
 
   await prisma.$transaction([
     prisma.sceneLog.create({
@@ -393,11 +414,11 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
     prisma.character.update({
       where: { id: character.id },
       data: {
-        hp: resolution.updatedSurvival.hp,
-        thirst: resolution.updatedSurvival.thirst,
-        hunger: resolution.updatedSurvival.hunger,
-        energy: resolution.updatedSurvival.energy,
-        calamine: resolution.updatedSurvival.calamine,
+        hp: finalSurvival.hp,
+        thirst: finalSurvival.thirst,
+        hunger: finalSurvival.hunger,
+        energy: finalSurvival.energy,
+        calamine: finalSurvival.calamine,
         activeConditions: finalConditions as unknown as object,
       },
     }),
@@ -406,7 +427,7 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
       data: {
         turnNumber: nextTurn,
         location: scene.location,
-        ...(resolution.gameOver ? { status: 'ended', endReason } : {}),
+        ...(gameOver ? { status: 'ended', endReason } : {}),
       },
     }),
   ])
@@ -422,7 +443,7 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
         await compressScene(
           session.id,
           recentTurns,
-          toGmCharacter(character, attributes, resolution.updatedSurvival, finalConditions),
+          toGmCharacter(character, attributes, finalSurvival, finalConditions),
           scene.location
         )
       } catch (err) {
@@ -446,7 +467,7 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
     })()
   }
 
-  if (resolution.gameOver) {
+  if (gameOver) {
     void (async () => {
       try {
         await generateChronicle(session.id)
@@ -458,7 +479,7 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
 
   return {
     scene,
-    updatedStats: toStatsRecord(resolution.updatedSurvival),
+    updatedStats: toStatsRecord(finalSurvival),
     updatedInventory: [],
     notifications: [],
     diceRoll: resolution.diceRoll,

--- a/docs/public/current-state/BACKEND_NEXT.md
+++ b/docs/public/current-state/BACKEND_NEXT.md
@@ -14,7 +14,7 @@ updated: 2026-07-24
 
 1. ~~#180~~ — figer les contrats shared Survie v2 : livré (PR #196).
 2. ~~#181~~ — conditions et Désavantage : livré (PR #198). #183 — inventaire réel reste à livrer.
-3. #182 et #184 — brancher la Calamine/fin Calciné et l'action de repos.
+3. ~~#182~~ — Calamine/fin Calciné : livré (PR #199). #184 — action de repos reste à livrer.
 4. #185 — renforcer le danger IA une fois les conséquences mécaniques disponibles.
 5. ~~#101~~ — fiabiliser les modèles : livré (PR #191).
 6. #152 — résoudre ou désactiver le concept libre.
@@ -24,7 +24,7 @@ updated: 2026-07-24
 
 Ordre de dépendance :
 
-`#183 → (#182 + #184) → #185 → (#152 + #162) → #161 → #129`
+`#183 → #184 → #185 → (#152 + #162) → #161 → #129`
 
 ## Post-déploiement
 

--- a/docs/public/current-state/BACKEND_STATUS.md
+++ b/docs/public/current-state/BACKEND_STATUS.md
@@ -26,11 +26,12 @@ updated: 2026-07-24
 - #180 / PR #196 — contrats partagés Survie v2 (`ConditionId`, `ActiveCondition`, `itemGained`).
 - #181 / PR #198 — conditions persistées, Désavantage au d20 et priorité langue explicite du
   switcher en jeu sur la détection navigateur.
+- #182 / PR #199 — paliers de Calamine et fin spéciale `calcined`, `ChronicleEndReason` dérivé de
+  `SessionEndReason`.
 
 ## Pré-déploiement restant
 
 - #183 — acquisition, consommation et équipement de l'inventaire réel.
-- #182 — paliers de Calamine et fin spéciale `calcined`.
 - #184 — repos court/feu et récupération canonique.
 - #185 — danger IA régulier et crescendo d'intensité.
 - #152 — résolution du concept libre ou signal explicite de masquage V1.

--- a/docs/public/current-state/RELEASE_READINESS.md
+++ b/docs/public/current-state/RELEASE_READINESS.md
@@ -27,21 +27,21 @@ merge. La checklist opérationnelle détaillée vit dans l'issue #163.
 | Disponibilité IA (fallback GM) | Livré | #101 / PR #191 |
 | Contrats shared Survie v2      | Livré | #180 / PR #196 |
 | Conditions et Désavantage      | Livré | #181 / PR #198 |
+| Calamine et fin Calciné        | Livré | #182 / PR #199 |
 
 ## Phase 1 — pré-déploiement
 
-| Bloc                    | État       | Référence |
-| ----------------------- | ---------- | --------- |
-| Calamine et fin Calciné | À faire    | #182      |
-| Inventaire réel         | À faire    | #183      |
-| Action de repos         | À faire    | #184      |
-| Danger IA               | À faire    | #185      |
-| UI Survie v2            | À faire    | #186      |
-| Concept libre           | À trancher | #152      |
-| Sécurité dépendances    | Bloquant   | #162      |
-| Déploiement API         | À faire    | #161      |
-| Golden path réel        | À faire    | #129      |
-| Checklist de livraison  | Ouverte    | #163      |
+| Bloc                   | État       | Référence |
+| ---------------------- | ---------- | --------- |
+| Inventaire réel        | À faire    | #183      |
+| Action de repos        | À faire    | #184      |
+| Danger IA              | À faire    | #185      |
+| UI Survie v2           | À faire    | #186      |
+| Concept libre          | À trancher | #152      |
+| Sécurité dépendances   | Bloquant   | #162      |
+| Déploiement API        | À faire    | #161      |
+| Golden path réel       | À faire    | #129      |
+| Checklist de livraison | Ouverte    | #163      |
 
 ## Post-déploiement
 

--- a/packages/shared/src/types/chronicle.types.ts
+++ b/packages/shared/src/types/chronicle.types.ts
@@ -1,3 +1,5 @@
+import type { SessionEndReason } from "./session.types";
+
 /** Dominant tone of a Chronicle. @see 17-RUN-CHRONICLE.md §2 */
 export type ChronicleMood =
   | "tragic"
@@ -11,8 +13,8 @@ export interface ChronicleKeyMoment {
   sceneRef: number;
 }
 
-/** Why a GameSession ended, mirrors GameSession.endReason. */
-export type ChronicleEndReason = "death" | "inn" | "abandon";
+/** Why a GameSession ended. Alias of `SessionEndReason` — a Chronicle always mirrors its GameSession. */
+export type ChronicleEndReason = SessionEndReason;
 
 export interface Chronicle {
   id: string;

--- a/packages/shared/src/types/session.types.ts
+++ b/packages/shared/src/types/session.types.ts
@@ -5,8 +5,12 @@ import type { QuestState } from "./quest.types";
 
 export type SessionStatus = "active" | "ended";
 
-/** Why a session ended. Only bridge to the A3 narrative memory layer. */
-export type SessionEndReason = "death" | "inn" | "abandon";
+/**
+ * Why a session ended. Only bridge to the A3 narrative memory layer.
+ * `calcined` = Calamine reached 100 (06-SURVIVAL §4) — the only ending
+ * without heirloom inheritance transmission (09-ACTION-LOOP endReason table).
+ */
+export type SessionEndReason = "death" | "inn" | "abandon" | "calcined";
 
 export interface WorldState {
   currentRegionId: string;


### PR DESCRIPTION
## Résumé
- Applique les paliers de Calamine (06-SURVIVAL §4) via les sources narratives canon validées par l'IA (`cendre_corrupt`), avec cap anti-abus +20/tour côté backend.
- À 100, la session se termine en `calcined` ("Calciné") et déclenche la Chronique dédiée (label narratif propre, réutilise `generateChronicle()` sans second chemin).
- Priorité `death` > `calcined` si les deux surviennent le même tour.
- Refactor : `ChronicleEndReason` dérive maintenant de `SessionEndReason` (élimine une duplication manuelle des deux unions).

Closes #182

## Test plan
- [x] `pnpm type-check --filter @grimoire/shared`
- [x] `pnpm type-check --filter @grimoire/backend`
- [x] `pnpm test --filter @grimoire/backend` (251/251)
- [x] Tests dédiés : paliers de Calamine, cap de delta, priorité death/calcined, pas de drain passif, label Chronique calciné