### PR TITLE
feat(#183): inventaire réel — acquisition, usage et équipement

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -65,6 +65,10 @@ model Character {
   /// @see docs/public/raw/06-SURVIVAL.md §2
   activeConditions Json @default("[]")
 
+  /// Inventaire réel (PersistedInventoryItem[] JSON), voir @grimoire/shared.
+  /// @see docs/public/raw/11-INVENTORY-ECONOMY.md §1
+  inventory Json @default("[]")
+
   /// Fer (🪙), monnaie in-game de Velkhar. Aucune mécanique de gain/dépense
   /// n'est encore branchée ailleurs dans le backend — champ persistant seul.
   iron Int @default(0)

--- a/apps/backend/src/ai/game-master.service.test.ts
+++ b/apps/backend/src/ai/game-master.service.test.ts
@@ -38,6 +38,7 @@ const character = {
     attributes: { blood: 10, breath: 10, ash: 10 },
     survival: { hp: 20, maxHp: 20, thirst: 100, hunger: 100, energy: 100, calamine: 0 },
     conditions: [],
+    inventory: [],
   },
   createdAt: new Date().toISOString(),
 }

--- a/apps/backend/src/ai/scene-validator.test.ts
+++ b/apps/backend/src/ai/scene-validator.test.ts
@@ -192,3 +192,88 @@ describe('aiSceneSchema — apply_condition (#181)', () => {
     expect(result.success).toBe(false)
   })
 })
