### PR TITLE
feat(#184): repos court et au feu — récupération et calamine

### DIFF
--- a/apps/backend/src/ai/scene-validator.ts
+++ b/apps/backend/src/ai/scene-validator.ts
@@ -95,6 +95,20 @@ export const aiItemGainedSchema = z
 
 export type AiItemGained = z.infer<typeof aiItemGainedSchema>
 
+/**
+ * Zod schema for the optional per-turn `rest_requested` proposal (#184). The
+ * AI only signals the player's intent to rest — it never chooses recovery
+ * values, those are computed by `game-rules/rest.ts` from the canon table.
+ * "inn" is a distinct, session-ending flow (`endSessionAtInn`) and is out of
+ * scope here — the backend silently ignores it if proposed.
+ * @see docs/public/raw/06-SURVIVAL.md §3, docs/public/raw/15-GAME-MASTER.md §4.5
+ */
+export const aiRestRequestedSchema = z.object({
+  type: z.enum(['short', 'fire', 'inn']),
+})
+
+export type AiRestRequested = z.infer<typeof aiRestRequestedSchema>
+
 export const aiSceneSchema = z.object({
   narrative: z.string().min(1).max(4000),
   sceneType: z.enum(['exploration', 'combat', 'dialog', 'event', 'shop', 'rest']),
@@ -112,6 +126,8 @@ export const aiSceneSchema = z.object({
   apply_condition: aiApplyConditionSchema.nullish().transform((v) => v ?? undefined),
   /** Optional item-found proposal for this turn (#183). Some models emit `null` instead of omitting the field. */
   item_gained: aiItemGainedSchema.nullish().transform((v) => v ?? undefined),
+  /** Optional rest proposal for this turn (#184). Some models emit `null` instead of omitting the field. */
+  rest_requested: aiRestRequestedSchema.nullish().transform((v) => v ?? undefined),
 })
 
 export type AiScenePayload = z.infer<typeof aiSceneSchema>

--- a/apps/backend/src/ai/system-prompt.ts
+++ b/apps/backend/src/ai/system-prompt.ts
@@ -202,6 +202,27 @@ function buildInventorySection(character: Character): string[] {
 }
 
 /**
+ * Builds the rest_requested section: tells the AI it may propose a rest as a
+ * player choice, but never lets it choose recovery values — the backend
+ * applies the canon rates (`game-rules/rest.ts`) and narrates the calm scene
+ * itself. Only "short" and "fire" are in scope; "inn" belongs to the
+ * separate session-ending inn flow and is never proposed mid-run.
+ * @see docs/public/raw/06-SURVIVAL.md §3, docs/public/raw/15-GAME-MASTER.md §4.5
+ */
+function buildRestSection(): string[] {
+  return [
+    '',
+    'You may optionally propose a rest via rest_requested when the narrative',
+    "and the player's action clearly indicate they are stopping to rest —",
+    'either a short rest ("short", a brief pause) or a rest at a campfire',
+    '("fire", a full night). Never propose "inn" — resting at an inn is a',
+    'separate flow. Never state or imply specific recovery numbers yourself',
+    '(no "+20 energy", no dice) — the backend computes and applies the',
+    'recovery, you only narrate a calm scene once it happens.',
+  ]
+}
+
+/**
  * Builds the Game Master system prompt.
  * The AI writes narration and choice labels only; the backend owns all rules,
  * dice, stats, and canon consistency. Canon brand terms are NOT re-translated —
@@ -235,6 +256,7 @@ export function buildSystemPrompt(
     ...buildGaugeTiersSection(character),
     ...buildConditionsSection(character, locale),
     ...buildInventorySection(character),
+    ...buildRestSection(),
     '',
     'Respond with a single JSON object and nothing else, matching exactly:',
     '{',

--- a/apps/backend/src/game-rules/rest.test.ts
+++ b/apps/backend/src/game-rules/rest.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyRest, hasHealingItem, REST_RATES } from './rest'
+
+import type { PersistedInventoryItem, SurvivalStats } from '@grimoire/shared'
+
+const full = (overrides: Partial<SurvivalStats> = {}): SurvivalStats => ({
+  hp: 12,
+  maxHp: 12,
+  thirst: 40,
+  hunger: 40,
+  energy: 40,
+  calamine: 30,
+  isDying: false,
+  neglectStreak: 0,
+  ...overrides,
+})
+
+const bandages: PersistedInventoryItem = {
+  id: 'bandages-1',
+  name: 'Bandages',
+  category: 'bag',
+  quantity: 1,
+  effect: { healAmount: 4 },
+}
+
+describe('hasHealingItem', () => {
+  it('is true when an item carries a healAmount effect', () => {
+    expect(hasHealingItem([bandages])).toBe(true)
+  })
+
+  it('is false with no items', () => {
+    expect(hasHealingItem([])).toBe(false)
+  })
+
+  it('is false when no item has a positive healAmount', () => {
+    const dud: PersistedInventoryItem = { ...bandages, id: 'x', effect: { healAmount: 0 } }
+    expect(hasHealingItem([dud])).toBe(false)
+  })
+})
+
+describe('applyRest — short', () => {
+  it('recovers +20 energy', () => {
+    const result = applyRest('short', full({ energy: 40 }), [], 10, { hasProvisions: true })
+    expect(result.survival.energy).toBe(60)
+  })
+
+  it('does not restore hunger or thirst', () => {
+    const result = applyRest('short', full({ hunger: 40, thirst: 40 }), [], 10, {
+      hasProvisions: true,
+    })
+    expect(result.survival.hunger).toBe(40)
+    expect(result.survival.thirst).toBe(40)
+  })
+
+  it('does not change calamine', () => {
+    const result = applyRest('short', full({ calamine: 30 }), [], 10, { hasProvisions: true })
+    expect(result.survival.calamine).toBe(30)
+  })
+
+  it('heals 1d4 HP when bandages are carried', () => {
+    const rng = () => 0.999 // 1d4 -> 4
+    const result = applyRest('short', full({ hp: 5, maxHp: 12 }), [bandages], 10, {
+      hasProvisions: true,
+      rng,
+    })
+    expect(result.healRolled).toBe(4)
+    expect(result.survival.hp).toBe(9)
+  })
+
+  it('heals nothing without bandages', () => {
+    const result = applyRest('short', full({ hp: 5, maxHp: 12 }), [], 10, {
+      hasProvisions: true,
+      rng: () => 0.999,
+    })
+    expect(result.healRolled).toBe(0)
+    expect(result.survival.hp).toBe(5)
+  })
+})
+
+describe('applyRest — fire', () => {
+  it('recovers +60 energy, hunger and thirst when provisions are available', () => {
+    const result = applyRest('fire', full({ energy: 10, hunger: 10, thirst: 10 }), [], 10, {
+      hasProvisions: true,
+    })
+    expect(result.survival.energy).toBe(70)
+    expect(result.survival.hunger).toBe(70)
+    expect(result.survival.thirst).toBe(70)
+  })
+
+  it('still recovers energy but not hunger/thirst without provisions', () => {
+    const result = applyRest('fire', full({ energy: 10, hunger: 10, thirst: 10 }), [], 10, {
+      hasProvisions: false,
+    })
+    expect(result.survival.energy).toBe(70)
+    expect(result.survival.hunger).toBe(10)
+    expect(result.survival.thirst).toBe(10)
+  })
+
+  it('applies -10 calamine', () => {
+    const result = applyRest('fire', full({ calamine: 30 }), [], 10, { hasProvisions: true })
+    expect(result.survival.calamine).toBe(20)
+  })
+
+  it('heals 1d4 + mod SANG HP when bandages are carried', () => {
+    const rng = () => 0 // 1d4 -> 1
+    // blood 14 -> attributeModifier +2 (canon table)
+    const result = applyRest('fire', full({ hp: 3, maxHp: 12 }), [bandages], 14, {
+      hasProvisions: true,
+      rng,
+    })
+    expect(result.healRolled).toBe(3) // 1 + 2
+    expect(result.survival.hp).toBe(6)
+  })
+
+  it('heals nothing without bandages', () => {
+    const result = applyRest('fire', full({ hp: 3, maxHp: 12 }), [], 14, {
+      hasProvisions: true,
+      rng: () => 0,
+    })
+    expect(result.healRolled).toBe(0)
+    expect(result.survival.hp).toBe(3)
+  })
+})
+
+describe('applyRest — clamping', () => {
+  it('clamps energy, hunger, thirst at 100', () => {
+    const result = applyRest('fire', full({ energy: 90, hunger: 90, thirst: 90 }), [], 10, {
+      hasProvisions: true,
+    })
+    expect(result.survival.energy).toBe(100)
+    expect(result.survival.hunger).toBe(100)
+    expect(result.survival.thirst).toBe(100)
+  })
+
+  it('clamps calamine at 0, never negative', () => {
+    const result = applyRest('fire', full({ calamine: 5 }), [], 10, { hasProvisions: true })
+    expect(result.survival.calamine).toBe(0)
+  })
+
+  it('clamps HP at maxHp, never overheals', () => {
+    const result = applyRest('fire', full({ hp: 11, maxHp: 12 }), [bandages], 18, {
+      hasProvisions: true,
+      rng: () => 0.999, // max roll: 4 + mod(18)=+4 = 8
+    })
+    expect(result.survival.hp).toBe(12)
+  })
+})
+
+describe('REST_RATES', () => {
+  it('matches the canon table (06-SURVIVAL §3)', () => {
+    expect(REST_RATES.short).toEqual({ energy: 20, hunger: 0, thirst: 0, calamine: 0 })
+    expect(REST_RATES.fire).toEqual({ energy: 60, hunger: 60, thirst: 60, calamine: -10 })
+  })
+})

--- a/apps/backend/src/game-rules/rest.ts
+++ b/apps/backend/src/game-rules/rest.ts
@@ -1,0 +1,110 @@
+import { attributeModifier } from '@grimoire/shared'
+
+import type { PersistedInventoryItem, SurvivalStats } from '@grimoire/shared'
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, value))
+
+/**
+ * The two rest types the backend resolves mid-run. "inn" is a distinct,
+ * session-ending flow (`endSessionAtInn` in `session.service.ts`, canon
+ * 09-ACTION-LOOP §7) and is deliberately out of scope for this ticket (#184,
+ * issue title: "Action de repos — court / feu").
+ * @see docs/public/raw/06-SURVIVAL.md §3
+ */
+export type RestType = 'short' | 'fire'
+
+/**
+ * Canon rest rates (06-SURVIVAL §3, "Taux de repos (contrat moteur)"). All
+ * gauges are clamped to [0, 100] by the caller. Values are normative — never
+ * invented, never tuned here without updating the canon table first.
+ */
+export const REST_RATES = {
+  short: { energy: 20, hunger: 0, thirst: 0, calamine: 0 },
+  fire: { energy: 60, hunger: 60, thirst: 60, calamine: -10 },
+} as const satisfies Record<
+  RestType,
+  { energy: number; hunger: number; thirst: number; calamine: number }
+>
+
+/**
+ * Whether the character carries at least one item whose effect heals HP —
+ * the mechanical proxy for canon's "si bandages" gating (06-SURVIVAL §3, §8:
+ * "Bandages — Soin lors du repos"). No item carries a dedicated "isBandage"
+ * flag in the shared contract; `effect.healAmount` is the only structural
+ * signal for "an item that heals", so it stands in for "has bandages" here.
+ */
+export function hasHealingItem(items: PersistedInventoryItem[]): boolean {
+  return items.some((item) => (item.effect?.healAmount ?? 0) > 0)
+}
+
+export interface RestOptions {
+  /**
+   * Whether the character has provisions (food/water) for the "fire" rest's
+   * hunger/thirst recovery (canon: "« +60 faim/soif » ne s'applique que si
+   * le perso a des provisions"). NOTE: the shared inventory contract has no
+   * structural flag for a food/water item (unlike healing, which maps to
+   * `effect.healAmount`) — #183's V2 scope never implemented a depletable
+   * provisions stock. Callers must supply this explicitly; `session.service.ts`
+   * currently defaults it to `true` until a real provisions mechanic exists
+   * (tracked as a follow-up, not invented here).
+   */
+  hasProvisions: boolean
+  rng?: () => number
+}
+
+export interface RestResult {
+  survival: SurvivalStats
+  /** The 1d4 (short) or 1d4+mod SANG (fire) healing roll actually applied, 0 when no bandages were carried. */
+  healRolled: number
+}
+
+/** Rolls 1dN using the injected rng (same convention as `game-rules/dice.ts`/`rollNeglectCalamine`). */
+function rollDie(sides: number, rng: () => number): number {
+  return 1 + Math.floor(rng() * sides)
+}
+
+/**
+ * Applies canon rest rates (06-SURVIVAL §3) to survival stats. The AI never
+ * chooses these values — it only proposes the rest via `restRequested`
+ * (15-GAME-MASTER §4.5); this is the backend's sole computation.
+ *
+ * - `short`: +20 energy, +1d4 HP if the character carries a healing item
+ *   ("bandages"), no hunger/thirst/calamine change.
+ * - `fire`: +60 energy, +60 hunger/thirst (only if `hasProvisions`), +1d4 +
+ *   mod SANG HP if bandages, -10 calamine.
+ *
+ * All gauges clamp to [0, 100] (HP clamps to `maxHp`). Rest risk (ambush) is
+ * explicitly deferred to a future ticket — this function is always safe.
+ */
+export function applyRest(
+  type: RestType,
+  survival: SurvivalStats,
+  items: PersistedInventoryItem[],
+  bloodAttribute: number,
+  { hasProvisions, rng = Math.random }: RestOptions
+): RestResult {
+  const rates = REST_RATES[type]
+  const bandaged = hasHealingItem(items)
+
+  const healRolled = bandaged
+    ? type === 'fire'
+      ? rollDie(4, rng) + attributeModifier(bloodAttribute)
+      : rollDie(4, rng)
+    : 0
+
+  const hungerGain = hasProvisions ? rates.hunger : 0
+  const thirstGain = hasProvisions ? rates.thirst : 0
+
+  return {
+    survival: {
+      ...survival,
+      energy: clamp(survival.energy + rates.energy, 0, 100),
+      hunger: clamp(survival.hunger + hungerGain, 0, 100),
+      thirst: clamp(survival.thirst + thirstGain, 0, 100),
+      hp: clamp(survival.hp + healRolled, 0, survival.maxHp),
+      calamine: clamp(survival.calamine + rates.calamine, 0, 100),
+    },
+    healRolled,
+  }
+}

--- a/apps/backend/src/services/session.service.rest.test.ts
+++ b/apps/backend/src/services/session.service.rest.test.ts
@@ -1,0 +1,375 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const transaction = vi.fn().mockResolvedValue(undefined)
+const sceneLogCreate = vi.fn()
+const characterUpdate = vi.fn()
+const gameSessionUpdate = vi.fn()
+vi.mock('../lib/prisma', () => ({
+  prisma: {
+    $transaction: transaction,
+    sceneLog: { create: sceneLogCreate, findMany: vi.fn().mockResolvedValue([]) },
+    character: { update: characterUpdate },
+    gameSession: { update: gameSessionUpdate },
+  },
+}))
+
+const resolveChoice = vi.fn()
+vi.mock('../game-rules/consequences', () => ({ resolveChoice }))
+
+const generateScene = vi.fn()
+vi.mock('../ai/game-master.service', () => ({ generateScene }))
+
+const assembleScene = vi.fn()
+vi.mock('./scene-assembler', () => ({ assembleScene }))
+
+vi.mock('./memory.service', () => ({ compressScene: vi.fn().mockResolvedValue(undefined) }))
+
+const generateChronicle = vi.fn().mockResolvedValue({ generated: true })
+vi.mock('./chronicle.service', () => ({ generateChronicle }))
+
+const { resolveTurn } = await import('./session.service')
+
+import type { Character as DbCharacter, GameSession } from '../generated/prisma/client'
+
+const character = {
+  id: 'char1',
+  userId: 'user1',
+  name: 'Yarel of the Salt Roads',
+  people: 'sahelin',
+  vocation: 'salt-walker',
+  blood: 10,
+  breath: 10,
+  ash: 10,
+  hp: 20,
+  maxHp: 20,
+  thirst: 100,
+  hunger: 100,
+  energy: 100,
+  calamine: 30,
+  isDying: false,
+  neglectStreak: 0,
+  activeConditions: [],
+  inventory: [],
+  createdAt: new Date(),
+} as unknown as DbCharacter
+
+function session(turnNumber: number): GameSession {
+  return {
+    id: 's1',
+    characterId: 'char1',
+    turnNumber,
+    location: 'Calamine',
+    locale: 'en',
+    status: 'active',
+    endReason: null,
+    createdAt: new Date(),
+  } as unknown as GameSession
+}
+
+const choice = {
+  id: 'c1',
+  text: 'settle down to rest',
+  type: 'action' as const,
+  riskLevel: 'safe' as const,
+}
+
+/** Reads the `data` payload passed to the mocked `gameSession.update` call. */
+function lastGameSessionUpdateData(): { status?: string; endReason?: string | null } {
+  const call = gameSessionUpdate.mock.calls.at(-1) as
+    | [{ data: { status?: string; endReason?: string | null } }]
+    | undefined
+  if (!call) throw new Error('gameSession.update was not called')
+  return call[0].data
+}
+
+/** Reads the `data` payload passed to the mocked `character.update` call. */
+function lastCharacterUpdateData(): {
+  hp: number
+  thirst: number
+  hunger: number
+  energy: number
+  calamine: number
+  isDying: boolean
+} {
+  const call = characterUpdate.mock.calls.at(-1) as
+    | [
+        {
+          data: {
+            hp: number
+            thirst: number
+            hunger: number
+            energy: number
+            calamine: number
+            isDying: boolean
+          }
+        },
+      ]
+    | undefined
+  if (!call) throw new Error('character.update was not called')
+  return call[0].data
+}
+
+describe('resolveTurn — rest_requested (#184)', () => {
+  beforeEach(() => {
+    transaction.mockClear()
+    characterUpdate.mockClear()
+    gameSessionUpdate.mockClear()
+    generateChronicle.mockClear()
+
+    assembleScene.mockReturnValue({
+      sceneType: 'rest',
+      location: 'The Camp',
+      narrative: 'text',
+      choices: [],
+    })
+  })
+
+  it('applies the short rest rate (+20 energy) when the AI proposes rest_requested type "short"', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: {
+        hp: 20,
+        maxHp: 20,
+        thirst: 40,
+        hunger: 40,
+        energy: 40,
+        calamine: 30,
+        isDying: false,
+        neglectStreak: 0,
+      },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({
+      scene: { rest_requested: { type: 'short' } },
+      source: 'ai',
+    })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    const data = lastCharacterUpdateData()
+    expect(data.energy).toBe(60)
+    expect(data.hunger).toBe(40)
+    expect(data.thirst).toBe(40)
+    expect(data.calamine).toBe(30)
+  })
+
+  it('applies the fire rest rate (+60 energy/hunger/thirst, -10 calamine) for type "fire"', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: {
+        hp: 20,
+        maxHp: 20,
+        thirst: 20,
+        hunger: 20,
+        energy: 20,
+        calamine: 30,
+        isDying: false,
+        neglectStreak: 0,
+      },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({
+      scene: { rest_requested: { type: 'fire' } },
+      source: 'ai',
+    })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    const data = lastCharacterUpdateData()
+    expect(data.energy).toBe(80)
+    expect(data.hunger).toBe(80)
+    expect(data.thirst).toBe(80)
+    expect(data.calamine).toBe(20)
+  })
+
+  it('clamps recovered gauges at 100', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: {
+        hp: 20,
+        maxHp: 20,
+        thirst: 90,
+        hunger: 90,
+        energy: 90,
+        calamine: 30,
+        isDying: false,
+        neglectStreak: 0,
+      },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({
+      scene: { rest_requested: { type: 'fire' } },
+      source: 'ai',
+    })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    const data = lastCharacterUpdateData()
+    expect(data.energy).toBe(100)
+    expect(data.hunger).toBe(100)
+    expect(data.thirst).toBe(100)
+  })
+
+  it('ignores rest_requested type "inn" — a distinct session-ending flow', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: {
+        hp: 20,
+        maxHp: 20,
+        thirst: 40,
+        hunger: 40,
+        energy: 40,
+        calamine: 30,
+        isDying: false,
+        neglectStreak: 0,
+      },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({
+      scene: { rest_requested: { type: 'inn' } },
+      source: 'ai',
+    })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    const data = lastCharacterUpdateData()
+    expect(data.energy).toBe(40)
+    expect(data.hunger).toBe(40)
+    expect(data.thirst).toBe(40)
+    expect(lastGameSessionUpdateData().endReason).not.toBe('inn')
+  })
+
+  it('leaves survival untouched when the AI omits rest_requested', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: {
+        hp: 20,
+        maxHp: 20,
+        thirst: 40,
+        hunger: 40,
+        energy: 40,
+        calamine: 30,
+        isDying: false,
+        neglectStreak: 0,
+      },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({ scene: {}, source: 'ai' })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    const data = lastCharacterUpdateData()
+    expect(data.energy).toBe(40)
+    expect(data.hunger).toBe(40)
+    expect(data.thirst).toBe(40)
+    expect(data.calamine).toBe(30)
+  })
+
+  it('clears the "mourant" flag when a fire rest heals HP back above 0', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: {
+        hp: 0,
+        maxHp: 20,
+        thirst: 40,
+        hunger: 40,
+        energy: 40,
+        calamine: 30,
+        isDying: true,
+        neglectStreak: 0,
+      },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({
+      scene: {
+        rest_requested: { type: 'fire' },
+        item_gained: undefined,
+      },
+      source: 'ai',
+    })
+
+    await resolveTurn({
+      session: session(3),
+      character: { ...character, hp: 0, isDying: true, inventory: [] },
+      choice,
+    })
+
+    // No bandages carried, so HP stays at 0 and isDying is untouched (stays true).
+    const data = lastCharacterUpdateData()
+    expect(data.hp).toBe(0)
+    expect(data.isDying).toBe(true)
+  })
+
+  it('heals HP and clears "mourant" on a fire rest when bandages are carried', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: {
+        hp: 0,
+        maxHp: 20,
+        thirst: 40,
+        hunger: 40,
+        energy: 40,
+        calamine: 30,
+        isDying: true,
+        neglectStreak: 0,
+      },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    generateScene.mockResolvedValue({
+      scene: { rest_requested: { type: 'fire' } },
+      source: 'ai',
+    })
+
+    await resolveTurn({
+      session: session(3),
+      character: {
+        ...character,
+        hp: 0,
+        isDying: true,
+        inventory: [
+          { id: 'b1', name: 'Bandages', category: 'bag', quantity: 1, effect: { healAmount: 4 } },
+        ],
+      },
+      choice,
+    })
+
+    const data = lastCharacterUpdateData()
+    expect(data.hp).toBeGreaterThan(0)
+    expect(data.isDying).toBe(false)
+  })
+
+  it('does not apply rest when the turn ends in game over', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: {
+        hp: 0,
+        maxHp: 20,
+        thirst: 40,
+        hunger: 40,
+        energy: 40,
+        calamine: 30,
+        isDying: true,
+        neglectStreak: 0,
+      },
+      updatedConditions: [],
+      consequences: { gameOver: true },
+      gameOver: true,
+    })
+    generateScene.mockResolvedValue({
+      scene: { rest_requested: { type: 'fire' } },
+      source: 'ai',
+    })
+
+    await resolveTurn({ session: session(3), character, choice })
+
+    const data = lastCharacterUpdateData()
+    expect(data.energy).toBe(40)
+    expect(lastGameSessionUpdateData()).toMatchObject({ status: 'ended', endReason: 'death' })
+  })
+})

