### PR TITLE
feat(#226): contrats de run partagés et scindement de SessionEndReason

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -113,7 +113,8 @@ model GameSession {
   /// normalisé). Persistée pour que la reprise garde la même langue (#168).
   locale     String   @default("en")
   status     String   @default("active") // active | ended
-  /// Why the session ended (death | inn | abandon | calcined). Null while active. Bridge to A3.
+  /// Why the session ended (death | extracted | returned_empty | abandon | calcined).
+  /// Null while active. Bridge to A3. @see docs/public/raw/23-RUN-STRUCTURE.md §5
   endReason  String?
   /// URL résolue du cache d'images de scène partagé (#207), mise à jour à
   /// chaque compression N2. Null tant qu'aucun chunk n'a encore résolu d'image.
@@ -231,7 +232,8 @@ model Chronicle {
   characterId String
   sessionId   String
 
-  /// Why the run ended (death | inn | abandon | calcined), copied from GameSession.endReason.
+  /// Why the run ended (death | extracted | returned_empty | abandon | calcined),
+  /// copied from GameSession.endReason.
   endReason String
 
   title        String

--- a/apps/backend/src/routes/game.routes.ts
+++ b/apps/backend/src/routes/game.routes.ts
@@ -159,7 +159,7 @@ gameRouter.post(
       return
     }
 
-    res.json({ success: true, data: { status: 'ended', endReason: 'inn' } })
+    res.json({ success: true, data: { status: 'ended', endReason: 'abandon' } })
   }
 )
 

--- a/apps/backend/src/services/chronicle.service.test.ts
+++ b/apps/backend/src/services/chronicle.service.test.ts
@@ -31,7 +31,7 @@ const character = {
 const baseSession = {
   id: 's1',
   turnNumber: 12,
-  endReason: 'inn',
+  endReason: 'abandon',
   locale: 'fr',
   character,
 }
@@ -102,7 +102,7 @@ describe('generateChronicle', () => {
         userId: 'user1',
         characterId: 'char1',
         sessionId: 's1',
-        endReason: 'inn',
+        endReason: 'abandon',
         title: validOutput.title,
         bodyMarkdown: validOutput.body_markdown,
         mood: validOutput.mood,

--- a/apps/backend/src/services/chronicle.service.ts
+++ b/apps/backend/src/services/chronicle.service.ts
@@ -53,7 +53,10 @@ function buildChroniclePrompt(context: ChronicleContext): string {
 
   const endReasonLabel: Record<ChronicleEndReason, string> = {
     death: 'Mort en cours de run',
-    inn: 'Choix de fin volontaire à l’auberge, face à L’Aveugle',
+    extracted:
+      'Retour à la surface avec l’objectif du contrat : le contrat est honoré, la prime est due',
+    returned_empty:
+      'Retour à la surface vivant mais les mains vides : le contrat n’est pas rempli, rien n’est payé',
     abandon: 'Abandon du personnage (inactivité ou clic explicite)',
     calcined:
       'Calamine à son comble : le personnage est devenu ce qu’il chassait, transformé en Calciné',

--- a/apps/backend/src/services/session.service.rest.test.ts
+++ b/apps/backend/src/services/session.service.rest.test.ts
@@ -240,7 +240,7 @@ describe('resolveTurn — rest_requested (#184)', () => {
     expect(data.energy).toBe(40)
     expect(data.hunger).toBe(40)
     expect(data.thirst).toBe(40)
-    expect(lastGameSessionUpdateData().endReason).not.toBe('inn')
+    expect(lastGameSessionUpdateData().endReason).toBeUndefined()
   })
 
   it('leaves survival untouched when the AI omits rest_requested', async () => {

--- a/apps/backend/src/services/session.service.ts
+++ b/apps/backend/src/services/session.service.ts
@@ -633,8 +633,8 @@ export async function performInventoryAction(
 }
 
 /**
- * Ends an active session with the given reason (`inn` or `abandon`) and
- * fires the Chronicle generation, mirroring the `death` path in `resolveTurn`.
+ * Ends an active session with the given reason and fires the Chronicle
+ * generation, mirroring the `death` path in `resolveTurn`.
  * Returns null if the session doesn't exist, isn't the caller's, or has
  * already ended — the route decides how to surface that.
  */
@@ -669,12 +669,18 @@ async function endSession(
 /**
  * Ends a session via the player's voluntary choice at the inn, facing
  * L'Aveugle ("Ton aventure se termine ici").
+ *
+ * Recorded as `abandon`, not as a return: this flow predates run contracts and
+ * ends the campaign on the player's initiative, without an objective to fulfil.
+ * The contract-aware endings (`extracted` / `returned_empty`) are produced by
+ * the return trip, wired in #228.
+ * @see docs/public/raw/23-RUN-STRUCTURE.md §5
  */
 export async function endSessionAtInn(
   sessionId: string,
   userId: string
 ): Promise<GameSession | null> {
-  return endSession(sessionId, userId, 'inn')
+  return endSession(sessionId, userId, 'abandon')
 }
 
 /**

--- a/apps/frontend/src/features/chronicle/api/chronicle-api.ts
+++ b/apps/frontend/src/features/chronicle/api/chronicle-api.ts
@@ -2,7 +2,7 @@ import type { ChronicleView, PublicChroniclePayload } from '../model/chronicle.t
 import type { ApiResponse, Chronicle } from '@grimoire/shared'
 
 const CHRONICLE_MOODS = new Set(['tragic', 'epic', 'melancholic', 'serene', 'absurd'])
-const END_REASONS = new Set(['death', 'inn', 'abandon'])
+const END_REASONS = new Set(['death', 'extracted', 'returned_empty', 'abandon', 'calcined'])
 
 function textOrFallback(value: string | undefined, fallback: string): string {
   const normalized = value?.trim()

--- a/apps/frontend/src/features/game-session/model/game-session.types.ts
+++ b/apps/frontend/src/features/game-session/model/game-session.types.ts
@@ -62,7 +62,7 @@ export interface GameSessionResponse {
 }
 
 export interface GameSessionEndResponse {
-  endReason: 'inn' | 'abandon'
+  endReason: SessionEndReason
   status: 'ended'
 }
 

--- a/docs/public/current-state/BACKEND_NEXT.md
+++ b/docs/public/current-state/BACKEND_NEXT.md
@@ -17,9 +17,18 @@ updated: 2026-08-06
 > `docs/public/raw/23-RUN-STRUCTURE.md`.
 
 1. [#214](https://github.com/AdamDjo/Grimoire-game/issues/214) — **boucle de run** : contrat,
-   paliers, demi-tour, trajet de retour. Inclut le scindement de `SessionEndReason`
-   (`inn` → `extracted` / `returned_empty`) avec migration des sessions existantes, le mode de jeu
-   porté par la session, et l'adaptation de `chronicle.service.ts` aux deux fins distinctes.
+   paliers, demi-tour, trajet de retour. Découpé en 4 lots :
+   - ~~[#226](https://github.com/AdamDjo/Grimoire-game/issues/226)~~ — contrats shared + scindement
+     de `SessionEndReason` : **livré**. Les 5 fins canoniques sont figées
+     (`death | extracted | returned_empty | abandon | calcined`), `run.types.ts` publie contrat,
+     paliers, salles, indices et estimation de retour. L'ancien `inn` est **remplacé**, pas renommé :
+     il était produit par la fin volontaire à l'auberge, sans contrat à honorer → migré en `abandon`.
+   - [#227](https://github.com/AdamDjo/Grimoire-game/issues/227) — `game-rules/dungeon.ts` et
+     `game-rules/run.ts` : génération des paliers, indices partiels, estimation du retour.
+   - [#228](https://github.com/AdamDjo/Grimoire-game/issues/228) — extension Prisma `GameSession`,
+     mode de jeu porté par la session, câblage dans `resolveTurn`.
+   - [#229](https://github.com/AdamDjo/Grimoire-game/issues/229) — frontend (domaine Codex),
+     débloqué par le merge de #226.
 2. [#215](https://github.com/AdamDjo/Grimoire-game/issues/215) — **moteur de combat par tours** :
    initiative, CA, tours, actions catégorisées, conditions, fuite dirigée, table de vérité de la
    mort. La spec est complète dans `docs/public/raw/10-COMBAT.md` — rien à concevoir, tout à

--- a/docs/public/current-state/BACKEND_STATUS.md
+++ b/docs/public/current-state/BACKEND_STATUS.md
@@ -5,7 +5,7 @@ rag: true
 source_of_truth: true
 owner: backend
 default_agent: claude
-updated: 2026-07-26
+updated: 2026-08-06
 ---
 
 # Backend Status
@@ -108,6 +108,23 @@ updated: 2026-07-26
   pour indisponibilité). ⚠️ Image non construite localement (daemon Docker indisponible) : correctif
   établi par lecture de la sortie `tsup` et des imports externes du bundle, à confirmer au premier
   build Coolify.
+- #226 (lot 1 de #214) — contrats partagés de la boucle de run. Nouveau
+  `packages/shared/src/types/run.types.ts` : `RunContract` (destination, profondeur 3/5/7 plafonnée
+  à 7, durée cible 45/90/150 min, prime due au retour), `DungeonFloor`/`Room`/`RoomHint`
+  (l'indice dit la **nature** du danger, jamais son **ampleur**), `ReturnEstimate` (salles et minutes
+  restantes, eau/vivres nécessaires, `suppliesShort`) et `RunState` (mode, profondeur courante et
+  max, demi-tour engagé, objectif sécurisé). `GameMode` (`inn | exploration | combat | return`)
+  est un **mode de jeu**, à ne pas confondre avec les fins de session ni avec le type de repos
+  `rest_requested.type: 'inn'` que le backend ignore volontairement.
+  `SessionEndReason` scindé en 5 valeurs canoniques —
+  `death | extracted | returned_empty | abandon | calcined`. L'ancien `inn` confondait « rentré
+  avec l'objectif » (payé) et « rentré les mains vides » (non payé) : il est **remplacé, pas
+  renommé**. Comme il n'était produit que par la fin volontaire à l'auberge, sans contrat à honorer,
+  les sessions existantes sont migrées en `abandon` (migration Supabase
+  `split_session_end_reason_run_structure` ; aucune ligne concernée en base à ce jour).
+  `ChronicleEndReason` suit par alias, et le prompt de Chronique distingue désormais les deux
+  retours. Les fins `extracted`/`returned_empty` sont **typées mais pas encore produites** : c'est
+  le trajet de retour (#228) qui les émettra. `@see docs/public/raw/23-RUN-STRUCTURE.md` §5.
 
 ## Pré-déploiement restant
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,7 @@ export * from "./types/quest.types";
 export * from "./types/inventory.types";
 export * from "./types/combat.types";
 export * from "./types/session.types";
+export * from "./types/run.types";
 export * from "./types/api.types";
 export * from "./types/souvenir.types";
 export * from "./types/chronicle.types";

--- a/packages/shared/src/types/run.types.ts
+++ b/packages/shared/src/types/run.types.ts
@@ -1,0 +1,151 @@
+/**
+ * Run structure contracts — the shape of a run: what the player sets out to do,
+ * how deep they go, and how they get back.
+ *
+ * @see docs/public/raw/23-RUN-STRUCTURE.md
+ */
+
+/**
+ * The four modes a run traverses, each with its own interface.
+ * `inn` here is a game mode (calm, tabular preparation), not an end reason.
+ * @see 23-RUN-STRUCTURE.md §6
+ */
+export type GameMode = "inn" | "exploration" | "combat" | "return";
+
+/**
+ * Contract depth in floors. The 7-floor ceiling is hard: no contract may
+ * exceed it, because run length is capped at 2h30 (01-PILLARS §2).
+ * @see 23-RUN-STRUCTURE.md §1
+ */
+export type ContractDepth = 3 | 5 | 7;
+
+/** Hard ceiling on generated floors. The engine cannot produce more. */
+export const MAX_CONTRACT_DEPTH = 7;
+
+/** Minimum depth a contract may target. */
+export const MIN_CONTRACT_DEPTH = 3;
+
+/**
+ * Target duration per depth, in minutes. Drives the honest estimate shown to
+ * the player when they accept a contract.
+ * @see 23-RUN-STRUCTURE.md §1
+ */
+export const CONTRACT_DURATION_MINUTES: Record<ContractDepth, number> = {
+  3: 45,
+  5: 90,
+  7: 150,
+};
+
+/**
+ * What the player accepts at the inn before setting out. A run is never
+ * "an adventure" — it has a destination, a depth, and a payout owed only on
+ * return.
+ * @see 23-RUN-STRUCTURE.md §1
+ */
+export interface RunContract {
+  id: string;
+  /** Location archetype the contract sends the player to. @see 03-BESTIARY.md */
+  destination: string;
+  targetDepth: ContractDepth;
+  /** Target duration in minutes, derived from `targetDepth`. */
+  targetDurationMinutes: number;
+  /** What the commissioner pays on a successful return, in iron (fer). */
+  rewardIron: number;
+  /** Player-facing description of what must be brought back. */
+  objective: string;
+}
+
+/** What a room holds. @see 23-RUN-STRUCTURE.md §2 */
+export type RoomType =
+  | "combat"
+  | "exploration"
+  | "encounter"
+  | "respite"
+  | "treasure"
+  | "boss";
+
+/**
+ * Partial clue shown before the player commits to a room.
+ *
+ * Rule of the hint: it tells the player the *nature* of what waits, never its
+ * *magnitude*. `kind` is what the character senses; `certainty` is how legible
+ * that sign is — never how dangerous.
+ * @see 23-RUN-STRUCTURE.md §2
+ */
+export interface RoomHint {
+  /** What the sign points to — danger, loot, rest, unknown. */
+  kind: "danger" | "loot" | "respite" | "unknown";
+  /** How readable the sign is. Never encodes magnitude. */
+  certainty: "clear" | "faint";
+  /** In-character phrasing of the sign ("Ça sent le sang froid"). */
+  label: string;
+}
+
+/** A single room within a floor. @see 23-RUN-STRUCTURE.md §2 */
+export interface Room {
+  id: string;
+  type: RoomType;
+  hint: RoomHint;
+  /** True once the player has entered and resolved this room. */
+  cleared: boolean;
+}
+
+/**
+ * One floor of the descent. Deeper floors are richer and deadlier — that curve
+ * is what creates the temptation to push on.
+ * @see 23-RUN-STRUCTURE.md §2
+ */
+export interface DungeonFloor {
+  /** 1-indexed depth. Never exceeds `MAX_CONTRACT_DEPTH`. */
+  depth: number;
+  rooms: Room[];
+  /** Rooms offered as the next step, by id. 2-3 entries. */
+  nextChoices: string[];
+}
+
+/** How risky the engine judges the return trip to be. */
+export type ReturnRisk = "safe" | "tight" | "critical";
+
+/**
+ * Honest estimate of the trip home, shown before *every* decision to descend.
+ * This is the mechanical guarantee behind the design rule: death must always be
+ * traceable to a decision the player saw coming.
+ * @see 23-RUN-STRUCTURE.md §3, §4
+ */
+export interface ReturnEstimate {
+  /** Rooms left to traverse to reach the surface from the current position. */
+  remainingRooms: number;
+  /** Estimated minutes to get back. */
+  estimatedMinutes: number;
+  /** Water rations the trip is expected to consume. */
+  waterNeeded: number;
+  /** Food rations the trip is expected to consume. */
+  foodNeeded: number;
+  risk: ReturnRisk;
+  /**
+   * True when current supplies no longer cover the return from this depth.
+   * Drives the in-character threshold warning — never a system popup.
+   * @see 23-RUN-STRUCTURE.md §4
+   */
+  suppliesShort: boolean;
+}
+
+/**
+ * Where the player stands in the run: how deep, how far along, and whether the
+ * trip home has been engaged.
+ * @see 23-RUN-STRUCTURE.md §3
+ */
+export interface RunState {
+  contract: RunContract;
+  mode: GameMode;
+  /** 1-indexed floor the player currently occupies. */
+  currentDepth: number;
+  /** Deepest floor reached this run. Persisted, and never decreases. */
+  maxDepthReached: number;
+  /** Id of the room being resolved, null between rooms. */
+  currentRoomId: string | null;
+  /** True once the player has committed to the turn back (§3). */
+  returnEngaged: boolean;
+  /** True when the contract objective has been secured. Decides `extracted`. */
+  objectiveSecured: boolean;
+}

--- a/packages/shared/src/types/session.types.ts
+++ b/packages/shared/src/types/session.types.ts
@@ -7,10 +7,26 @@ export type SessionStatus = "active" | "ended";
 
 /**
  * Why a session ended. Only bridge to the A3 narrative memory layer.
- * `calcined` = Calamine reached 100 (06-SURVIVAL §4) — the only ending
- * without heirloom inheritance transmission (09-ACTION-LOOP endReason table).
+ *
+ * - `extracted` — the player came back **with** the contract objective (paid).
+ * - `returned_empty` — the player came back alive but empty-handed (unpaid).
+ * - `death` — 0 HP, the AI narrates the unconsciousness (10-COMBAT §8).
+ * - `calcined` — Calamine reached 100 (06-SURVIVAL §4), the only ending
+ *   without heirloom inheritance transmission (09-ACTION-LOOP endReason table).
+ * - `abandon` — the player walked away voluntarily.
+ *
+ * The former `inn` value was replaced: it conflated "came home victorious" with
+ * "came home empty-handed", two endings that neither tell the same story nor
+ * pay the same. Sessions that ended through the old voluntary end-of-run flow
+ * are `abandon` — none of them ever had a contract to fulfil.
+ * @see docs/public/raw/23-RUN-STRUCTURE.md §5
  */
-export type SessionEndReason = "death" | "inn" | "abandon" | "calcined";
+export type SessionEndReason =
+  | "death"
+  | "extracted"
+  | "returned_empty"
+  | "abandon"
+  | "calcined";
 
 export interface WorldState {
   currentRegionId: string;


### PR DESCRIPTION
Lot 1 de l'EPIC #214 (boucle de run). Fige les contrats partagés de la structure de run et scinde `SessionEndReason`, pour débloquer #227, #228 et #229.

## Contrats partagés

Nouveau `packages/shared/src/types/run.types.ts` :

- `RunContract` — destination, profondeur (3/5/7, plafond dur à 7), durée cible (45/90/150 min), prime due **au retour** seulement.
- `DungeonFloor` / `Room` / `RoomHint` — l'indice dit la **nature** du danger, jamais son **ampleur** (règle de l'indice, §2).
- `ReturnEstimate` — salles et minutes restantes, eau/vivres nécessaires, `suppliesShort`. C'est la garantie mécanique derrière la règle de design : la mort doit toujours être imputable à une décision que le joueur a vue venir.
- `RunState` — mode, profondeur courante et max atteinte, demi-tour engagé, objectif sécurisé.

Chaque membre porte une référence `@see docs/public/raw/23-RUN-STRUCTURE.md §N`. Aucune constante provisoire.

## Scindement de `SessionEndReason`

```
death | inn | abandon | calcined
  →  death | extracted | returned_empty | abandon | calcined
```

Deux points à relire avec attention :

**1. `inn` est remplacé, pas renommé.** Le ticket annonçait `inn → returned_empty`. La lecture du code a montré que `inn` n'était produit que par la fin volontaire à l'auberge (« Ton aventure se termine ici »), sans contrat à honorer : le mapper vers un retour aurait inventé une histoire qui n'a pas eu lieu. Il devient donc `abandon`.

**2. `extracted` et `returned_empty` sont typées mais encore jamais produites.** Aucun code ne les émet aujourd'hui — c'est le trajet de retour (#228) qui les émettra. Le type est volontairement en avance sur le moteur ; ce n'est pas du gameplay livré.

## Migration

`split_session_end_reason_run_structure`, appliquée via MCP Supabase (la CLI `prisma migrate` est cassée sur ce projet). Vérification préalable en base : **aucune ligne `inn`** — la seule session terminée est `death`, `Chronicle` est vide. No-op ici, écrite pour l'historique et les autres environnements.

## Deux `inn` sans rapport — non touchés

- `rest_requested.type: 'inn'` (`scene-validator.ts`, `rest.ts`, `system-prompt.ts`) — type de repos que le backend ignore volontairement.
- `GameMode = 'inn'` — mode de jeu (auberge), pas une fin.
- `CampaignResumeStage = 'inn'` côté frontend.

## Consommateurs adaptés

`endSessionAtInn`, route `POST /session/end-inn`, mapping de prompt de `chronicle.service.ts` (les deux retours y sont décrits distinctement pour l'IA), fixtures de test, `chronicle-api.ts`, `game-session.types.ts`, commentaires du schéma Prisma.

## Vérification

- `pnpm type-check` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ — **523 tests** (410 backend, 113 frontend)

`BACKEND_STATUS.md` et `BACKEND_NEXT.md` mis à jour, avec le découpage de #214 en 4 lots.

Closes #226