+
+describe('aiSceneSchema — item_gained (#183)', () => {
+  it('accepts a payload with no item_gained at all (most turns)', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Yarel keeps walking.',
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a valid bag item', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Yarel loots a waterskin from the wreck.',
+      item_gained: { name: 'Waterskin', category: 'bag' },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a valid equipment item with a canon slot', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Yarel takes the fallen blade.',
+      item_gained: { name: 'Salt-iron blade', category: 'equipment', slot: 'main-hand' },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an equipment item with no slot', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Yarel takes the fallen blade.',
+      item_gained: { name: 'Salt-iron blade', category: 'equipment' },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an equipment item with an unknown slot', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Yarel takes the fallen blade.',
+      item_gained: { name: 'Salt-iron blade', category: 'equipment', slot: 'backpack' },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an unknown category', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Something happened.',
+      item_gained: { name: "Grandmother's ring", category: 'heirloom' },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects an item_gained missing name', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Something happened.',
+      item_gained: { category: 'bag' },
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts an item_gained with a valid effect', () => {
+    const result = aiSceneSchema.safeParse({
+      ...basePayload,
+      turnSummary: 'Yarel finds a healing salve.',
+      item_gained: {
+        name: 'Salve of Ash',
+        category: 'bag',
+        effect: { healAmount: 5, calamineReduction: 2 },
+      },
+    })
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/apps/backend/src/ai/scene-validator.ts
+++ b/apps/backend/src/ai/scene-validator.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { isValidAiConditionId } from '../game-rules/conditions'
+import { isValidEquipmentSlot } from '../game-rules/inventory'
 
 /**
  * Zod schema for the raw narrative payload the AI is allowed to produce.
@@ -64,6 +65,36 @@ export const aiApplyConditionSchema = z.object({
 
 export type AiApplyCondition = z.infer<typeof aiApplyConditionSchema>
 
+/**
+ * Zod schema for the optional per-turn `item_gained` proposal (#183). The AI
+ * signals a found item; the backend re-validates category/slot/capacity in
+ * `game-rules/inventory.ts` before ever persisting it — this schema only
+ * checks structure (known category, a known slot when the item is
+ * equipment). "heirloom" is never AI-proposable (death/inheritance only).
+ * @see docs/public/raw/11-INVENTORY-ECONOMY.md §1, docs/public/raw/15-GAME-MASTER.md §4.5
+ */
+export const aiItemGainedEffectSchema = z.object({
+  healAmount: z.number().finite().optional(),
+  calamineReduction: z.number().finite().optional(),
+  removesCondition: z.string().min(1).optional(),
+  damage: z.string().min(1).max(20).optional(),
+})
+
+export const aiItemGainedSchema = z
+  .object({
+    name: z.string().min(1).max(120),
+    category: z.enum(['equipment', 'bag', 'artifact', 'key']),
+    slot: z.string().min(1).optional(),
+    effect: aiItemGainedEffectSchema.optional(),
+    description: z.string().min(1).max(400).optional(),
+  })
+  .refine((v) => v.category !== 'equipment' || (v.slot && isValidEquipmentSlot(v.slot)), {
+    message: 'Equipment items require a valid canon slot',
+    path: ['slot'],
+  })
+
+export type AiItemGained = z.infer<typeof aiItemGainedSchema>
+
 export const aiSceneSchema = z.object({
   narrative: z.string().min(1).max(4000),
   sceneType: z.enum(['exploration', 'combat', 'dialog', 'event', 'shop', 'rest']),
@@ -79,6 +110,8 @@ export const aiSceneSchema = z.object({
   souvenir_candidate: aiSouvenirCandidateSchema.nullish().transform((v) => v ?? undefined),
   /** Optional [IA-PROPOSÉE] condition proposal for this turn (#181). Some models emit `null` instead of omitting the field. */
   apply_condition: aiApplyConditionSchema.nullish().transform((v) => v ?? undefined),
+  /** Optional item-found proposal for this turn (#183). Some models emit `null` instead of omitting the field. */
+  item_gained: aiItemGainedSchema.nullish().transform((v) => v ?? undefined),
 })
 
 export type AiScenePayload = z.infer<typeof aiSceneSchema>

--- a/apps/backend/src/ai/system-prompt.test.ts
+++ b/apps/backend/src/ai/system-prompt.test.ts
@@ -14,6 +14,7 @@ const character = {
     attributes: { blood: 10, breath: 10, ash: 10 },
     survival: { hp: 20, maxHp: 20, thirst: 100, hunger: 100, energy: 100, calamine: 0 },
     conditions: [],
+    inventory: [],
   },
   createdAt: new Date().toISOString(),
 }
@@ -189,5 +190,44 @@ describe('buildSystemPrompt — N3 Souvenirs injection (#115)', () => {
 
     expect(prompt).toContain('"souvenir_candidate"?')
     expect(prompt).toContain('npc-death')
+  })
+})
+
+describe('buildSystemPrompt — item_gained injection (#183)', () => {
+  it('states the player carries no items when the inventory is empty', () => {
+    const prompt = buildSystemPrompt(character, 'en')
+
+    expect(prompt).toContain('The player currently carries no items.')
+  })
+
+  it('lists each carried item by name and category', () => {
+    const withItems = {
+      ...character,
+      stats: {
+        ...character.stats,
+        inventory: [
+          { id: 'i1', name: 'Waterskin', category: 'bag' as const, quantity: 1 },
+          {
+            id: 'i2',
+            name: 'Salt-iron blade',
+            category: 'equipment' as const,
+            quantity: 1,
+            slot: 'main-hand' as const,
+          },
+        ],
+      },
+    }
+
+    const prompt = buildSystemPrompt(withItems, 'en')
+
+    expect(prompt).toContain('Waterskin (category: "bag")')
+    expect(prompt).toContain('Salt-iron blade (category: "equipment")')
+  })
+
+  it('documents the optional item_gained field in the JSON output instructions', () => {
+    const prompt = buildSystemPrompt(character, 'en')
+
+    expect(prompt).toContain('"item_gained"?')
+    expect(prompt).toContain('Never propose category "heirloom"')
   })
 })

--- a/apps/backend/src/ai/system-prompt.ts
+++ b/apps/backend/src/ai/system-prompt.ts
@@ -128,6 +128,34 @@ function buildConditionsSection(character: Character, locale: Locale): string[] 
 }
 
 /**
+ * Builds the item_gained section: the character's currently carried items (so
+ * the AI never re-grants a duplicate) and the rules for proposing a new item.
+ * The backend re-validates category/slot/capacity in `game-rules/inventory.ts`
+ * before ever persisting a proposal — this is guidance only.
+ * @see docs/public/raw/11-INVENTORY-ECONOMY.md §1
+ */
+function buildInventorySection(character: Character): string[] {
+  const items = character.stats.inventory ?? []
+  const lines = items.map((item) => `- ${item.name} (category: "${item.category}")`)
+
+  return [
+    '',
+    items.length > 0
+      ? `The player currently carries: ${lines.join('; ')}.`
+      : 'The player currently carries no items.',
+    '',
+    'You may optionally signal ONE found item via item_gained when the',
+    'narrative clearly justifies it (looted from a container, taken off a',
+    'defeated foe, handed over by an NPC). Never propose an item the player',
+    'already carries. category must be one of: "equipment" (worn gear —',
+    'requires a slot among main-hand, off-hand, armor, cloak, head, accessory,',
+    'belt, feet), "bag" (consumable or carried goods, backend caps the bag at',
+    '12 items), "artifact" (a single dedicated slot), "key" (quest-critical,',
+    'unlimited). Never propose category "heirloom" — it is never AI-granted.',
+  ]
+}
+
+/**
  * Builds the Game Master system prompt.
  * The AI writes narration and choice labels only; the backend owns all rules,
  * dice, stats, and canon consistency. Canon brand terms are NOT re-translated —
@@ -159,6 +187,7 @@ export function buildSystemPrompt(
     ...buildRecentTurnsSection(recentTurns),
     ...buildSouvenirsSection(souvenirs),
     ...buildConditionsSection(character, locale),
+    ...buildInventorySection(character),
     '',
     'Respond with a single JSON object and nothing else, matching exactly:',
     '{',
@@ -169,6 +198,7 @@ export function buildSystemPrompt(
     '  "turnSummary": string,',
     '  "souvenir_candidate"?: { "title_suggestion": string, "body": string, "type": "npc-death"|"moral-choice"|"secret-discovery"|"boss-victory"|"strong-promise" }',
     '  "apply_condition"?: { "id": string, "reason": string, "calamineDelta"?: number }',
+    '  "item_gained"?: { "name": string, "category": "equipment"|"bag"|"artifact"|"key", "slot"?: string, "effect"?: { "healAmount"?: number, "calamineReduction"?: number, "removesCondition"?: string, "damage"?: string }, "description"?: string }',
     '}',
     '',
     'turnSummary: a short factual sentence (max 200 characters) condensing what just',
@@ -187,5 +217,9 @@ export function buildSystemPrompt(
     '(e.g. "crossed the poisonous marsh without protection"). calamineDelta is',
     'only meaningful when id is "cendre_corrupt" — see the Calamine sources',
     'above; omit it for every other condition id.',
+    '',
+    'item_gained: OPTIONAL, omit on most turns. Only include it when the',
+    'narrative you just wrote clearly has the player finding or receiving an',
+    'item THIS turn. Never invent an item that was not part of the narrative.',
   ].join('\n')
 }

--- a/apps/backend/src/game-rules/inventory.test.ts
+++ b/apps/backend/src/game-rules/inventory.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest'
+
+import { acquireItem, equipItem, isValidEquipmentSlot, unequipItem, useItem } from './inventory'
+
+import type {
+  ActiveCondition,
+  ItemGained,
+  PersistedInventoryItem,
+  SurvivalStats,
+} from '@grimoire/shared'
+
+const survival = (overrides: Partial<SurvivalStats> = {}): SurvivalStats => ({
+  hp: 12,
+  maxHp: 20,
+  thirst: 100,
+  hunger: 100,
+  energy: 100,
+  calamine: 10,
+  ...overrides,
+})
+
+const bagItem = (overrides: Partial<PersistedInventoryItem> = {}): PersistedInventoryItem => ({
+  id: 'item1',
+  name: 'Waterskin',
+  category: 'bag',
+  quantity: 1,
+  ...overrides,
+})
+
+describe('isValidEquipmentSlot', () => {
+  it('accepts a canon slot', () => {
+    expect(isValidEquipmentSlot('main-hand')).toBe(true)
+  })
+
+  it('rejects an unknown slot', () => {
+    expect(isValidEquipmentSlot('backpack')).toBe(false)
+  })
+})
+
+describe('acquireItem', () => {
+  const proposal = (overrides: Partial<ItemGained> = {}): ItemGained => ({
+    name: 'Salt-cured meat',
+    category: 'bag',
+    ...overrides,
+  })
+
+  it('accepts a bag item under capacity', () => {
+    const result = acquireItem([], proposal(), 'new-id')
+    expect(result.accepted).toBe(true)
+    expect(result.items).toEqual([
+      {
+        id: 'new-id',
+        name: 'Salt-cured meat',
+        category: 'bag',
+        quantity: 1,
+        slot: undefined,
+        effect: undefined,
+        description: undefined,
+      },
+    ])
+  })
+
+  it('rejects a bag item when the bag is already at the 12-item cap', () => {
+    const fullBag = Array.from({ length: 12 }, (_, i) => bagItem({ id: `b${i}` }))
+    const result = acquireItem(fullBag, proposal(), 'new-id')
+    expect(result.accepted).toBe(false)
+    expect(result.items).toBe(fullBag)
+  })
+
+  it('does not count equipment/artifact/key items toward the bag cap', () => {
+    const nonBagItems = Array.from({ length: 12 }, (_, i) =>
+      bagItem({ id: `e${i}`, category: 'artifact' })
+    )
+    const result = acquireItem(nonBagItems, proposal(), 'new-id')
+    expect(result.accepted).toBe(true)
+    expect(result.items).toHaveLength(13)
+  })
+
+  it('accepts an equipment item with a valid canon slot', () => {
+    const result = acquireItem(
+      [],
+      proposal({ name: 'Salt-iron blade', category: 'equipment', slot: 'main-hand' }),
+      'new-id'
+    )
+    expect(result.accepted).toBe(true)
+    expect(result.items[0]?.slot).toBe('main-hand')
+  })
+
+  it('rejects an equipment item with no slot', () => {
+    const result = acquireItem([], proposal({ category: 'equipment' }), 'new-id')
+    expect(result.accepted).toBe(false)
+    expect(result.items).toEqual([])
+  })
+
+  it('rejects an equipment item with an unknown slot', () => {
+    const result = acquireItem([], proposal({ category: 'equipment', slot: 'backpack' }), 'new-id')
+    expect(result.accepted).toBe(false)
+  })
+
+  it('accepts an artifact item regardless of bag fullness', () => {
+    const result = acquireItem([], proposal({ category: 'artifact' }), 'new-id')
+    expect(result.accepted).toBe(true)
+  })
+
+  it('accepts a key item regardless of bag fullness', () => {
+    const result = acquireItem([], proposal({ category: 'key' }), 'new-id')
+    expect(result.accepted).toBe(true)
+  })
+})
+
+describe('useItem', () => {
+  const conditions: ActiveCondition[] = [
+    { id: 'poison', source: 'ai', appliedAtTurn: 1, expiresRule: { type: 'until_cured' } },
+  ]
+
+  it('returns applied: false for an unknown item id', () => {
+    const result = useItem([], 'missing', survival(), [])
+    expect(result.applied).toBe(false)
+    expect(result.survival).toEqual(survival())
+  })
+
+  it('returns applied: false for an equipment item (worn, not consumed)', () => {
+    const items = [bagItem({ category: 'equipment', slot: 'main-hand' })]
+    const result = useItem(items, 'item1', survival(), [])
+    expect(result.applied).toBe(false)
+    expect(result.items).toBe(items)
+  })
+
+  it('applies healAmount, clamped to maxHp', () => {
+    const items = [bagItem({ effect: { healAmount: 50 } })]
+    const result = useItem(items, 'item1', survival({ hp: 12, maxHp: 20 }), [])
+    expect(result.applied).toBe(true)
+    expect(result.survival.hp).toBe(20)
+  })
+
+  it('applies calamineReduction, clamped to 0', () => {
+    const items = [bagItem({ effect: { calamineReduction: 50 } })]
+    const result = useItem(items, 'item1', survival({ calamine: 10 }), [])
+    expect(result.survival.calamine).toBe(0)
+  })
+
+  it('removes the named condition on removesCondition', () => {
+    const items = [bagItem({ effect: { removesCondition: 'poison' } })]
+    const result = useItem(items, 'item1', survival(), conditions)
+    expect(result.conditions).toEqual([])
+  })
+
+  it('decrements quantity when more than one remains', () => {
+    const items = [bagItem({ quantity: 3 })]
+    const result = useItem(items, 'item1', survival(), [])
+    expect(result.items).toEqual([expect.objectContaining({ quantity: 2 })])
+  })
+
+  it('removes the item entirely once quantity reaches 0', () => {
+    const items = [bagItem({ quantity: 1 })]
+    const result = useItem(items, 'item1', survival(), [])
+    expect(result.items).toEqual([])
+  })
+
+  it('leaves other items untouched', () => {
+    const items = [bagItem({ id: 'item1', quantity: 1 }), bagItem({ id: 'item2', quantity: 1 })]
+    const result = useItem(items, 'item1', survival(), [])
+    expect(result.items).toEqual([bagItem({ id: 'item2', quantity: 1 })])
+  })
+})
+
+describe('equipItem', () => {
+  it('returns applied: false for an unknown item id', () => {
+    const result = equipItem([], 'missing')
+    expect(result.applied).toBe(false)
+  })
+
+  it('returns applied: false for a non-equipment item', () => {
+    const items = [bagItem({ category: 'bag' })]
+    const result = equipItem(items, 'item1')
+    expect(result.applied).toBe(false)
+  })
+
+  it('returns applied: false for an equipment item with no slot', () => {
+    const items = [bagItem({ category: 'equipment', slot: undefined })]
+    const result = equipItem(items, 'item1')
+    expect(result.applied).toBe(false)
+  })
+
+  it('equips the item into its canon slot', () => {
+    const items = [bagItem({ category: 'equipment', slot: 'main-hand' })]
+    const result = equipItem(items, 'item1')
+    expect(result.applied).toBe(true)
+    expect(result.items[0]?.equippedSlot).toBe('main-hand')
+  })
+
+  it('auto-unequips whatever already occupies that slot', () => {
+    const items = [
+      bagItem({ id: 'old', category: 'equipment', slot: 'main-hand', equippedSlot: 'main-hand' }),
+      bagItem({ id: 'new', category: 'equipment', slot: 'main-hand' }),
+    ]
+    const result = equipItem(items, 'new')
+    const old = result.items.find((i) => i.id === 'old')
+    const next = result.items.find((i) => i.id === 'new')
+    expect(old?.equippedSlot).toBeUndefined()
+    expect(next?.equippedSlot).toBe('main-hand')
+  })
+})
+
+describe('unequipItem', () => {
+  it('returns applied: false for an unknown item id', () => {
+    const result = unequipItem([], 'missing')
+    expect(result.applied).toBe(false)
+  })
+
+  it('returns applied: false when the item is not currently equipped', () => {
+    const items = [bagItem({ category: 'equipment', slot: 'main-hand' })]
+    const result = unequipItem(items, 'item1')
+    expect(result.applied).toBe(false)
+  })
+
+  it('clears equippedSlot while keeping the item', () => {
+    const items = [bagItem({ category: 'equipment', slot: 'main-hand', equippedSlot: 'main-hand' })]
+    const result = unequipItem(items, 'item1')
+    expect(result.applied).toBe(true)
+    expect(result.items[0]?.equippedSlot).toBeUndefined()
+    expect(result.items[0]?.slot).toBe('main-hand')
+  })
+})

--- a/apps/backend/src/game-rules/inventory.ts
+++ b/apps/backend/src/game-rules/inventory.ts
@@ -1,0 +1,164 @@
+import { INVENTORY_BAG_CAPACITY, INVENTORY_EQUIPMENT_SLOTS } from '@grimoire/shared'
+
+import type {
+  ActiveCondition,
+  ConditionId,
+  InventoryEquipmentSlot,
+  ItemGained,
+  PersistedInventoryItem,
+  SurvivalStats,
+} from '@grimoire/shared'
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, value))
+
+export function isValidEquipmentSlot(slot: string): slot is InventoryEquipmentSlot {
+  return (INVENTORY_EQUIPMENT_SLOTS as readonly string[]).includes(slot)
+}
+
+/** Bag items only — equipment, artifact and key items never count toward the 12-slot cap (11-INVENTORY-ECONOMY.md §1). */
+function bagCount(items: PersistedInventoryItem[]): number {
+  return items.filter((item) => item.category === 'bag').length
+}
+
+export interface AcquireItemResult {
+  items: PersistedInventoryItem[]
+  /** False when the bag was full and the item (category "bag") was dropped — narration stays, nothing is added. */
+  accepted: boolean
+}
+
+/**
+ * Applies a validated [IA-PROPOSÉE] `itemGained` (#183) to the persisted
+ * inventory. Structural validity (known category, known slot) is already
+ * checked by `scene-validator.ts` — this only enforces state-dependent rules
+ * the schema cannot: bag capacity (12) and a valid slot for an equipment item.
+ * Silent rejection on failure, mirroring `apply_condition` (#181): narration
+ * stays, nothing is added.
+ * @see docs/public/raw/11-INVENTORY-ECONOMY.md §1, docs/public/raw/15-GAME-MASTER.md §4.5
+ */
+export function acquireItem(
+  items: PersistedInventoryItem[],
+  proposal: ItemGained,
+  newId: string
+): AcquireItemResult {
+  if (
+    proposal.category === 'equipment' &&
+    (!proposal.slot || !isValidEquipmentSlot(proposal.slot))
+  ) {
+    return { items, accepted: false }
+  }
+
+  if (proposal.category === 'bag' && bagCount(items) >= INVENTORY_BAG_CAPACITY) {
+    return { items, accepted: false }
+  }
+
+  const next: PersistedInventoryItem = {
+    id: newId,
+    name: proposal.name,
+    category: proposal.category,
+    quantity: 1,
+    slot: proposal.category === 'equipment' ? proposal.slot : undefined,
+    effect: proposal.effect,
+    description: proposal.description,
+  }
+
+  return { items: [...items, next], accepted: true }
+}
+
+export interface UseItemResult {
+  items: PersistedInventoryItem[]
+  survival: SurvivalStats
+  conditions: ActiveCondition[]
+  /** False when the item id was not found, or was equipment (equipment is worn, not consumed). */
+  applied: boolean
+}
+
+/**
+ * Consumes one unit of a bag/artifact/key item, applying its `ItemGainedEffect`
+ * (heal, calamineReduction, removesCondition) to survival/conditions, then
+ * decrementing quantity (removing the entry once it reaches 0). Equipment
+ * items are never consumable here — unequip/equip is the only valid action
+ * on them.
+ */
+export function useItem(
+  items: PersistedInventoryItem[],
+  itemId: string,
+  survival: SurvivalStats,
+  conditions: ActiveCondition[]
+): UseItemResult {
+  const item = items.find((i) => i.id === itemId)
+  if (!item || item.category === 'equipment') {
+    return { items, survival, conditions, applied: false }
+  }
+
+  const effect = item.effect
+  let nextSurvival = survival
+  let nextConditions = conditions
+
+  if (effect?.healAmount) {
+    nextSurvival = {
+      ...nextSurvival,
+      hp: clamp(nextSurvival.hp + effect.healAmount, 0, nextSurvival.maxHp),
+    }
+  }
+  if (effect?.calamineReduction) {
+    nextSurvival = {
+      ...nextSurvival,
+      calamine: clamp(nextSurvival.calamine - effect.calamineReduction, 0, 100),
+    }
+  }
+  if (effect?.removesCondition) {
+    const removedId = effect.removesCondition as ConditionId
+    nextConditions = nextConditions.filter((condition) => condition.id !== removedId)
+  }
+
+  const remaining = item.quantity - 1
+  const nextItems =
+    remaining > 0
+      ? items.map((i) => (i.id === itemId ? { ...i, quantity: remaining } : i))
+      : items.filter((i) => i.id !== itemId)
+
+  return { items: nextItems, survival: nextSurvival, conditions: nextConditions, applied: true }
+}
+
+export interface EquipItemResult {
+  items: PersistedInventoryItem[]
+  /** False when the item id was not found, is not category "equipment", or has no valid slot. */
+  applied: boolean
+}
+
+/**
+ * Equips an inventory item into its canon slot, automatically unequipping
+ * whatever already occupies that slot (never two items in the same slot).
+ * The unequipped item stays in the inventory, simply loses `equippedSlot`.
+ */
+export function equipItem(items: PersistedInventoryItem[], itemId: string): EquipItemResult {
+  const item = items.find((i) => i.id === itemId)
+  if (item?.category !== 'equipment' || !item.slot) {
+    return { items, applied: false }
+  }
+
+  const nextItems = items.map((i) => {
+    if (i.id === itemId) return { ...i, equippedSlot: item.slot }
+    if (i.equippedSlot === item.slot) return { ...i, equippedSlot: undefined }
+    return i
+  })
+
+  return { items: nextItems, applied: true }
+}
+
+export interface UnequipItemResult {
+  items: PersistedInventoryItem[]
+  /** False when the item id was not found or was not currently equipped. */
+  applied: boolean
+}
+
+export function unequipItem(items: PersistedInventoryItem[], itemId: string): UnequipItemResult {
+  const item = items.find((i) => i.id === itemId)
+  if (!item?.equippedSlot) {
+    return { items, applied: false }
+  }
+
+  const nextItems = items.map((i) => (i.id === itemId ? { ...i, equippedSlot: undefined } : i))
+  return { items: nextItems, applied: true }
+}

--- a/apps/backend/src/routes/character.routes.ts
+++ b/apps/backend/src/routes/character.routes.ts
@@ -53,6 +53,7 @@ characterRouter.post('/', async (req: Request, res: Response<ApiResponse<Charact
           calamine: character.calamine,
         },
         conditions: [],
+        inventory: [],
       },
       createdAt: character.createdAt.toISOString(),
     }