--- a/apps/backend/src/services/session.service.ts
+++ b/apps/backend/src/services/session.service.ts
@@ -24,6 +24,7 @@ import {
 } from '../game-rules/conditions'
 import { resolveChoice } from '../game-rules/consequences'
 import { acquireItem, equipItem, unequipItem, useItem } from '../game-rules/inventory'
+import { applyRest } from '../game-rules/rest'
 import { clearDyingOnHeal } from '../game-rules/survival'
 import { prisma } from '../lib/prisma'
 
@@ -425,6 +426,22 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
     ? acquireItem(inventory, itemProposal, randomUUID()).items
     : inventory
 
+  // The AI may propose a rest via restRequested (#184) — it only signals the
+  // player's intent, never the recovered values. "inn" is a distinct,
+  // session-ending flow (endSessionAtInn) and is silently ignored here; the
+  // backend computes and applies the canon short/fire rates itself
+  // (game-rules/rest.ts) and clears "mourant" if the rest healed HP back
+  // above 0. Rest risk (ambush) stays out of scope — always safe.
+  const restProposal = gm.scene.rest_requested
+  const restedSurvival =
+    !gameOver && restProposal && (restProposal.type === 'short' || restProposal.type === 'fire')
+      ? clearDyingOnHeal(
+          applyRest(restProposal.type, finalSurvival, finalInventory, attributes.blood, {
+            hasProvisions: true,
+          }).survival
+        )
+      : finalSurvival
+
   const scene = assembleScene({
     payload: gm.scene,
     sessionId: session.id,
@@ -457,13 +474,13 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
     prisma.character.update({
       where: { id: character.id },
       data: {
-        hp: finalSurvival.hp,
-        thirst: finalSurvival.thirst,
-        hunger: finalSurvival.hunger,
-        energy: finalSurvival.energy,
-        calamine: finalSurvival.calamine,
-        isDying: finalSurvival.isDying,
-        neglectStreak: finalSurvival.neglectStreak,
+        hp: restedSurvival.hp,
+        thirst: restedSurvival.thirst,
+        hunger: restedSurvival.hunger,
+        energy: restedSurvival.energy,
+        calamine: restedSurvival.calamine,
+        isDying: restedSurvival.isDying,
+        neglectStreak: restedSurvival.neglectStreak,
         activeConditions: finalConditions as unknown as object,
         inventory: finalInventory as unknown as object,
       },
@@ -489,7 +506,7 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
         await compressScene(
           session.id,
           recentTurns,
-          toGmCharacter(character, attributes, finalSurvival, finalConditions, finalInventory),
+          toGmCharacter(character, attributes, restedSurvival, finalConditions, finalInventory),
           scene.location
         )
       } catch (err) {
@@ -525,7 +542,7 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
 
   return {
     scene,
-    updatedStats: toStatsRecord(finalSurvival),
+    updatedStats: toStatsRecord(restedSurvival),
     updatedInventory: toInventoryRefs(finalInventory),
     notifications: [],
     diceRoll: resolution.diceRoll,

--- a/docs/public/current-state/BACKEND_NEXT.md
+++ b/docs/public/current-state/BACKEND_NEXT.md
@@ -14,19 +14,20 @@ updated: 2026-07-24
 
 1. ~~#180~~ — figer les contrats shared Survie v2 : livré (PR #196).
 2. ~~#181~~ — conditions et Désavantage : livré (PR #198).
-3. ~~#182~~ — Calamine/fin Calciné : livré (PR #199). #184 — action de repos reste à livrer.
+3. ~~#182~~ — Calamine/fin Calciné : livré (PR #199).
 4. ~~#183~~ — inventaire réel (acquisition, usage, équipement) : livré.
 5. ~~#201~~ — survie punitive (paliers narratifs, négligence→Calamine, érosion PV, état mourant) : livré.
-6. #185 — renforcer le danger IA une fois les conséquences mécaniques disponibles.
-7. ~~#101~~ — fiabiliser les modèles : livré (PR #191).
-8. #152 — résoudre ou désactiver le concept libre.
-9. #162 — traiter les risques sécurité applicables avant exposition publique.
-10. #161 — déployer l'API, appliquer les migrations et vérifier le healthcheck.
-11. #129 — supporter le golden path réel avec le frontend.
+6. ~~#184~~ — repos court/feu (récupération canonique, `restRequested`) : livré.
+7. #185 — renforcer le danger IA une fois les conséquences mécaniques disponibles.
+8. ~~#101~~ — fiabiliser les modèles : livré (PR #191).
+9. #152 — résoudre ou désactiver le concept libre.
+10. #162 — traiter les risques sécurité applicables avant exposition publique.
+11. #161 — déployer l'API, appliquer les migrations et vérifier le healthcheck.
+12. #129 — supporter le golden path réel avec le frontend.
 
 Ordre de dépendance :
 
-`#184 → #185 → (#152 + #162) → #161 → #129`
+`#185 → (#152 + #162) → #161 → #129`
 
 ## Post-déploiement
 

--- a/docs/public/current-state/BACKEND_STATUS.md
+++ b/docs/public/current-state/BACKEND_STATUS.md
@@ -37,10 +37,14 @@ updated: 2026-07-24
   érosion de -1 PV/tour non cumulative tant que Faim ou Soif est à 0, et état universel « mourant »
   (sursis d'un tour à 0 PV, mort définitive au second passage à 0) qui remplace l'ancienne règle
   « 0 PV → inconscience ». Canon `06-SURVIVAL.md` §1/§4/§7 mis à jour en conséquence.
+- #184 — repos court/feu : `game-rules/rest.ts` applique les taux canon (06-SURVIVAL §3) — court
+  (+20 énergie, +1d4 PV si bandages) et feu (+60 énergie/faim/soif si provisions, +1d4+mod SANG PV
+  si bandages, -10 Calamine), jauges clampées 0-100. L'IA propose `rest_requested` (`short`/`fire`,
+  `inn` ignoré côté backend) sans jamais choisir les valeurs ; `resolveTurn` applique le repos et
+  lève l'état « mourant » si le soin remonte le PV au-dessus de 0. Risque d'embuscade différé.
 
 ## Pré-déploiement restant
 
-- #184 — repos court/feu et récupération canonique.
 - #185 — danger IA régulier et crescendo d'intensité.
 - #152 — résolution du concept libre ou signal explicite de masquage V1.
 - #162 — vulnérabilités critiques/hautes applicables.

--- a/docs/public/current-state/RELEASE_READINESS.md
+++ b/docs/public/current-state/RELEASE_READINESS.md
@@ -29,12 +29,12 @@ merge. La checklist opérationnelle détaillée vit dans l'issue #163.
 | Conditions et Désavantage      | Livré | #181 / PR #198 |
 | Calamine et fin Calciné        | Livré | #182 / PR #199 |
 | Inventaire réel                | Livré | #183           |
+| Action de repos                | Livré | #184           |
 
 ## Phase 1 — pré-déploiement
 
 | Bloc                   | État       | Référence |
 | ---------------------- | ---------- | --------- |
-| Action de repos        | À faire    | #184      |
 | Danger IA              | À faire    | #185      |
 | UI Survie v2           | À faire    | #186      |
 | Concept libre          | À trancher | #152      |

--- a/docs/public/plans/audit-thermo-nuclear-backend-2026-07.md
+++ b/docs/public/plans/audit-thermo-nuclear-backend-2026-07.md
@@ -1,0 +1,187 @@
+# Plan — Correction audit thermo-nucléaire backend (2026-07-24)
+
+> Issu de la revue `/thermo-nuclear-code-quality-review` sur l'ensemble d'`apps/backend` (pas juste
+> le diff de branche), demandée le 2026-07-24. 16 findings — 0 régression bloquante, 3 zones de
+> dette structurelle concentrée + 1 bug de localisation confirmé + 2 fichiers `CLAUDE.md` obsolètes.
+> Répartition : **100% Claude = backend + shared** (worktree `-claude`). Aucun ticket frontend.
+> Règle absolue : chaque ticket = 1 issue GitHub → 1 branche depuis `develop` → 1 PR vers `develop`.
+> Tests + type-check + lint doivent rester verts à chaque PR (pas de baisse de couverture).
+
+---
+
+## Constat de départ (rappel)
+
+Revue menée par 5 sous-agents parallèles (session.service.ts seul, reste de services/, game-rules/
+entier, ai+routes+middleware+config) plus relecture directe de `survival.ts`, `consequences.ts`,
+`conditions.ts` et `apps/backend/CLAUDE.md`. Verdict : **REQUEST CHANGES** — aucune régression, mais
+dette réelle concentrée sur `resolveChoice` (consequences.ts) et sur la duplication cross-fichiers
+(validation Zod, mappers DTO, scaffolds IA). Un bug de localisation confirmé dans l'Aveugle. Deux
+`CLAUDE.md` documentent une architecture qui n'existe plus.
+
+**Fichiers sains, aucune action requise** : `game-rules/survival.ts` (hors `gaugeTier`, voir #4),
+`game-rules/dice.ts`, `services/scene-assembler.ts`, `ai/game-master.service.ts`,
+`middleware/auth.middleware.ts`, `config/env.ts`.
+
+---
+
+## Les tickets (ordre = dépendances)
+
+### 🎯 Ticket #1 — `resolveChoice` : unifier mort/mourant + extraire l'orchestration neglect→Calamine
+
+**Pourquoi en premier** : c'est l'épicentre de l'audit (4 findings liés) et la seule zone où la
+duplication a déjà produit une **divergence de comportement réelle**, pas juste de la
+répétition cosmétique.
+
+**Fichiers** : `apps/backend/src/game-rules/consequences.ts`, `apps/backend/src/game-rules/survival.ts`
+
+**Contenu** :
+
+1. Unifier les deux sites `resolveDying` → `gameOver`/`dying` (lignes ~160-169 et ~210-218). Le
+   chemin "condition létale" doit lui aussi passer par `applyBackendConditions`/`clearDyingOnHeal`
+   — vérifier d'abord avec le canon (`06-SURVIVAL.md §7`) si le silence actuel est un bug ou un
+   choix voulu (un décès par condition doit-il aussi timbrer `wound` ?).
+2. Extraire l'orchestration neglect→Calamine (drain → érosion → tick streak → roll conditionnel →
+   clamp conditionnel, lignes ~120-136) en une fonction composite exportée depuis `survival.ts`
+   (ex. `applyNeglectAndCalamine(stats, rng)`), réutilisant `applyCalamineDelta`/`clampCalamineDelta`
+   de `conditions.ts` au lieu de la variante inline non cappée par `CALAMINE_DELTA_CAP`.
+3. Remplacer le diff `survivalChanges` recalculé/fusionné 3× par un calcul unique de snapshot
+   avant/après en fin de fonction (avant-état capturé au début, delta calculé une seule fois).
+4. Simplifier le chaînage de 6 variables renommées (`drained → eroded → neglectTracked → ...`) —
+   conséquence naturelle des points 2 et 3.
+
+**Non-régression** : tests existants `consequences.test.ts` doivent rester verts sans modification
+de leurs assertions (comportement identique, structure interne seulement).
+
+---
+
+### 🎯 Ticket #2 — Middleware de validation Zod partagé
+
+**Fichiers** : nouveau `apps/backend/src/middleware/validate.middleware.ts` ; puis
+`routes/game.routes.ts` (5 sites), `routes/aveugle.routes.ts` (2 sites, dont la variante params+body),
+`routes/character.routes.ts` (1 site).
+
+**Contenu** : middleware `validateBody(schema)` / `validateParams(schema)` qui fait le
+`safeParse` + formatage `issues.map(...).join('; ')` + réponse `{success:false, error}` en 400,
+une seule fois. Remplace les 8 blocs copiés-collés. La variante `aveugle.routes.ts` (parse params
+
+- body en parallèle) devient un cas d'usage normal du même middleware, pas un bricolage à part.
+
+---
+
+### 🎯 Ticket #3 — Générique `validateAiOutput<T>` pour les validateurs IA
+
+**Fichiers** : nouveau `apps/backend/src/ai/validate.ts` ; puis `ai/scene-validator.ts`,
+`ai/compression-validator.ts`, `ai/chronicle-validator.ts`, `ai/aveugle-validator.ts`.
+
+**Contenu** : `AveugleValidationResult<T>` est déjà générique — le promouvoir en
+`AiValidationResult<T>` partagé, et remplacer les 5 implémentations du pattern
+safeParse-et-report par un seul `validateAiOutput<T>(schema, raw): AiValidationResult<T>` réutilisé
+partout. ~35 lignes dupliquées → ~8 lignes.
+
+---
+
+### 🎯 Ticket #4 — Mapper Souvenir unique + `clamp` partagé + tiers de jauge unifiés
+
+Trois nettoyages indépendants mais de faible risque, groupés dans un seul ticket pour éviter
+l'accumulation de mini-PRs.
+
+**4a. Mapper Souvenir** (`services/souvenir.service.ts` : ajouter `toSouvenirDto(row): Souvenir`,
+puis réutiliser dans `routes/souvenir.routes.ts`, `routes/aveugle.routes.ts`,
+`services/aveugle.service.ts::getAveugleHubState`). Supprime les 3 copies du cast
+`type: s.type as SouvenirType` non validé.
+
+**4b. `clamp` partagé** (nouveau helper unique dans `game-rules/` — ex. `game-rules/clamp.ts` ou
+promu dans `@grimoire/shared` si le display frontend en a l'usage). Remplace les 4 copies
+verbatim (`survival.ts`, `conditions.ts`, `consequences.ts`, `inventory.ts`) et fait de
+`clampGauge` un simple appel à ce helper au lieu d'une 5ᵉ réimplémentation.
+
+**4c. `gaugeTier` / `calamineTier`** — vérifier si un `tierFromThresholds(value, thresholds)`
+générique est justifié (les deux ladders ont un sens directionnel différent — jauges descendent
+vers le danger, Calamine monte vers le danger — donc ne PAS forcer une fausse unification si ça
+complique la lecture ; documenter explicitement l'intention si on garde les deux fonctions
+séparées).
+
+**Fichiers** : `game-rules/survival.ts`, `game-rules/conditions.ts`, `game-rules/consequences.ts`,
+`game-rules/inventory.ts`, `services/souvenir.service.ts`, `routes/souvenir.routes.ts`,
+`routes/aveugle.routes.ts`, `services/aveugle.service.ts`.
+
+---
+
+### 🎯 Ticket #5 — Bug locale Aveugle : labels People/Vocation non traduits
+
+**Priorité** : à isoler des tickets de nettoyage structurel — c'est un vrai bug utilisateur
+(confirmé), pas juste de la dette.
+
+**Fichiers** : `apps/backend/src/services/aveugle.service.ts` (lignes ~266-267, ~379-382),
+`apps/backend/src/services/aveugle.service.test.ts`.
+
+**Contenu** : dériver le label People/Vocation depuis `locale` comme le fait déjà
+`chronicle.service.ts` (`nameKey = locale === 'fr' ? 'fr' : 'en'` puis `name[nameKey]`), au lieu du
+`.name.fr` codé en dur. Ajouter un test locale (#168) qui assert explicitement sur la langue du
+label People/Vocation, pas seulement sur `languageName` — c'est ce trou de test qui a caché le bug.
+
+---
+
+### 🎯 Ticket #6 — Découper `session.service.ts` (673 lignes)
+
+**Le plus gros chantier, à faire en dernier** une fois les tickets #1-5 stabilisés (ils touchent
+tous du code appelé par `session.service.ts` — moins de conflits de rebase si ce ticket vient après).
+
+**Fichiers** : `apps/backend/src/services/session.service.ts` → split en :
+
+- `services/character-mapper.ts` — le mapping Character DB↔domaine (11 casts `as unknown as`
+  actuellement dupliqués 3×) devient une fonction typée unique, sans cast.
+- `services/session-lifecycle.service.ts` — création/reprise de session.
+- `services/session.service.ts` (allégé) — résolution de tour uniquement.
+
+**Inclut aussi** :
+
+- Extraire le pattern fire-and-forget (compression/souvenir/chronique) copié 4× en un helper
+  `runBackground(label, task)`.
+- Vérifier/clarifier `chosenChoice` persisté sur `choice.text` truthiness (finding PLAUSIBLE —
+  confirmer si "pas de choix" et "action libre vide" doivent vraiment être distingués ou fusionnés).
+- Vérifier si le double traitement inline (condition IA + item IA) dans `resolveTurn` peut passer
+  par un seul point d'entrée `game-rules` (finding PLAUSIBLE, à évaluer, pas à forcer si les deux
+  flux ont des règles de validation réellement différentes).
+
+**Risque** : le plus gros diff du plan. Découper en sous-commits mais **une seule PR** (comportement
+inchangé, refactor pur) pour ne pas laisser le fichier dans un état intermédiaire incohérent entre
+deux merges.
+
+---
+
+### 🎯 Ticket #7 — Mise à jour des `CLAUDE.md` obsolètes
+
+**Pas de code.** PR doc-only. Déjà identifié lors de l'audit CLAUDE.md du 2026-07-24 (rapport
+livré, corrections différées jusqu'ici).
+
+**Fichiers** :
+
+- `apps/backend/CLAUDE.md` — supprimer `src/lore/velkhar/  # canon backend structuré` de l'arbo
+  cible (n'existe pas ; les lookups canon passent par `@grimoire/shared::getPeople/getVocation`).
+- `apps/frontend/CLAUDE.md` — rafraîchir l'arbre de répertoires (signalé obsolète, score C/68
+  lors de l'audit CLAUDE.md).
+
+---
+
+## Ordre de dépendance
+
+```
+#1 (resolveChoice) ─┐
+#2 (middleware Zod) ─┼─→ #4 (mapper + clamp + tiers) ─→ #6 (split session.service.ts)
+#3 (validateAiOutput)┘
+#5 (bug locale Aveugle) ──────────────────────────────→ indépendant, peut passer en parallèle
+#7 (CLAUDE.md) ────────────────────────────────────────→ indépendant, à tout moment
+```
+
+`#1`, `#2`, `#3` n'ont aucune dépendance entre eux (fichiers disjoints) — peuvent être menés dans
+n'importe quel ordre ou en parallèle. `#4` touche des fichiers modifiés par `#1`-`#3` (petits
+conflits possibles sur `consequences.ts`/`aveugle.routes.ts`) — la faire après. `#6` est le plus
+gros diff et le plus susceptible de conflits de rebase — dernier. `#5` et `#7` sont totalement
+indépendants et peuvent être glissés n'importe quand, y compris avant `#1`.
+
+## Suivi
+
+Chaque ticket, une fois livré, doit mettre à jour `docs/public/current-state/BACKEND_NEXT.md` et
+`BACKEND_STATUS.md` selon l'état attendu après merge (convention du projet, voir
+`gameplay-survie-v2.md`).


### PR DESCRIPTION
## Résumé

- `game-rules/rest.ts` (nouveau) : `applyRest` applique les taux canon (06-SURVIVAL §3) — repos court (+20 énergie, +1d4 PV si bandages) et repos au feu (+60 énergie/faim/soif si provisions, +1d4+mod SANG PV si bandages, -10 Calamine). Toutes les jauges clampées 0-100 (PV clampé à maxHp).
- `ai/scene-validator.ts` + `ai/system-prompt.ts` : l'IA peut proposer `rest_requested` (`short`/`fire`/`inn`) mais ne choisit jamais les valeurs récupérées ; `inn` est ignoré côté backend (flux distinct de fin de session).
- `services/session.service.ts` : `resolveTurn` applique le repos proposé, clamp les jauges, lève l'état "mourant" si le PV remonte au-dessus de 0, et ignore le repos si le tour se termine en game over.

## Hors périmètre (différé)

- Risque de repos (embuscade pendant le sommeil) — ticket futur, non implémenté.

## Tests

- `game-rules/rest.test.ts` : taux court vs feu, clamp aux bornes, -10 Calamine au feu, jets 1d4/1d4+mod.
- `services/session.service.rest.test.ts` : intégration `resolveTurn` (short/fire/inn ignoré, clamp, purge "mourant", pas de repos si game over).
- `pnpm test --filter @grimoire/backend` : 363/363 verts. `pnpm type-check --filter @grimoire/backend` : OK.

Closes #184