--- a/apps/backend/src/routes/game-action.schema.ts
+++ b/apps/backend/src/routes/game-action.schema.ts
@@ -47,3 +47,16 @@ export const endSessionSchema = z.object({
 })
 
 export type EndSessionRequest = z.infer<typeof endSessionSchema>
+
+/**
+ * Player-initiated inventory action (use/equip/unequip, #183). Never advances
+ * the turn — the backend applies `game-rules/inventory.ts` against the
+ * persisted state and returns immediately, no AI call, no dice.
+ */
+export const inventoryActionSchema = z.object({
+  sessionId: z.string().min(1),
+  itemId: z.string().min(1),
+  action: z.enum(['use', 'equip', 'unequip']),
+})
+
+export type InventoryActionRequest = z.infer<typeof inventoryActionSchema>

--- a/apps/backend/src/routes/game.routes.inventory.test.ts
+++ b/apps/backend/src/routes/game.routes.inventory.test.ts
@@ -1,0 +1,111 @@
+import express from 'express'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { AddressInfo } from 'node:net'
+
+const performInventoryAction = vi.fn()
+vi.mock('../services/session.service', () => ({
+  performInventoryAction,
+  resolveTurn: vi.fn(),
+  resolveChosenChoice: vi.fn(),
+  INVALID_CHOICE: Symbol('invalid-choice'),
+  getOrCreateSession: vi.fn(),
+  buildOpeningScene: vi.fn(),
+}))
+
+const { gameRouter } = await import('./game.routes')
+
+async function withServer(
+  auth: { userId: string; isAnonymous: boolean },
+  run: (baseUrl: string) => Promise<void>
+): Promise<void> {
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.auth = auth
+    next()
+  })
+  app.use('/api/game', gameRouter)
+
+  const server = app.listen(0)
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()))
+  const { port } = server.address() as AddressInfo
+  try {
+    await run(`http://127.0.0.1:${port}`)
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+}
+
+async function postInventoryAction(baseUrl: string, body: unknown): Promise<Response> {
+  return fetch(`${baseUrl}/api/game/inventory/action`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /inventory/action (#183)', () => {
+  beforeEach(() => {
+    performInventoryAction.mockReset()
+  })
+
+  it('rejects a payload with an invalid action with 400', async () => {
+    await withServer({ userId: 'u1', isAnonymous: false }, async (baseUrl) => {
+      const res = await postInventoryAction(baseUrl, {
+        sessionId: 's1',
+        itemId: 'item1',
+        action: 'discard',
+      })
+      expect(res.status).toBe(400)
+      expect(performInventoryAction).not.toHaveBeenCalled()
+    })
+  })
+
+  it('rejects a payload missing itemId with 400', async () => {
+    await withServer({ userId: 'u1', isAnonymous: false }, async (baseUrl) => {
+      const res = await postInventoryAction(baseUrl, { sessionId: 's1', action: 'use' })
+      expect(res.status).toBe(400)
+      expect(performInventoryAction).not.toHaveBeenCalled()
+    })
+  })
+
+  it('returns 404 when the service reports no active session for the caller', async () => {
+    performInventoryAction.mockResolvedValue(null)
+
+    await withServer({ userId: 'u1', isAnonymous: false }, async (baseUrl) => {
+      const res = await postInventoryAction(baseUrl, {
+        sessionId: 'nope',
+        itemId: 'item1',
+        action: 'use',
+      })
+      expect(res.status).toBe(404)
+      const body = (await res.json()) as { success: boolean }
+      expect(body.success).toBe(false)
+    })
+  })
+
+  it('returns 200 with the service response on success', async () => {
+    performInventoryAction.mockResolvedValue({
+      updatedStats: { hp: 17, maxHp: 20, thirst: 100, hunger: 100, energy: 100, calamine: 10 },
+      updatedInventory: [],
+      applied: true,
+    })
+
+    await withServer({ userId: 'u1', isAnonymous: false }, async (baseUrl) => {
+      const res = await postInventoryAction(baseUrl, {
+        sessionId: 's1',
+        itemId: 'item1',
+        action: 'use',
+      })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { success: boolean; data: { applied: boolean } }
+      expect(body.success).toBe(true)
+      expect(body.data.applied).toBe(true)
+      expect(performInventoryAction).toHaveBeenCalledWith(
+        { sessionId: 's1', itemId: 'item1', action: 'use' },
+        'u1'
+      )
+    })
+  })
+})

--- a/apps/backend/src/routes/game.routes.ts
+++ b/apps/backend/src/routes/game.routes.ts
@@ -7,13 +7,24 @@ import {
   endSessionAtInn,
   getOrCreateSession,
   INVALID_CHOICE,
+  performInventoryAction,
   resolveChosenChoice,
   resolveTurn,
 } from '../services/session.service'
 
-import { createSessionSchema, endSessionSchema, gameActionSchema } from './game-action.schema'
+import {
+  createSessionSchema,
+  endSessionSchema,
+  gameActionSchema,
+  inventoryActionSchema,
+} from './game-action.schema'
 
-import type { ApiResponse, SceneResponse, SessionEndReason } from '@grimoire/shared'
+import type {
+  ApiResponse,
+  InventoryActionResponse,
+  SceneResponse,
+  SessionEndReason,
+} from '@grimoire/shared'
 
 export const gameRouter: Router = Router()
 
@@ -97,6 +108,33 @@ gameRouter.post('/action', async (req: Request, res: Response<ApiResponse<SceneR
 
   res.json({ success: true, data: response })
 })
+
+/**
+ * POST /api/game/inventory/action
+ * Player-initiated inventory action (use/equip/unequip, #183). Never advances
+ * the turn — no AI call, no dice. Rejects (409) once the session has ended.
+ */
+gameRouter.post(
+  '/inventory/action',
+  async (req: Request, res: Response<ApiResponse<InventoryActionResponse>>) => {
+    const parsed = inventoryActionSchema.safeParse(req.body)
+    if (!parsed.success) {
+      res.status(400).json({
+        success: false,
+        error: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+      })
+      return
+    }
+
+    const response = await performInventoryAction(parsed.data, req.auth!.userId)
+    if (!response) {
+      res.status(404).json({ success: false, error: 'Active session not found' })
+      return
+    }
+
+    res.json({ success: true, data: response })
+  }
+)
 
 /**
  * POST /api/game/session/end-inn

--- a/apps/backend/src/services/chronicle.service.test.ts
+++ b/apps/backend/src/services/chronicle.service.test.ts
@@ -32,6 +32,7 @@ const baseSession = {
   id: 's1',
   turnNumber: 12,
   endReason: 'inn',
+  locale: 'fr',
   character,
 }
 
@@ -180,6 +181,28 @@ describe('generateChronicle', () => {
     const prompt = messages[0].content
     expect(prompt).not.toContain('undefined')
     expect(prompt).toContain('Calciné')
+  })
+
+  it('instructs the AI to write in the session locale, English by default (#168)', async () => {
+    gameSessionFindUnique.mockResolvedValue({ ...baseSession, locale: 'es-ES' })
+    callOpenRouter.mockResolvedValue({ success: true, content: JSON.stringify(validOutput) })
+
+    await generateChronicle('s1')
+
+    const [messages] = callOpenRouter.mock.calls[0] as [{ content: string }[]]
+    const prompt = messages[0].content
+    expect(prompt).toContain('Spanish')
+  })
+
+  it('falls back to English when the session locale is unusable', async () => {
+    gameSessionFindUnique.mockResolvedValue({ ...baseSession, locale: undefined })
+    callOpenRouter.mockResolvedValue({ success: true, content: JSON.stringify(validOutput) })
+
+    await generateChronicle('s1')
+
+    const [messages] = callOpenRouter.mock.calls[0] as [{ content: string }[]]
+    const prompt = messages[0].content
+    expect(prompt).toContain('en English')
   })
 
   it('deduplicates pinned facts across memory chunks', async () => {

--- a/apps/backend/src/services/chronicle.service.ts
+++ b/apps/backend/src/services/chronicle.service.ts
@@ -1,4 +1,4 @@
-import { getPeople, getVocation } from '@grimoire/shared'
+import { getPeople, getVocation, localeDisplayName, resolveLocale } from '@grimoire/shared'
 
 import { type ChronicleOutput, validateChronicleOutput } from '../ai/chronicle-validator'
 import { callOpenRouter } from '../ai/openrouter.provider'
@@ -30,6 +30,7 @@ interface ChronicleContext {
   characterName: string
   peopleLabel: string
   vocationLabel: string
+  languageName: string
   endReason: ChronicleEndReason
   turnCount: number
   memorySummaries: string[]
@@ -43,6 +44,7 @@ function buildChroniclePrompt(context: ChronicleContext): string {
     characterName,
     peopleLabel,
     vocationLabel,
+    languageName,
     endReason,
     memorySummaries,
     pinnedFacts,
@@ -59,6 +61,7 @@ function buildChroniclePrompt(context: ChronicleContext): string {
 
   return [
     'Tu écris la Chronique de fin de run — un récit littéraire de 800 à 1200 mots qui transforme la partie vécue en histoire.',
+    `Écris le texte final (title, body_markdown, tagline) en ${languageName}. Le français est la langue par défaut.`,
     '',
     '[IDENTITÉ]',
     `Nom : ${characterName}`,
@@ -156,6 +159,8 @@ export async function generateChronicle(
   }
 
   const { character } = session
+  const locale = resolveLocale(session.locale)
+  const nameKey = locale === 'fr' ? 'fr' : 'en'
   const people = getPeople(character.people)
   const vocation = getVocation(character.vocation)
 
@@ -169,8 +174,9 @@ export async function generateChronicle(
     userId: character.userId,
     characterId: character.id,
     characterName: character.name,
-    peopleLabel: people?.name.fr ?? character.people,
-    vocationLabel: vocation?.name.fr ?? character.vocation,
+    peopleLabel: people?.name[nameKey] ?? character.people,
+    vocationLabel: vocation?.name[nameKey] ?? character.vocation,
+    languageName: localeDisplayName(locale),
     endReason: session.endReason as ChronicleEndReason,
     turnCount: session.turnNumber,
     memorySummaries: memoryChunks.map((chunk) => chunk.summary),

--- a/apps/backend/src/services/memory.service.test.ts
+++ b/apps/backend/src/services/memory.service.test.ts
@@ -20,6 +20,7 @@ const character = {
     attributes: { blood: 10, breath: 10, ash: 10 },
     survival: { hp: 20, maxHp: 20, thirst: 100, hunger: 100, energy: 100, calamine: 0 },
     conditions: [],
+    inventory: [],
   },
   createdAt: new Date().toISOString(),
 }

--- a/apps/backend/src/services/session.service.condition.test.ts
+++ b/apps/backend/src/services/session.service.condition.test.ts
@@ -47,6 +47,7 @@ const character = {
   energy: 100,
   calamine: 0,
   activeConditions: [],
+  inventory: [],
   createdAt: new Date(),
 } as unknown as DbCharacter
 

--- a/apps/backend/src/services/session.service.inventory.test.ts
+++ b/apps/backend/src/services/session.service.inventory.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const findFirst = vi.fn()
+const characterUpdate = vi.fn()
+vi.mock('../lib/prisma', () => ({
+  prisma: {
+    gameSession: { findFirst },
+    character: { update: characterUpdate },
+  },
+}))
+
+const { performInventoryAction } = await import('./session.service')
+
+import type { Character as DbCharacter } from '../generated/prisma/client'
+
+function character(overrides: Partial<DbCharacter> = {}): DbCharacter {
+  return {
+    id: 'char1',
+    userId: 'user1',
+    hp: 12,
+    maxHp: 20,
+    thirst: 100,
+    hunger: 100,
+    energy: 100,
+    calamine: 10,
+    activeConditions: [],
+    inventory: [{ id: 'item1', name: 'Waterskin', category: 'bag', quantity: 1 }],
+    ...overrides,
+  } as unknown as DbCharacter
+}
+
+function activeSession(char: DbCharacter) {
+  return { id: 's1', status: 'active', character: char }
+}
+
+/** Reads the `data` payload passed to the mocked `character.update` call. */
+function lastCharacterUpdateData(): { hp: number; inventory: unknown } {
+  const call = characterUpdate.mock.calls.at(-1) as
+    | [{ data: { hp: number; inventory: unknown } }]
+    | undefined
+  if (!call) throw new Error('character.update was not called')
+  return call[0].data
+}
+
+describe('performInventoryAction (#183)', () => {
+  beforeEach(() => {
+    findFirst.mockReset()
+    characterUpdate.mockReset()
+  })
+
+  it('returns null when the session is not active or not the caller’s', async () => {
+    findFirst.mockResolvedValue(null)
+
+    const result = await performInventoryAction(
+      { sessionId: 's1', itemId: 'item1', action: 'use' },
+      'user1'
+    )
+
+    expect(result).toBeNull()
+    expect(characterUpdate).not.toHaveBeenCalled()
+  })
+
+  it('applies a use action, persists the new state, and returns applied: true', async () => {
+    findFirst.mockResolvedValue(
+      activeSession(
+        character({
+          inventory: [
+            {
+              id: 'item1',
+              name: 'Salve of Ash',
+              category: 'bag',
+              quantity: 1,
+              effect: { healAmount: 5 },
+            },
+          ],
+        })
+      )
+    )
+
+    const result = await performInventoryAction(
+      { sessionId: 's1', itemId: 'item1', action: 'use' },
+      'user1'
+    )
+
+    expect(result).toEqual({
+      updatedStats: { hp: 17, maxHp: 20, thirst: 100, hunger: 100, energy: 100, calamine: 10 },
+      updatedInventory: [],
+      applied: true,
+    })
+    expect(lastCharacterUpdateData()).toEqual(expect.objectContaining({ hp: 17, inventory: [] }))
+  })
+
+  it('returns applied: false and skips persistence when the action does not apply', async () => {
+    findFirst.mockResolvedValue(activeSession(character()))
+
+    const result = await performInventoryAction(
+      { sessionId: 's1', itemId: 'missing-item', action: 'use' },
+      'user1'
+    )
+
+    expect(result).toEqual({
+      updatedStats: { hp: 12, maxHp: 20, thirst: 100, hunger: 100, energy: 100, calamine: 10 },
+      updatedInventory: [
+        expect.objectContaining({
+          id: 'item1',
+          name: 'Waterskin',
+          allowedActions: ['use', 'inspect'],
+        }),
+      ],
+      applied: false,
+    })
+    expect(characterUpdate).not.toHaveBeenCalled()
+  })
+
+  it('equips an item and reflects the equipped slot in the returned inventory', async () => {
+    findFirst.mockResolvedValue(
+      activeSession(
+        character({
+          inventory: [
+            {
+              id: 'item1',
+              name: 'Salt-iron blade',
+              category: 'equipment',
+              quantity: 1,
+              slot: 'main-hand',
+            },
+          ],
+        })
+      )
+    )
+
+    const result = await performInventoryAction(
+      { sessionId: 's1', itemId: 'item1', action: 'equip' },
+      'user1'
+    )
+
+    expect(result?.applied).toBe(true)
+    expect(result?.updatedInventory).toEqual([
+      expect.objectContaining({
+        id: 'item1',
+        equippedSlot: 'main-hand',
+        allowedActions: ['unequip', 'inspect'],
+      }),
+    ])
+  })
+
+  it('unequips an item and reflects the cleared slot in the returned inventory', async () => {
+    findFirst.mockResolvedValue(
+      activeSession(
+        character({
+          inventory: [
+            {
+              id: 'item1',
+              name: 'Salt-iron blade',
+              category: 'equipment',
+              quantity: 1,
+              slot: 'main-hand',
+              equippedSlot: 'main-hand',
+            },
+          ],
+        })
+      )
+    )
+
+    const result = await performInventoryAction(
+      { sessionId: 's1', itemId: 'item1', action: 'unequip' },
+      'user1'
+    )
+
+    expect(result?.applied).toBe(true)
+    expect(result?.updatedInventory).toEqual([
+      expect.objectContaining({
+        id: 'item1',
+        equippedSlot: undefined,
+        allowedActions: ['equip', 'inspect'],
+      }),
+    ])
+  })
+})

--- a/apps/backend/src/services/session.service.trigger.test.ts
+++ b/apps/backend/src/services/session.service.trigger.test.ts
@@ -46,6 +46,7 @@ const character = {
   energy: 100,
   calamine: 0,
   conditions: [],
+  inventory: [],
   createdAt: new Date(),
 } as unknown as DbCharacter
 

--- a/apps/backend/src/services/session.service.ts
+++ b/apps/backend/src/services/session.service.ts
@@ -1,8 +1,13 @@
+import { randomUUID } from 'node:crypto'
+
 import {
   type ActiveCondition,
   type Attributes,
   type Choice,
+  type InventoryActionResponse,
+  type InventoryItemRef,
   type Locale,
+  type PersistedInventoryItem,
   resolveLocale,
   type SceneResponse,
   type SessionEndReason,
@@ -18,6 +23,7 @@ import {
   isValidAiConditionId,
 } from '../game-rules/conditions'
 import { resolveChoice } from '../game-rules/consequences'
+import { acquireItem, equipItem, unequipItem, useItem } from '../game-rules/inventory'
 import { prisma } from '../lib/prisma'
 
 import { deriveAttributes } from './character.service'
@@ -27,6 +33,7 @@ import { assembleScene } from './scene-assembler'
 import { validateAndPersistSouvenirCandidate } from './souvenir.service'
 
 import type { Character as DbCharacter, GameSession } from '../generated/prisma/client'
+import type { InventoryActionRequest } from '../routes/game-action.schema'
 
 /**
  * Fallback seed character (Yarel of the Salt Roads), the same canon build the
@@ -58,11 +65,12 @@ function buildSeedCharacter(): {
   }
 }
 
-/** Reads a DB character row into the shared attribute/survival/conditions shapes. */
+/** Reads a DB character row into the shared attribute/survival/conditions/inventory shapes. */
 function readCharacter(character: DbCharacter): {
   attributes: Attributes
   survival: SurvivalStats
   activeConditions: ActiveCondition[]
+  inventory: PersistedInventoryItem[]
 } {
   return {
     attributes: { blood: character.blood, breath: character.breath, ash: character.ash },
@@ -75,7 +83,29 @@ function readCharacter(character: DbCharacter): {
       calamine: character.calamine,
     },
     activeConditions: character.activeConditions as unknown as ActiveCondition[],
+    inventory: character.inventory as unknown as PersistedInventoryItem[],
   }
+}
+
+/**
+ * Projects the backend-persisted inventory into the display-facing shape the
+ * client HUD reads. `allowedActions` is derived purely from category/state —
+ * the backend is still the sole authority when the action route is hit.
+ */
+function toInventoryRefs(items: PersistedInventoryItem[]): InventoryItemRef[] {
+  return items.map((item) => ({
+    id: item.id,
+    name: item.name,
+    category: item.category,
+    quantity: item.quantity,
+    equippedSlot: item.equippedSlot,
+    description: item.description,
+    state: 'ready',
+    allowedActions:
+      item.category === 'equipment'
+        ? [item.equippedSlot ? 'unequip' : 'equip', 'inspect']
+        : ['use', 'inspect'],
+  }))
 }
 
 /** Flattens survival stats into the display record the client HUD reads. */
@@ -199,7 +229,7 @@ async function resumeLatestScene({
   }
 
   const choices = persistedChoicesSchema.safeParse(last.choices)
-  const { survival } = readCharacter(character)
+  const { survival, inventory } = readCharacter(character)
   const source = last.source === 'ai' ? 'ai' : 'stub'
 
   const scene: SceneResponse['scene'] = {
@@ -216,7 +246,7 @@ async function resumeLatestScene({
   return {
     scene,
     updatedStats: toStatsRecord(survival),
-    updatedInventory: [],
+    updatedInventory: toInventoryRefs(inventory),
     notifications: [],
     source,
   }
@@ -237,10 +267,10 @@ export async function buildOpeningScene(context: SessionContext): Promise<SceneR
   }
 
   const { session, character } = context
-  const { attributes, survival, activeConditions } = readCharacter(character)
+  const { attributes, survival, activeConditions, inventory } = readCharacter(character)
 
   const gm = await generateScene({
-    character: toGmCharacter(character, attributes, survival, activeConditions),
+    character: toGmCharacter(character, attributes, survival, activeConditions, inventory),
     // Locale is resolved and persisted at session creation — the DB is the
     // source of truth, never the per-request client value (#168).
     locale: session.locale,
@@ -268,7 +298,7 @@ export async function buildOpeningScene(context: SessionContext): Promise<SceneR
   return {
     scene,
     updatedStats: toStatsRecord(survival),
-    updatedInventory: [],
+    updatedInventory: toInventoryRefs(inventory),
     notifications: [],
     source: gm.source,
   }
@@ -333,7 +363,7 @@ export interface ResolveTurnInput {
  */
 export async function resolveTurn(input: ResolveTurnInput): Promise<SceneResponse> {
   const { session, character, choice, chosenActionText, freeAction } = input
-  const { attributes, survival, activeConditions } = readCharacter(character)
+  const { attributes, survival, activeConditions, inventory } = readCharacter(character)
 
   const resolution = resolveChoice({
     attributes,
@@ -349,7 +379,8 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
       character,
       attributes,
       resolution.updatedSurvival,
-      resolution.updatedConditions
+      resolution.updatedConditions,
+      inventory
     ),
     // Persisted session locale is the source of truth (#168).
     locale: session.locale,
@@ -381,6 +412,15 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
   const finalSurvival = applyCalamineDelta(resolution.updatedSurvival, calamineDelta)
   const calcined = !resolution.gameOver && calamineTier(finalSurvival.calamine) === 'dead'
   const gameOver = resolution.gameOver || calcined
+
+  // The AI may signal ONE found item caused by what it just narrated (#183).
+  // Structural validity is already Zod-checked; acquireItem re-validates the
+  // state-dependent rules (bag capacity, slot) the schema cannot — the AI only
+  // proposes, the backend decides.
+  const itemProposal = gm.scene.item_gained
+  const finalInventory = itemProposal
+    ? acquireItem(inventory, itemProposal, randomUUID()).items
+    : inventory
 
   const scene = assembleScene({
     payload: gm.scene,
@@ -420,6 +460,7 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
         energy: finalSurvival.energy,
         calamine: finalSurvival.calamine,
         activeConditions: finalConditions as unknown as object,
+        inventory: finalInventory as unknown as object,
       },
     }),
     prisma.gameSession.update({
@@ -443,7 +484,7 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
         await compressScene(
           session.id,
           recentTurns,
-          toGmCharacter(character, attributes, finalSurvival, finalConditions),
+          toGmCharacter(character, attributes, finalSurvival, finalConditions, finalInventory),
           scene.location
         )
       } catch (err) {
@@ -480,10 +521,67 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
   return {
     scene,
     updatedStats: toStatsRecord(finalSurvival),
-    updatedInventory: [],
+    updatedInventory: toInventoryRefs(finalInventory),
     notifications: [],
     diceRoll: resolution.diceRoll,
     source: gm.source,
+  }
+}
+
+/**
+ * Applies a player-initiated inventory action (use/equip/unequip, #183)
+ * against the persisted world-state. Never advances the turn — no AI call,
+ * no dice, no SceneLog entry. Scoped to the caller's own active session, the
+ * same guard as `resolveTurn`. Returns null when the session doesn't belong
+ * to the caller or isn't active.
+ */
+export async function performInventoryAction(
+  request: InventoryActionRequest,
+  userId: string
+): Promise<InventoryActionResponse | null> {
+  const session = await prisma.gameSession.findFirst({
+    where: { id: request.sessionId, status: 'active', character: { userId } },
+    include: { character: true },
+  })
+  if (!session) {
+    return null
+  }
+
+  const { character } = session
+  const { survival, activeConditions, inventory } = readCharacter(character)
+
+  const result =
+    request.action === 'use'
+      ? useItem(inventory, request.itemId, survival, activeConditions)
+      : request.action === 'equip'
+        ? { ...equipItem(inventory, request.itemId), survival, conditions: activeConditions }
+        : { ...unequipItem(inventory, request.itemId), survival, conditions: activeConditions }
+
+  if (!result.applied) {
+    return {
+      updatedStats: toStatsRecord(survival),
+      updatedInventory: toInventoryRefs(inventory),
+      applied: false,
+    }
+  }
+
+  await prisma.character.update({
+    where: { id: character.id },
+    data: {
+      hp: result.survival.hp,
+      thirst: result.survival.thirst,
+      hunger: result.survival.hunger,
+      energy: result.survival.energy,
+      calamine: result.survival.calamine,
+      activeConditions: result.conditions as unknown as object,
+      inventory: result.items as unknown as object,
+    },
+  })
+
+  return {
+    updatedStats: toStatsRecord(result.survival),
+    updatedInventory: toInventoryRefs(result.items),
+    applied: true,
   }
 }
 
@@ -549,7 +647,8 @@ function toGmCharacter(
   character: DbCharacter,
   attributes: Attributes,
   survival: SurvivalStats,
-  activeConditions: ActiveCondition[] = []
+  activeConditions: ActiveCondition[] = [],
+  inventory: PersistedInventoryItem[] = []
 ) {
   return {
     id: character.id,
@@ -557,7 +656,7 @@ function toGmCharacter(
     name: character.name,
     people: character.people,
     vocation: character.vocation,
-    stats: { attributes, survival, conditions: activeConditions },
+    stats: { attributes, survival, conditions: activeConditions, inventory },
     createdAt: character.createdAt.toISOString(),
   }
 }

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -342,6 +342,7 @@
     "itemDetail": "Item detail",
     "noDescription": "No description has been revealed yet.",
     "authorizedActions": "Authorized now: {actions}",
+    "authorizedActionsLabel": "Authorized actions",
     "actionUse": "use",
     "actionEquip": "equip",
     "actionUnequip": "unequip",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -342,6 +342,7 @@
     "itemDetail": "Détail de l’objet",
     "noDescription": "Aucune description n’a encore été révélée.",
     "authorizedActions": "Autorisé maintenant : {actions}",
+    "authorizedActionsLabel": "Actions autorisées",
     "actionUse": "utiliser",
     "actionEquip": "équiper",
     "actionUnequip": "déséquiper",

--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharInventoryPanel.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharInventoryPanel.tsx
@@ -14,6 +14,7 @@ import type { InventoryItemRef } from '@grimoire/shared'
 interface VelkharInventoryPanelProps {
   iron: number | null
   items: InventoryItemRef[]
+  onAction: (item: InventoryItemRef, action: 'use' | 'equip' | 'unequip') => void
 }
 
 function itemIcon(item: InventoryItemRef): GameIconName {
@@ -62,7 +63,7 @@ function ItemSlot({ fallbackIcon, item, label, onSelect, selectedId }: ItemSlotP
   )
 }
 
-export function VelkharInventoryPanel({ iron, items }: VelkharInventoryPanelProps) {
+export function VelkharInventoryPanel({ iron, items, onAction }: VelkharInventoryPanelProps) {
   const t = useTranslations('Session')
   const inventory = useMemo(() => buildVelkharInventoryView(items), [items])
   const [selectedId, setSelectedId] = useState<string | null>(null)
@@ -170,13 +171,24 @@ export function VelkharInventoryPanel({ iron, items }: VelkharInventoryPanelProp
             <h3>{selectedItem.name}</h3>
             <p>{selectedItem.description ?? t('noDescription')}</p>
             {selectedItem.allowedActions?.length ? (
-              <p className="velkhar-inventory__permissions">
-                {t('authorizedActions', {
-                  actions: selectedItem.allowedActions
-                    .map((action) => actionLabels[action])
-                    .join(', '),
-                })}
-              </p>
+              <div
+                className="velkhar-inventory__actions"
+                role="group"
+                aria-label={t('authorizedActionsLabel')}
+              >
+                {selectedItem.allowedActions
+                  .filter((action) => action !== 'inspect')
+                  .map((action) => (
+                    <button
+                      key={action}
+                      type="button"
+                      className="velkhar-inventory__action-button"
+                      onClick={() => onAction(selectedItem, action)}
+                    >
+                      {actionLabels[action]}
+                    </button>
+                  ))}
+              </div>
             ) : (
               <p className="velkhar-session-window__muted">{t('noAuthorizedAction')}</p>
             )}

--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.test.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.test.tsx
@@ -220,7 +220,8 @@ describe('VelkharSession', () => {
 
     await user.click(screen.getByRole('button', { name: /Bag slot 1: Waterskin/ }))
     expect(screen.getByRole('heading', { name: 'Waterskin' })).toBeInTheDocument()
-    expect(screen.getByText('Authorized now: use, inspect')).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Authorized actions' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'use' })).toBeInTheDocument()
   })
 
   it('restaure le focus après Escape', async () => {

--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSession.tsx
@@ -292,6 +292,7 @@ export function VelkharSession({ initialCharacter, locale }: VelkharSessionProps
         survival={session.worldState}
         onAbandon={handleAbandon}
         onClose={closeTool}
+        onInventoryAction={session.performInventoryAction}
       />
       <SoftSignupPrompt />
     </>

--- a/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSessionToolPanel.tsx
+++ b/apps/frontend/src/app/(game)/velkhar/session/_components/VelkharSessionToolPanel.tsx
@@ -18,6 +18,7 @@ interface VelkharSessionToolPanelProps {
   openTool: VelkharSessionTool | null
   onAbandon: () => Promise<void>
   onClose: () => void
+  onInventoryAction: (item: InventoryItemRef, action: 'use' | 'equip' | 'unequip') => void
   source?: 'ai' | 'stub'
   survival: SurvivalStats
 }
@@ -29,6 +30,7 @@ export function VelkharSessionToolPanel({
   inventory,
   onAbandon,
   onClose,
+  onInventoryAction,
   openTool,
   source,
   survival,
@@ -57,7 +59,9 @@ export function VelkharSessionToolPanel({
             : t('sessionMenu')
       }
     >
-      {openTool === 'inventory' ? <VelkharInventoryPanel iron={iron} items={inventory} /> : null}
+      {openTool === 'inventory' ? (
+        <VelkharInventoryPanel iron={iron} items={inventory} onAction={onInventoryAction} />
+      ) : null}
 
       {openTool === 'character' ? (
         <VelkharCharacterSheet character={character} survival={survival} />

--- a/apps/frontend/src/app/(game)/velkhar/session/_data/mock-character.ts
+++ b/apps/frontend/src/app/(game)/velkhar/session/_data/mock-character.ts
@@ -38,6 +38,7 @@ export const MOCK_CHARACTER: Character = {
       calamine: 0,
     },
     conditions: [],
+    inventory: [],
   },
   backstory:
     'A caravan survivor of the Makhzen who learned to read the dunes before he ' +

--- a/apps/frontend/src/app/(game)/velkhar/session/_theme/velkhar-session.css
+++ b/apps/frontend/src/app/(game)/velkhar/session/_theme/velkhar-session.css
@@ -722,6 +722,29 @@
   text-transform: capitalize;
 }
 
+.velkhar-inventory__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.velkhar-inventory__action-button {
+  background: color-mix(in srgb, var(--gold) 12%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--gold) 30%, transparent);
+  color: var(--gold-light);
+  cursor: pointer;
+  font-family: var(--font-game-ui);
+  font-size: 0.78rem;
+  padding: 0.4rem 0.9rem;
+  text-transform: capitalize;
+  transition: background-color 0.15s ease;
+}
+
+.velkhar-inventory__action-button:hover {
+  background: color-mix(in srgb, var(--gold) 22%, transparent);
+}
+
 .velkhar-session-menu {
   display: grid;
   gap: 0.8rem;

--- a/apps/frontend/src/features/game-session/api/game-session-api.ts
+++ b/apps/frontend/src/features/game-session/api/game-session-api.ts
@@ -1,4 +1,8 @@
-import type { GameSessionEndResponse, GameSessionResponse } from '../model/game-session.types'
+import type {
+  GameSessionEndResponse,
+  GameSessionInventoryActionResponse,
+  GameSessionResponse,
+} from '../model/game-session.types'
 import type { ApiResponse, Locale } from '@grimoire/shared'
 
 /**
@@ -34,6 +38,18 @@ async function readSceneResponse<TResponse extends GameSessionResponse>(
 
 async function readEndResponse(response: Response): Promise<GameSessionEndResponse> {
   const body = (await response.json()) as ApiResponse<GameSessionEndResponse>
+
+  if (!response.ok || !body.success || !body.data) {
+    throw new Error(body.error ?? `Game request failed (${response.status})`)
+  }
+
+  return body.data
+}
+
+async function readInventoryActionResponse(
+  response: Response
+): Promise<GameSessionInventoryActionResponse> {
+  const body = (await response.json()) as ApiResponse<GameSessionInventoryActionResponse>
 
   if (!response.ok || !body.success || !body.data) {
     throw new Error(body.error ?? `Game request failed (${response.status})`)
@@ -99,8 +115,32 @@ export async function abandonSession(sessionId: string): Promise<GameSessionEndR
   return readEndResponse(response)
 }
 
+export interface InventoryActionInput {
+  sessionId: string
+  itemId: string
+  action: 'use' | 'equip' | 'unequip'
+}
+
+/**
+ * Player-initiated inventory action (use/equip/unequip, #183). Never advances
+ * the turn — no AI call, no dice, no new scene — only the resulting stats and
+ * inventory state.
+ */
+export async function postInventoryAction(
+  input: InventoryActionInput
+): Promise<GameSessionInventoryActionResponse> {
+  const response = await fetch('/api/game/inventory/action', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+
+  return readInventoryActionResponse(response)
+}
+
 export const gameSessionApi = {
   abandonSession,
   createSession,
   postGameAction,
+  postInventoryAction,
 } as const

--- a/apps/frontend/src/features/game-session/hooks/use-game-session.ts
+++ b/apps/frontend/src/features/game-session/hooks/use-game-session.ts
@@ -9,6 +9,7 @@ import { useSessionStore } from '@/stores/session-store'
 import type {
   GameSessionApi,
   GameSessionChoice,
+  GameSessionInventoryItem,
   GameSessionResponse,
   GameSessionState,
   PendingGameAction,
@@ -32,6 +33,10 @@ export interface UseGameSessionResult<
 > extends GameSessionState<TWorldState, TResponse> {
   abandon: () => Promise<boolean>
   choose: (choice: GameSessionChoice) => void
+  performInventoryAction: (
+    item: GameSessionInventoryItem,
+    action: 'use' | 'equip' | 'unequip'
+  ) => void
   retry: () => void
   submitFreeAction: (action: string) => void
 }
@@ -216,6 +221,31 @@ export function useGameSession<TWorldState, TResponse extends GameSessionRespons
     else void openSession()
   }, [openSession, submitAction])
 
+  const performInventoryAction = useCallback(
+    (item: GameSessionInventoryItem, action: 'use' | 'equip' | 'unequip') => {
+      const sessionId = sessionIdRef.current
+      if (!sessionId) return
+
+      void (async () => {
+        try {
+          const result = await api.postInventoryAction({ sessionId, itemId: item.id, action })
+          if (!result.applied) return
+
+          setState((current) => ({
+            ...current,
+            inventory: result.updatedInventory,
+            worldState: reduceWorldState(current.worldState, {
+              updatedStats: result.updatedStats,
+            } as TResponse),
+          }))
+        } catch (error) {
+          handleRequestError(error)
+        }
+      })()
+    },
+    [api, handleRequestError, reduceWorldState]
+  )
+
   const abandon = useCallback(async () => {
     const sessionId = sessionIdRef.current
     if (!sessionId || state.ending) return false
@@ -238,5 +268,5 @@ export function useGameSession<TWorldState, TResponse extends GameSessionRespons
     }
   }, [api, handleRequestError, state.ending])
 
-  return { ...state, abandon, choose, retry, submitFreeAction }
+  return { ...state, abandon, choose, performInventoryAction, retry, submitFreeAction }
 }

--- a/apps/frontend/src/features/game-session/model/game-session.types.ts
+++ b/apps/frontend/src/features/game-session/model/game-session.types.ts
@@ -59,6 +59,12 @@ export interface GameSessionEndResponse {
   status: 'ended'
 }
 
+export interface GameSessionInventoryActionResponse {
+  updatedStats: Record<string, number>
+  updatedInventory: GameSessionInventoryItem[]
+  applied: boolean
+}
+
 export interface PendingGameAction {
   choice?: GameSessionChoice
   freeAction?: string
@@ -73,6 +79,11 @@ export interface GameSessionApi<TResponse extends GameSessionResponse = GameSess
     chosenActionText?: string
     freeAction?: string
   }) => Promise<TResponse>
+  postInventoryAction: (input: {
+    sessionId: string
+    itemId: string
+    action: 'use' | 'equip' | 'unequip'
+  }) => Promise<GameSessionInventoryActionResponse>
 }
 
 export interface GameSessionState<

--- a/docs/public/current-state/BACKEND_NEXT.md
+++ b/docs/public/current-state/BACKEND_NEXT.md
@@ -13,18 +13,19 @@ updated: 2026-07-24
 ## Phase 1 — pré-déploiement
 
 1. ~~#180~~ — figer les contrats shared Survie v2 : livré (PR #196).
-2. ~~#181~~ — conditions et Désavantage : livré (PR #198). #183 — inventaire réel reste à livrer.
+2. ~~#181~~ — conditions et Désavantage : livré (PR #198).
 3. ~~#182~~ — Calamine/fin Calciné : livré (PR #199). #184 — action de repos reste à livrer.
-4. #185 — renforcer le danger IA une fois les conséquences mécaniques disponibles.
-5. ~~#101~~ — fiabiliser les modèles : livré (PR #191).
-6. #152 — résoudre ou désactiver le concept libre.
-7. #162 — traiter les risques sécurité applicables avant exposition publique.
-8. #161 — déployer l'API, appliquer les migrations et vérifier le healthcheck.
-9. #129 — supporter le golden path réel avec le frontend.
+4. ~~#183~~ — inventaire réel (acquisition, usage, équipement) : livré.
+5. #185 — renforcer le danger IA une fois les conséquences mécaniques disponibles.
+6. ~~#101~~ — fiabiliser les modèles : livré (PR #191).
+7. #152 — résoudre ou désactiver le concept libre.
+8. #162 — traiter les risques sécurité applicables avant exposition publique.
+9. #161 — déployer l'API, appliquer les migrations et vérifier le healthcheck.
+10. #129 — supporter le golden path réel avec le frontend.
 
 Ordre de dépendance :
 
-`#183 → #184 → #185 → (#152 + #162) → #161 → #129`
+`#184 → #185 → (#152 + #162) → #161 → #129`
 
 ## Post-déploiement
 

--- a/docs/public/current-state/BACKEND_STATUS.md
+++ b/docs/public/current-state/BACKEND_STATUS.md
@@ -5,7 +5,7 @@ rag: true
 source_of_truth: true
 owner: backend
 default_agent: claude
-updated: 2026-07-24
+updated: 2026-07-25
 ---
 
 # Backend Status
@@ -29,7 +29,8 @@ updated: 2026-07-24
 - #182 / PR #199 — paliers de Calamine et fin spéciale `calcined`, `ChronicleEndReason` dérivé de
   `SessionEndReason`.
 - #183 — inventaire réel : acquisition via `item_gained` signalé par l'IA, usage/équipement/
-  déséquipement joueur via `/inventory/action`, persisté et validé côté backend.
+  déséquipement joueur via `/inventory/action`, persisté et validé côté backend, et branché
+  côté frontend (boutons d'action dans le panneau d'inventaire Velkhar).
 
 ## Pré-déploiement restant
 

--- a/docs/public/current-state/BACKEND_STATUS.md
+++ b/docs/public/current-state/BACKEND_STATUS.md
@@ -28,10 +28,11 @@ updated: 2026-07-24
   switcher en jeu sur la détection navigateur.
 - #182 / PR #199 — paliers de Calamine et fin spéciale `calcined`, `ChronicleEndReason` dérivé de
   `SessionEndReason`.
+- #183 — inventaire réel : acquisition via `item_gained` signalé par l'IA, usage/équipement/
+  déséquipement joueur via `/inventory/action`, persisté et validé côté backend.
 
 ## Pré-déploiement restant
 
-- #183 — acquisition, consommation et équipement de l'inventaire réel.
 - #184 — repos court/feu et récupération canonique.
 - #185 — danger IA régulier et crescendo d'intensité.
 - #152 — résolution du concept libre ou signal explicite de masquage V1.

--- a/docs/public/current-state/FRONTEND_NEXT.md
+++ b/docs/public/current-state/FRONTEND_NEXT.md
@@ -5,15 +5,16 @@ rag: true
 source_of_truth: true
 owner: frontend
 default_agent: codex
-updated: 2026-07-24
+updated: 2026-07-25
 ---
 
 # Frontend Next
 
 ## Phase 1 — pré-déploiement
 
-1. #186 — afficher le HUD Survie v2, les conditions, l'inventaire réel, le Désavantage et la fin
-   Calciné ; dépend de ~~#180~~ (livré, PR #196), ~~#181~~ (livré, PR #198) et #182-#184.
+1. #186 — afficher le HUD Survie v2, les conditions, le Désavantage et la fin Calciné ; dépend de
+   ~~#180~~ (livré, PR #196), ~~#181~~ (livré, PR #198) et #182-#184. Actions d'inventaire réel
+   (~~#183~~, PR #200) déjà branchées : boutons utiliser/équiper/déséquiper opérationnels.
 2. #152 — livrer le flow du concept libre ou masquer l'option sans cul-de-sac pour la V1.
 3. #161 — configurer `NEXT_PUBLIC_API_URL`, le domaine final et les redirects Supabase.
 4. #129 — exécuter les golden paths anonyme, conversion et résilience en EN/FR.

--- a/docs/public/current-state/FRONTEND_STATUS.md
+++ b/docs/public/current-state/FRONTEND_STATUS.md
@@ -5,7 +5,7 @@ rag: true
 source_of_truth: true
 owner: frontend
 default_agent: codex
-updated: 2026-07-24
+updated: 2026-07-25
 ---
 
 # Frontend Status
@@ -28,6 +28,9 @@ updated: 2026-07-24
   résilience et reprise anonyme/authentifiée.
 - #181 / PR #198 — priorité langue explicite du switcher en jeu sur la détection navigateur pour
   la narration IA (le HUD Survie v2 consommant conditions/Désavantage reste #186).
+- #183 / PR #200 — panneau d'inventaire Velkhar branché sur `POST /api/game/inventory/action` :
+  boutons utiliser/équiper/déséquiper par objet, mise à jour de l'inventaire et des stats de
+  survie après réponse serveur.
 
 ## Pré-déploiement restant
 

--- a/docs/public/current-state/RELEASE_READINESS.md
+++ b/docs/public/current-state/RELEASE_READINESS.md
@@ -28,12 +28,12 @@ merge. La checklist opérationnelle détaillée vit dans l'issue #163.
 | Contrats shared Survie v2      | Livré | #180 / PR #196 |
 | Conditions et Désavantage      | Livré | #181 / PR #198 |
 | Calamine et fin Calciné        | Livré | #182 / PR #199 |
+| Inventaire réel                | Livré | #183           |
 
 ## Phase 1 — pré-déploiement
 
 | Bloc                   | État       | Référence |
 | ---------------------- | ---------- | --------- |
-| Inventaire réel        | À faire    | #183      |
 | Action de repos        | À faire    | #184      |
 | Danger IA              | À faire    | #185      |
 | UI Survie v2           | À faire    | #186      |
@@ -50,6 +50,6 @@ multi-provider (#159), pgvector (#114), World events (#117) et échange Souvenir
 
 ## Go / No-Go
 
-`NO-GO` tant que les onze blocs fonctionnels pré-déploiement ne sont pas livrés, que la sécurité
+`NO-GO` tant que les huit blocs fonctionnels pré-déploiement ne sont pas livrés, que la sécurité
 n'est pas qualifiée, que l'API n'est pas déployée et que le golden path #129 n'est pas vert sur
 l'environnement de release.

--- a/packages/shared/src/types/character.types.ts
+++ b/packages/shared/src/types/character.types.ts
@@ -3,6 +3,8 @@
  * @see docs/public/raw/04-ATTRIBUTES.md, 06-SURVIVAL.md
  */
 
+import type { PersistedInventoryItem } from "./inventory.types";
+
 /** The three canon attributes (SANG / SOUFFLE / CENDRE). Values range 3–18. */
 export type Attribute = "blood" | "breath" | "ash";
 
@@ -78,6 +80,7 @@ export interface CharacterStats {
   attributes: Attributes;
   survival: SurvivalStats;
   conditions: ActiveCondition[];
+  inventory: PersistedInventoryItem[];
 }
 
 export interface Character {

--- a/packages/shared/src/types/inventory.types.ts
+++ b/packages/shared/src/types/inventory.types.ts
@@ -68,3 +68,41 @@ export interface ItemGainedEffect {
   damage?: string;
   attributeModifiers?: Partial<Record<Attribute, number>>;
 }
+
+/**
+ * One item as persisted on `Character.inventory` (backend-owned JSON array).
+ * Distinct from `ItemGained` (raw AI proposal) and `InventoryItemRef`
+ * (scene.types.ts, the display-facing projection sent to the client) — this
+ * is the durable record the backend reads/writes every turn.
+ * @see docs/public/raw/11-INVENTORY-ECONOMY.md §1
+ */
+export interface PersistedInventoryItem {
+  id: string;
+  name: string;
+  /** "heirloom" never appears here — it is never AI-granted (death/inheritance only, not yet implemented). */
+  category: "equipment" | "bag" | "artifact" | "key";
+  quantity: number;
+  /** Backend-owned equipment slot id, set only while category is "equipment" and the item is worn. */
+  equippedSlot?: string;
+  /** One of the 8 canon slots this item may occupy — required when category is "equipment". */
+  slot?: string;
+  effect?: ItemGainedEffect;
+  description?: string;
+}
+
+/** Canon bag capacity (11-INVENTORY-ECONOMY.md §1) — v2 has no bag extension. */
+export const INVENTORY_BAG_CAPACITY = 12;
+
+/** The 8 canon equipment slots (11-INVENTORY-ECONOMY.md §1). */
+export const INVENTORY_EQUIPMENT_SLOTS = [
+  "main-hand",
+  "off-hand",
+  "armor",
+  "cloak",
+  "head",
+  "accessory",
+  "belt",
+  "feet",
+] as const;
+
+export type InventoryEquipmentSlot = (typeof INVENTORY_EQUIPMENT_SLOTS)[number];

--- a/packages/shared/src/types/scene.types.ts
+++ b/packages/shared/src/types/scene.types.ts
@@ -123,6 +123,18 @@ export type InventoryItemCategory =
 
 export type InventoryItemState = "ready" | "locked" | "pending";
 
+/**
+ * Response to a player-initiated inventory action (use/equip/unequip, #183).
+ * Unlike `SceneResponse` this never advances the turn — no scene, no dice —
+ * it only reflects the resulting stats/conditions/inventory state.
+ */
+export interface InventoryActionResponse {
+  updatedStats: Record<string, number>;
+  updatedInventory: InventoryItemRef[];
+  /** False when the action was rejected (unknown item, wrong category/state) — nothing changed. */
+  applied: boolean;
+}
+
 export interface GameNotification {
   type:
     | "item_gained"


### PR DESCRIPTION
## Résumé

- Acquisition d'objets signalée par l'IA via `item_gained` (validée et appliquée côté backend, jamais décidée par l'IA).
- Usage/équipement/déséquipement joueur via la nouvelle route `POST /api/game/inventory/action` (mutation directe, hors tour IA).
- 4 catégories canon (equipment, bag cap 12, artifact, key/heirloom — heirloom jamais accordé par l'IA), 8 slots d'équipement canon.
- Correction du fix de langue Chronique (repli anglais quand la locale de session est inutilisable).

Closes #183

## Test plan

- [x] 299 tests backend passants (25 fichiers), type-check clean, lint clean.
- [x] Nouveaux tests : `game-rules/inventory.test.ts`, `session.service.inventory.test.ts`, `game.routes.inventory.test.ts`, section `item_gained` dans `system-prompt.test.ts` et `scene-validator.test.ts`.
- [x] Docs de statut mises à jour (`BACKEND_STATUS.md`, `BACKEND_NEXT.md`, `RELEASE_READINESS.md`).