### PR TITLE
feat(#227): moteur de donjon et estimation de retour

### DIFF
--- a/apps/backend/src/game-rules/dungeon.test.ts
+++ b/apps/backend/src/game-rules/dungeon.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  countDescentRooms,
+  countReturnRooms,
+  generateDescent,
+  generateReturn,
+  RETURN_ROOMS_PER_FLOOR,
+  ROOMS_PER_FLOOR,
+} from './dungeon'
+
+import type { ContractDepth } from '@grimoire/shared'
+
+/** Deterministic rng cycling through fixed values, so draws are reproducible. */
+function seededRng(values: number[]): () => number {
+  let index = 0
+  return () => values[index++ % values.length]
+}
+
+const DEPTHS: ContractDepth[] = [3, 5, 7]
+
+describe('generateDescent', () => {
+  it.each(DEPTHS)('generates exactly %i floors for a contract of that depth', (depth) => {
+    const floors = generateDescent(depth, seededRng([0.1, 0.4, 0.7, 0.9]))
+    expect(floors).toHaveLength(depth)
+    expect(floors.map((floor) => floor.depth)).toEqual(
+      Array.from({ length: depth }, (_, index) => index + 1)
+    )
+  })
+
+  it('never exceeds 7 floors even when called with an out-of-range depth', () => {
+    // The 2h30 ceiling is structural: a bad runtime value cannot lengthen a run.
+    const floors = generateDescent(99 as ContractDepth, seededRng([0.5]))
+    expect(floors).toHaveLength(7)
+  })
+
+  it('fills every floor with the same number of rooms', () => {
+    const floors = generateDescent(5, seededRng([0.2, 0.6, 0.35, 0.8]))
+    for (const floor of floors) {
+      expect(floor.rooms).toHaveLength(ROOMS_PER_FLOOR)
+    }
+  })
+
+  it('offers 2 or 3 onward choices per floor, all pointing at rooms of that floor', () => {
+    const floors = generateDescent(7, seededRng([0.15, 0.55, 0.25, 0.95, 0.45]))
+    for (const floor of floors) {
+      expect(floor.nextChoices.length).toBeGreaterThanOrEqual(2)
+      expect(floor.nextChoices.length).toBeLessThanOrEqual(3)
+      const roomIds = floor.rooms.map((room) => room.id)
+      for (const choice of floor.nextChoices) {
+        expect(roomIds).toContain(choice)
+      }
+    }
+  })
+
+  it('gives every room a hint whose kind matches the room type', () => {
+    const floors = generateDescent(7, seededRng([0.05, 0.65, 0.3, 0.85, 0.5]))
+    const expectedKind = {
+      combat: 'danger',
+      boss: 'danger',
+      treasure: 'loot',
+      respite: 'respite',
+      exploration: 'unknown',
+      encounter: 'unknown',
+    } as const
+
+    for (const floor of floors) {
+      for (const room of floor.rooms) {
+        expect(room.hint.kind).toBe(expectedKind[room.type])
+        expect(room.hint.label.length).toBeGreaterThan(0)
+        expect(room.cleared).toBe(false)
+      }
+    }
+  })
+
+  it('never leaks magnitude through the hint: a boss reads exactly like any combat room', () => {
+    // Rule of the hint (§2): the sign says the nature of the danger, never how bad it is.
+    const floors = generateDescent(7, seededRng([0.9, 0.1, 0.4, 0.7]))
+    const bossHints = floors.flatMap((floor) =>
+      floor.rooms.filter((room) => room.type === 'boss').map((room) => room.hint)
+    )
+    const combatHints = floors.flatMap((floor) =>
+      floor.rooms.filter((room) => room.type === 'combat').map((room) => room.hint)
+    )
+
+    expect(bossHints.length).toBeGreaterThan(0)
+    for (const hint of bossHints) {
+      expect(hint.kind).toBe('danger')
+    }
+    for (const hint of combatHints) {
+      expect(hint.kind).toBe('danger')
+    }
+  })
+
+  it('places a boss only on deep floors, and only as the floor’s last room', () => {
+    const floors = generateDescent(7, seededRng([0.3, 0.6, 0.2, 0.8]))
+    for (const floor of floors) {
+      floor.rooms.forEach((room, index) => {
+        if (room.type !== 'boss') return
+        expect(floor.depth).toBeGreaterThanOrEqual(5)
+        expect(index).toBe(ROOMS_PER_FLOOR - 1)
+      })
+    }
+    // Floors 5+ end on a boss.
+    for (const floor of floors.filter((f) => f.depth >= 5)) {
+      expect(floor.rooms.at(-1)!.type).toBe('boss')
+    }
+  })
+
+  it('grows the share of hostile rooms with depth', () => {
+    // Same rng for both, so the difference comes from the depth bias alone.
+    const hostileShare = (depth: ContractDepth, floorIndex: number): number => {
+      const floors = generateDescent(depth, seededRng([0.35, 0.42, 0.55, 0.6]))
+      const rooms = floors[floorIndex].rooms
+      return rooms.filter((room) => room.type === 'combat' || room.type === 'treasure').length
+    }
+
+    expect(hostileShare(7, 6)).toBeGreaterThanOrEqual(hostileShare(7, 0))
+  })
+})
+
+describe('generateReturn', () => {
+  it.each([3, 5, 7])('climbs back through every floor from depth %i', (depth) => {
+    const floors = generateReturn(depth, seededRng([0.25, 0.75, 0.5]))
+    expect(floors.map((floor) => floor.depth)).toEqual(
+      Array.from({ length: depth }, (_, index) => depth - index)
+    )
+  })
+
+  it('is strictly shorter than the descent it undoes', () => {
+    // §4 "Plus court" — a return as long as the descent would be filler and would
+    // break the 2h30 cap.
+    for (const depth of [3, 5, 7]) {
+      const descentRooms = generateDescent(depth as ContractDepth, seededRng([0.4])).flatMap(
+        (floor) => floor.rooms
+      )
+      const returnRooms = generateReturn(depth, seededRng([0.4])).flatMap((floor) => floor.rooms)
+      expect(returnRooms.length).toBeLessThan(descentRooms.length)
+    }
+  })
+
+  it('is a distinct route, not the descent replayed backwards', () => {
+    const descentIds = new Set(
+      generateDescent(5, seededRng([0.4, 0.6])).flatMap((floor) =>
+        floor.rooms.map((room) => room.id)
+      )
+    )
+    const returnIds = generateReturn(5, seededRng([0.4, 0.6])).flatMap((floor) =>
+      floor.rooms.map((room) => room.id)
+    )
+
+    for (const id of returnIds) {
+      expect(descentIds.has(id)).toBe(false)
+    }
+  })
+
+  it('never places a boss on the way home — the return kills by attrition, not ambush', () => {
+    for (const seed of [
+      [0.9, 0.1],
+      [0.05, 0.95],
+      [0.5, 0.5],
+      [0.99, 0.99],
+    ]) {
+      const rooms = generateReturn(7, seededRng(seed)).flatMap((floor) => floor.rooms)
+      expect(rooms.some((room) => room.type === 'boss')).toBe(false)
+    }
+  })
+
+  it('caps the climb at 7 floors', () => {
+    expect(generateReturn(50, seededRng([0.5]))).toHaveLength(7)
+  })
+})
+
+describe('room counts', () => {
+  it('matches the generated descent and return lengths', () => {
+    for (const depth of [3, 5, 7] as ContractDepth[]) {
+      expect(countDescentRooms(depth)).toBe(
+        generateDescent(depth, seededRng([0.5])).flatMap((floor) => floor.rooms).length
+      )
+      expect(countReturnRooms(depth)).toBe(
+        generateReturn(depth, seededRng([0.5])).flatMap((floor) => floor.rooms).length
+      )
+    }
+  })
+
+  it('keeps the return cheaper than the descent, floor for floor', () => {
+    expect(RETURN_ROOMS_PER_FLOOR).toBeLessThan(ROOMS_PER_FLOOR)
+  })
+})

--- a/apps/backend/src/game-rules/dungeon.ts
+++ b/apps/backend/src/game-rules/dungeon.ts
@@ -1,0 +1,190 @@
+import {
+  type ContractDepth,
+  type DungeonFloor,
+  MAX_CONTRACT_DEPTH,
+  type Room,
+  type RoomHint,
+  type RoomType,
+} from '@grimoire/shared'
+
+/**
+ * Rooms traversed per floor on the way down. Constant across depths: what grows
+ * with depth is danger and reward, never length — the 2h30 ceiling is hard.
+ * @see docs/public/raw/23-RUN-STRUCTURE.md §1, §2
+ */
+export const ROOMS_PER_FLOOR = 3
+
+/**
+ * Rooms traversed per floor on the way back. Strictly lower than
+ * `ROOMS_PER_FLOOR`: the return is "nettement plus rapide que la descente"
+ * because replaying seen ground would be filler and would break the 2h30 cap.
+ * @see 23-RUN-STRUCTURE.md §4
+ */
+export const RETURN_ROOMS_PER_FLOOR = 1
+
+/**
+ * Minutes budgeted per room, used by the return estimate.
+ *
+ * Calibrated against the canon duration table rather than picked round: the
+ * shortest contract is the binding one, at 3 floors × 3 rooms of descent plus
+ * 3 rooms of return = 12 rooms for its ~45 min target. Deeper contracts then
+ * land under their own targets (5 floors ≈ 75 min ≤ 90, 7 floors ≈ 105 ≤ 150),
+ * which is what the table asks — those are ceilings, not quotas to fill.
+ * @see docs/public/raw/23-RUN-STRUCTURE.md §1 "Barème de durée"
+ */
+export const MINUTES_PER_ROOM = 3.75
+
+/** A boss locks the far end of deep floors. @see 23-RUN-STRUCTURE.md §2 */
+const BOSS_FLOOR_THRESHOLD = 5
+
+/**
+ * Room types offered on the way down, ordered from safest to most hostile.
+ * `boss` is absent on purpose: it is placed by depth, never drawn at random.
+ */
+const DESCENT_ROOM_TYPES: readonly RoomType[] = [
+  'exploration',
+  'encounter',
+  'respite',
+  'treasure',
+  'combat',
+]
+
+/**
+ * In-character phrasings per hint kind. Several per kind so repeated rooms do
+ * not read identically. Each says what the sign *is*, never how bad it gets.
+ * @see 23-RUN-STRUCTURE.md §2
+ */
+const HINT_LABELS: Record<RoomHint['kind'], readonly string[]> = {
+  danger: ['Ça sent le sang froid', 'Des marques griffées', 'Un silence qui ne tient pas'],
+  loot: ['Un reflet de métal', 'Des sacs éventrés', 'Quelque chose brille au fond'],
+  respite: ['Un courant d’air sec', 'De l’eau qui goutte, régulière', 'Une odeur de cendre froide'],
+  unknown: ['Le passage s’enfonce', 'Rien ne se lit d’ici', 'L’obscurité avale le seuil'],
+}
+
+/** Which kind of sign a room type gives off. */
+const HINT_KIND_BY_ROOM: Record<RoomType, RoomHint['kind']> = {
+  combat: 'danger',
+  boss: 'danger',
+  treasure: 'loot',
+  respite: 'respite',
+  exploration: 'unknown',
+  encounter: 'unknown',
+}
+
+/** Picks one element from a non-empty list. */
+function pick<T>(items: readonly T[], rng: () => number): T {
+  return items[Math.floor(rng() * items.length)]
+}
+
+/**
+ * Weight of hostile room types, rising with depth. Deeper floors are "plus
+ * dangereux et plus riches" — that curve is what creates the temptation to
+ * push on one more floor.
+ * @see 23-RUN-STRUCTURE.md §2
+ */
+function hostileBias(depth: number): number {
+  return Math.min(0.15 + depth * 0.1, 0.75)
+}
+
+/** Draws a room type for a floor, biased toward hostility as depth grows. */
+function rollRoomType(depth: number, rng: () => number): RoomType {
+  if (rng() < hostileBias(depth)) {
+    return rng() < 0.5 ? 'combat' : 'treasure'
+  }
+  return pick(DESCENT_ROOM_TYPES, rng)
+}
+
+/**
+ * Builds the partial clue shown before the player commits to a room.
+ *
+ * **Rule of the hint**: it reveals the *nature* of what waits, never its
+ * *magnitude*. `certainty` says how legible the sign is — a `boss` and a lone
+ * scavenger both read as `danger`, and nothing in the hint separates them.
+ * That ambiguity is the point: the player chooses informed, not solved.
+ * @see 23-RUN-STRUCTURE.md §2
+ */
+function buildHint(type: RoomType, rng: () => number): RoomHint {
+  const kind = HINT_KIND_BY_ROOM[type]
+  return {
+    kind,
+    certainty: rng() < 0.5 ? 'clear' : 'faint',
+    label: pick(HINT_LABELS[kind], rng),
+  }
+}
+
+function buildRoom(id: string, type: RoomType, rng: () => number): Room {
+  return { id, type, hint: buildHint(type, rng), cleared: false }
+}
+
+/**
+ * Generates the floors of a descent for a contract.
+ *
+ * The 7-floor ceiling is structural, not a validation: `targetDepth` is typed
+ * as `ContractDepth` and clamped here too, so the engine cannot produce a run
+ * longer than the 2h30 cap even if called with a bad value at runtime.
+ * @see 23-RUN-STRUCTURE.md §1, §2, §9
+ */
+export function generateDescent(
+  targetDepth: ContractDepth,
+  rng: () => number = Math.random
+): DungeonFloor[] {
+  const depth = Math.min(targetDepth, MAX_CONTRACT_DEPTH)
+  const floors: DungeonFloor[] = []
+
+  for (let level = 1; level <= depth; level++) {
+    const rooms: Room[] = []
+
+    for (let index = 0; index < ROOMS_PER_FLOOR; index++) {
+      const isLastRoom = index === ROOMS_PER_FLOOR - 1
+      // A boss seals the deep floors, and only ever the floor's last room.
+      const type = isLastRoom && level >= BOSS_FLOOR_THRESHOLD ? 'boss' : rollRoomType(level, rng)
+      rooms.push(buildRoom(`f${level}-r${index + 1}`, type, rng))
+    }
+
+    floors.push({
+      depth: level,
+      rooms,
+      // 2-3 onward choices, the most frequent gesture of the game.
+      nextChoices: rooms.slice(0, rng() < 0.5 ? 2 : 3).map((room) => room.id),
+    })
+  }
+
+  return floors
+}
+
+/**
+ * Generates the trip home from `fromDepth`.
+ *
+ * Two canon properties hold by construction: the route is **distinct** (fresh
+ * room ids and freshly drawn types — never the descent replayed backwards) and
+ * **strictly shorter**, since `RETURN_ROOMS_PER_FLOOR < ROOMS_PER_FLOOR`.
+ * Floors come back in ascending order, the player climbing toward the surface.
+ * @see 23-RUN-STRUCTURE.md §4
+ */
+export function generateReturn(fromDepth: number, rng: () => number = Math.random): DungeonFloor[] {
+  const depth = Math.min(fromDepth, MAX_CONTRACT_DEPTH)
+  const floors: DungeonFloor[] = []
+
+  for (let level = depth; level >= 1; level--) {
+    const rooms: Room[] = []
+
+    for (let index = 0; index < RETURN_ROOMS_PER_FLOOR; index++) {
+      // No boss on the way back: the return kills by attrition, never by ambush.
+      rooms.push(buildRoom(`r${level}-r${index + 1}`, rollRoomType(level, rng), rng))
+    }
+
+    floors.push({ depth: level, rooms, nextChoices: rooms.map((room) => room.id) })
+  }
+
+  return floors
+}
+
+/** Total rooms of a descent down to `depth`. */
+export function countDescentRooms(depth: number): number {
+  return Math.min(depth, MAX_CONTRACT_DEPTH) * ROOMS_PER_FLOOR
+}
+
+/** Total rooms of the trip home from `depth`. */
+export function countReturnRooms(depth: number): number {
+  return Math.min(depth, MAX_CONTRACT_DEPTH) * RETURN_ROOMS_PER_FLOOR
+}

--- a/apps/backend/src/game-rules/run.test.ts
+++ b/apps/backend/src/game-rules/run.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from 'vitest'
+
+import { MINUTES_PER_ROOM } from './dungeon'
+import {
+  ascend,
+  canDescend,
+  computeReturnEstimate,
+  createContract,
+  createRunState,
+  descend,
+  detectReturnWarnings,
+  engageReturn,
+  estimateRemainingMinutes,
+  hasReachedSurface,
+  isValidContractDepth,
+  RETURN_SAFETY_MARGIN,
+  WATER_PER_RETURN_ROOM,
+} from './run'
+
+import type { ContractDepth, RunState } from '@grimoire/shared'
+
+function contract(targetDepth: ContractDepth = 5) {
+  return createContract({
+    id: 'contract-1',
+    destination: 'Les Salines Basses',
+    targetDepth,
+    rewardIron: 120,
+    objective: 'Rapporter le sceau du contremaître',
+  })
+}
+
+/** Run state sitting at `depth`, having descended there normally. */
+function atDepth(depth: number, targetDepth: ContractDepth = 7): RunState {
+  let state = createRunState(contract(targetDepth))
+  for (let i = 0; i < depth; i++) state = descend(state)
+  return state
+}
+
+describe('createContract', () => {
+  it.each([
+    [3, 45],
+    [5, 90],
+    [7, 150],
+  ])('derives the target duration from depth %i → %i minutes', (depth, minutes) => {
+    expect(
+      createContract({
+        id: 'c',
+        destination: 'd',
+        targetDepth: depth as ContractDepth,
+        rewardIron: 10,
+        objective: 'o',
+      }).targetDurationMinutes
+    ).toBe(minutes)
+  })
+})
+
+describe('isValidContractDepth', () => {
+  it('accepts only the three canon depths', () => {
+    expect(isValidContractDepth(3)).toBe(true)
+    expect(isValidContractDepth(5)).toBe(true)
+    expect(isValidContractDepth(7)).toBe(true)
+    expect(isValidContractDepth(4)).toBe(false)
+    expect(isValidContractDepth(8)).toBe(false)
+    expect(isValidContractDepth(0)).toBe(false)
+  })
+})
+
+describe('descent', () => {
+  it('starts at the surface with nothing secured', () => {
+    const state = createRunState(contract(5))
+    expect(state.currentDepth).toBe(0)
+    expect(state.maxDepthReached).toBe(0)
+    expect(state.returnEngaged).toBe(false)
+    expect(state.objectiveSecured).toBe(false)
+  })
+
+  it('stops at the contract depth', () => {
+    const state = atDepth(5, 5)
+    expect(state.currentDepth).toBe(5)
+    expect(canDescend(state)).toBe(false)
+    expect(descend(state)).toBe(state)
+  })
+
+  it('never goes past the 7-floor ceiling, whatever the contract claims', () => {
+    // Structural guarantee of the 2h30 cap, independent of the ContractDepth type.
+    let state = createRunState({ ...contract(7), targetDepth: 99 as ContractDepth })
+    for (let i = 0; i < 20; i++) state = descend(state)
+    expect(state.currentDepth).toBe(7)
+    expect(canDescend(state)).toBe(false)
+  })
+
+  it('remembers the deepest point reached after turning back', () => {
+    const state = ascend(ascend(engageReturn(atDepth(4))))
+    expect(state.currentDepth).toBe(2)
+    expect(state.maxDepthReached).toBe(4)
+  })
+})
+
+describe('engageReturn', () => {
+  it('switches the run to return mode and forbids descending again', () => {
+    const state = engageReturn(atDepth(3))
+    expect(state.mode).toBe('return')
+    expect(state.returnEngaged).toBe(true)
+    expect(canDescend(state)).toBe(false)
+    expect(descend(state)).toBe(state)
+  })
+
+  it('is idempotent', () => {
+    const once = engageReturn(atDepth(3))
+    expect(engageReturn(once)).toBe(once)
+  })
+
+  it('reaches the surface after climbing every floor', () => {
+    let state = engageReturn(atDepth(3))
+    expect(hasReachedSurface(state)).toBe(false)
+    for (let i = 0; i < 3; i++) state = ascend(state)
+    expect(state.currentDepth).toBe(0)
+    expect(hasReachedSurface(state)).toBe(true)
+  })
+
+  it('does not climb before the player turned back', () => {
+    const state = atDepth(3)
+    expect(ascend(state)).toBe(state)
+  })
+})
+
+describe('computeReturnEstimate', () => {
+  it('costs more the deeper the player stands', () => {
+    const supplies = { water: 10, food: 10 }
+    const shallow = computeReturnEstimate(atDepth(2), supplies)
+    const deep = computeReturnEstimate(atDepth(6), supplies)
+
+    expect(deep.remainingRooms).toBeGreaterThan(shallow.remainingRooms)
+    expect(deep.estimatedMinutes).toBeGreaterThan(shallow.estimatedMinutes)
+    expect(deep.waterNeeded).toBeGreaterThan(shallow.waterNeeded)
+  })
+
+  it('reports minutes consistent with the rooms left to cross', () => {
+    const estimate = computeReturnEstimate(atDepth(4), { water: 10, food: 10 })
+    // Rounded up, so the panel never undersells how long getting home takes.
+    expect(estimate.estimatedMinutes).toBe(Math.ceil(estimate.remainingRooms * MINUTES_PER_ROOM))
+    expect(Number.isInteger(estimate.estimatedMinutes)).toBe(true)
+  })
+
+  it('includes a safety margin on top of the strict need', () => {
+    const state = atDepth(3)
+    const estimate = computeReturnEstimate(state, { water: 10, food: 10 })
+    expect(estimate.waterNeeded).toBe(
+      estimate.remainingRooms * WATER_PER_RETURN_ROOM + RETURN_SAFETY_MARGIN
+    )
+  })
+
+  it('rates the return safe when supplies cover the need with margin', () => {
+    const estimate = computeReturnEstimate(atDepth(3), { water: 20, food: 20 })
+    expect(estimate.risk).toBe('safe')
+    expect(estimate.suppliesShort).toBe(false)
+  })
+
+  it('rates the return tight when supplies fall just under the need', () => {
+    const state = atDepth(3)
+    const needed = computeReturnEstimate(state, { water: 99, food: 99 })
+    const estimate = computeReturnEstimate(state, {
+      water: needed.waterNeeded - 1,
+      food: needed.foodNeeded,
+    })
+    expect(estimate.risk).toBe('tight')
+    expect(estimate.suppliesShort).toBe(true)
+  })
+
+  it('rates the return critical when supplies cover less than half the need', () => {
+    const state = atDepth(6)
+    const estimate = computeReturnEstimate(state, { water: 1, food: 1 })
+    expect(estimate.risk).toBe('critical')
+    expect(estimate.suppliesShort).toBe(true)
+  })
+
+  it('lets the scarcest supply drive the risk', () => {
+    // Plenty of food does not save a player who runs out of water on the climb.
+    const estimate = computeReturnEstimate(atDepth(6), { water: 1, food: 99 })
+    expect(estimate.risk).toBe('critical')
+  })
+
+  it('costs nothing at the surface', () => {
+    const estimate = computeReturnEstimate(createRunState(contract(5)), { water: 0, food: 0 })
+    expect(estimate.remainingRooms).toBe(0)
+    expect(estimate.estimatedMinutes).toBe(0)
+    expect(estimate.risk).toBe('safe')
+  })
+})
+
+describe('estimateRemainingMinutes', () => {
+  it('counts the floors still to descend plus the trip home', () => {
+    const start = createRunState(contract(3))
+    const halfway = atDepth(2, 3)
+    expect(estimateRemainingMinutes(start)).toBeGreaterThan(estimateRemainingMinutes(halfway))
+  })
+
+  it('drops to the return cost alone once the player turned back', () => {
+    const state = engageReturn(atDepth(4, 7))
+    const estimate = computeReturnEstimate(state, { water: 10, food: 10 })
+    expect(estimateRemainingMinutes(state)).toBe(estimate.estimatedMinutes)
+  })
+
+  it('stays inside the contract duration budget at the start of a run', () => {
+    for (const depth of [3, 5, 7] as ContractDepth[]) {
+      const state = createRunState(contract(depth))
+      expect(estimateRemainingMinutes(state)).toBeLessThanOrEqual(
+        state.contract.targetDurationMinutes
+      )
+    }
+  })
+})
+
+describe('detectReturnWarnings', () => {
+  it('warns the turn a supply drops under what getting home costs', () => {
+    const state = atDepth(5)
+    const needed = computeReturnEstimate(state, { water: 99, food: 99 })
+
+    const warnings = detectReturnWarnings(
+      state,
+      { water: needed.waterNeeded, food: 99 },
+      { water: needed.waterNeeded - 1, food: 99 }
+    )
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].supply).toBe('water')
+    expect(warnings[0].needed).toBe(needed.waterNeeded)
+    expect(warnings[0].carried).toBe(needed.waterNeeded - 1)
+  })
+
+  it('warns for food on its own threshold', () => {
+    const state = atDepth(5)
+    const needed = computeReturnEstimate(state, { water: 99, food: 99 })
+
+    const warnings = detectReturnWarnings(
+      state,
+      { water: 99, food: needed.foodNeeded },
+      { water: 99, food: needed.foodNeeded - 1 }
+    )
+
+    expect(warnings.map((warning) => warning.supply)).toEqual(['food'])
+  })
+
+  it('warns for both supplies when both cross on the same turn', () => {
+    const state = atDepth(5)
+    const needed = computeReturnEstimate(state, { water: 99, food: 99 })
+
+    const warnings = detectReturnWarnings(
+      state,
+      { water: needed.waterNeeded, food: needed.foodNeeded },
+      { water: 0, food: 0 }
+    )
+
+    expect(warnings.map((warning) => warning.supply).sort()).toEqual(['food', 'water'])
+  })
+
+  it('stays silent while supplies still cover the trip home', () => {
+    const state = atDepth(3)
+    expect(detectReturnWarnings(state, { water: 30, food: 30 }, { water: 29, food: 29 })).toEqual(
+      []
+    )
+  })
+
+  it('does not repeat itself once the supply is already short', () => {
+    // The warning must keep its weight — it is not per-turn noise.
+    const state = atDepth(5)
+    expect(detectReturnWarnings(state, { water: 1, food: 1 }, { water: 0, food: 0 })).toEqual([])
+  })
+
+  it('warns when descending alone makes the trip home unaffordable', () => {
+    // The player spent nothing this turn: the threshold moved, not the supply.
+    const before = atDepth(3)
+    const after = descend(before)
+    const needAfter = computeReturnEstimate(after, { water: 99, food: 99 })
+    const needBefore = computeReturnEstimate(before, { water: 99, food: 99 })
+    const carried = { water: needBefore.waterNeeded, food: 99 }
+
+    expect(needAfter.waterNeeded).toBeGreaterThan(needBefore.waterNeeded)
+
+    const warnings = detectReturnWarnings(after, carried, carried, before)
+    expect(warnings.map((warning) => warning.supply)).toContain('water')
+  })
+
+  it('carries the resulting risk level so the prompt can pitch the warning', () => {
+    // §4.2 — this lot produces the data; the AI prompt phrases it in character.
+    const state = atDepth(6)
+    const needed = computeReturnEstimate(state, { water: 99, food: 99 })
+    const warnings = detectReturnWarnings(
+      state,
+      { water: needed.waterNeeded, food: 99 },
+      { water: 0, food: 99 }
+    )
+
+    expect(warnings[0].risk).toBe('critical')
+  })
+})

--- a/apps/backend/src/game-rules/run.ts
+++ b/apps/backend/src/game-rules/run.ts
@@ -1,0 +1,259 @@
+import {
+  type ContractDepth,
+  CONTRACT_DURATION_MINUTES,
+  MAX_CONTRACT_DEPTH,
+  MIN_CONTRACT_DEPTH,
+  type ReturnEstimate,
+  type ReturnRisk,
+  type RunContract,
+  type RunState,
+} from '@grimoire/shared'
+
+import { countReturnRooms, MINUTES_PER_ROOM, ROOMS_PER_FLOOR } from './dungeon'
+
+/**
+ * Water rations consumed per room on the way back. Water leads the survival
+ * pressure in this setting (desert, salt roads), so it is the gauge that
+ * usually crosses its threshold first.
+ * @see docs/public/raw/06-SURVIVAL.md §1, 23-RUN-STRUCTURE.md §4
+ */
+export const WATER_PER_RETURN_ROOM = 1
+
+/**
+ * Food rations consumed per room on the way back. Lower than water: hunger
+ * degrades more slowly than thirst.
+ * @see 06-SURVIVAL.md §1
+ */
+export const FOOD_PER_RETURN_ROOM = 0.5
+
+/**
+ * Safety margin applied on top of the strict need, in rations. The estimate
+ * errs on the side of caution: a run that dies on the way home must die from a
+ * decision the player saw, never from an estimate that was optimistic.
+ * @see 23-RUN-STRUCTURE.md §4 "Le retour peut tuer, mais jamais par surprise"
+ */
+export const RETURN_SAFETY_MARGIN = 1
+
+/**
+ * Supply ratio below which the trip home is `critical`, then `tight`. Above
+ * `TIGHT_RATIO` the player carries the strict need plus the margin, so the
+ * return reads as `safe`.
+ */
+const CRITICAL_RATIO = 0.5
+const TIGHT_RATIO = 1
+
+/** Rations carried, as counted from the character's inventory by the caller. */
+export interface CarriedSupplies {
+  water: number
+  food: number
+}
+
+/** Builds the run contract accepted at the inn. @see 23-RUN-STRUCTURE.md §1 */
+export function createContract(params: {
+  id: string
+  destination: string
+  targetDepth: ContractDepth
+  rewardIron: number
+  objective: string
+}): RunContract {
+  return {
+    id: params.id,
+    destination: params.destination,
+    targetDepth: params.targetDepth,
+    targetDurationMinutes: CONTRACT_DURATION_MINUTES[params.targetDepth],
+    rewardIron: params.rewardIron,
+    objective: params.objective,
+  }
+}
+
+/** Opening state of a run: at the mouth of the dungeon, nothing secured yet. */
+export function createRunState(contract: RunContract): RunState {
+  return {
+    contract,
+    mode: 'exploration',
+    currentDepth: 0,
+    maxDepthReached: 0,
+    currentRoomId: null,
+    returnEngaged: false,
+    objectiveSecured: false,
+  }
+}
+
+/**
+ * Whether the player may descend one more floor.
+ *
+ * The 7-floor ceiling is enforced here as a rule, not only as a type: the
+ * engine structurally cannot produce a run past `MAX_CONTRACT_DEPTH`, whatever
+ * the contract asked for. Once the return is engaged, descending is over.
+ * @see 23-RUN-STRUCTURE.md §1, §3
+ */
+export function canDescend(state: RunState): boolean {
+  if (state.returnEngaged) return false
+  return state.currentDepth < Math.min(state.contract.targetDepth, MAX_CONTRACT_DEPTH)
+}
+
+/** Descends one floor, tracking the deepest point reached. No-op if forbidden. */
+export function descend(state: RunState): RunState {
+  if (!canDescend(state)) return state
+  const currentDepth = state.currentDepth + 1
+  return {
+    ...state,
+    currentDepth,
+    maxDepthReached: Math.max(state.maxDepthReached, currentDepth),
+    currentRoomId: null,
+  }
+}
+
+/**
+ * Turns back. Irreversible: once climbing, the player does not descend again —
+ * the arbitrage was made and the run commits to it.
+ * @see 23-RUN-STRUCTURE.md §3, §4
+ */
+export function engageReturn(state: RunState): RunState {
+  if (state.returnEngaged) return state
+  return { ...state, returnEngaged: true, mode: 'return', currentRoomId: null }
+}
+
+/** Climbs one floor on the way home, bottoming out at the surface. */
+export function ascend(state: RunState): RunState {
+  if (!state.returnEngaged) return state
+  return { ...state, currentDepth: Math.max(0, state.currentDepth - 1), currentRoomId: null }
+}
+
+/** True once the player has climbed back out. */
+export function hasReachedSurface(state: RunState): boolean {
+  return state.returnEngaged && state.currentDepth === 0
+}
+
+/**
+ * Computes the honest cost of getting home from the current depth.
+ *
+ * This is the data behind the panel shown before *every* descend decision
+ * (§4.1). It is deliberately conservative — `RETURN_SAFETY_MARGIN` is added to
+ * the strict need — so that a player who reads `safe` and dies anyway would be
+ * a bug, not a difficulty setting.
+ * @see 23-RUN-STRUCTURE.md §3, §4
+ */
+export function computeReturnEstimate(state: RunState, supplies: CarriedSupplies): ReturnEstimate {
+  const remainingRooms = countReturnRooms(state.currentDepth)
+
+  // At the surface there is no trip left to pay for: the margin would otherwise
+  // report a player carrying nothing as being in danger of not getting home.
+  if (remainingRooms === 0) {
+    return {
+      remainingRooms: 0,
+      estimatedMinutes: 0,
+      waterNeeded: 0,
+      foodNeeded: 0,
+      risk: 'safe',
+      suppliesShort: false,
+    }
+  }
+
+  const waterNeeded = remainingRooms * WATER_PER_RETURN_ROOM + RETURN_SAFETY_MARGIN
+  const foodNeeded = Math.ceil(remainingRooms * FOOD_PER_RETURN_ROOM) + RETURN_SAFETY_MARGIN
+
+  // The scarcest of the two gauges drives the risk: carrying plenty of food
+  // does not help a player who runs out of water three rooms from the exit.
+  const waterRatio = waterNeeded === 0 ? Infinity : supplies.water / waterNeeded
+  const foodRatio = foodNeeded === 0 ? Infinity : supplies.food / foodNeeded
+  const ratio = Math.min(waterRatio, foodRatio)
+
+  let risk: ReturnRisk = 'safe'
+  if (ratio < CRITICAL_RATIO) risk = 'critical'
+  else if (ratio < TIGHT_RATIO) risk = 'tight'
+
+  return {
+    remainingRooms,
+    // Rounded up: the estimate shown to the player never undersells the trip.
+    estimatedMinutes: Math.ceil(remainingRooms * MINUTES_PER_ROOM),
+    waterNeeded,
+    foodNeeded,
+    risk,
+    suppliesShort: supplies.water < waterNeeded || supplies.food < foodNeeded,
+  }
+}
+
+/**
+ * Estimated minutes for the whole run left, descent included. Feeds the
+ * duration honesty of the contract: the player picked an evening's length and
+ * the engine must keep telling them where they stand against it.
+ * @see 23-RUN-STRUCTURE.md §1
+ */
+export function estimateRemainingMinutes(state: RunState): number {
+  const target = Math.min(state.contract.targetDepth, MAX_CONTRACT_DEPTH)
+  const floorsLeftToDescend = state.returnEngaged ? 0 : Math.max(0, target - state.currentDepth)
+  const deepestPoint = state.returnEngaged ? state.currentDepth : target
+
+  return Math.ceil(
+    (floorsLeftToDescend * ROOMS_PER_FLOOR + countReturnRooms(deepestPoint)) * MINUTES_PER_ROOM
+  )
+}
+
+/** Which supply crossed under what the trip home requires. */
+export type SupplyThreshold = 'water' | 'food'
+
+/**
+ * A threshold crossing: the moment a resource drops under what getting home
+ * costs. This is the trigger of the canon warning — the engine produces the
+ * fact, the AI prompt phrases it in character language at injection time.
+ * @see 23-RUN-STRUCTURE.md §4.2
+ */
+export interface ReturnWarning {
+  supply: SupplyThreshold
+  /** Rations left right now. */
+  carried: number
+  /** Rations the trip home costs from the current depth. */
+  needed: number
+  /** Risk level of the return once this supply ran short. */
+  risk: ReturnRisk
+}
+
+/**
+ * Detects supplies that crossed *this turn* under the return requirement.
+ *
+ * Only genuine crossings are reported: a supply that was already short before
+ * the turn does not warn again, so the message keeps its weight instead of
+ * becoming per-turn noise. The warning is guaranteed — any supply that goes
+ * from sufficient to insufficient produces one entry, which is what makes
+ * "jamais par surprise" a property of the engine rather than of the writing.
+ * @see 23-RUN-STRUCTURE.md §4.2
+ */
+export function detectReturnWarnings(
+  state: RunState,
+  before: CarriedSupplies,
+  after: CarriedSupplies,
+  previousState: RunState = state
+): ReturnWarning[] {
+  // Compared against the cost as it stood *before* the turn: a supply can cross
+  // the line without being spent at all, simply because descending one more
+  // floor made the trip home more expensive. That crossing must warn too.
+  const previousEstimate = computeReturnEstimate(previousState, before)
+  const estimate = computeReturnEstimate(state, after)
+  const warnings: ReturnWarning[] = []
+
+  if (before.water >= previousEstimate.waterNeeded && after.water < estimate.waterNeeded) {
+    warnings.push({
+      supply: 'water',
+      carried: after.water,
+      needed: estimate.waterNeeded,
+      risk: estimate.risk,
+    })
+  }
+
+  if (before.food >= previousEstimate.foodNeeded && after.food < estimate.foodNeeded) {
+    warnings.push({
+      supply: 'food',
+      carried: after.food,
+      needed: estimate.foodNeeded,
+      risk: estimate.risk,
+    })
+  }
+
+  return warnings
+}
+
+/** Guards a contract depth coming from the outside world. @see 23-RUN-STRUCTURE.md §1 */
+export function isValidContractDepth(depth: number): depth is ContractDepth {
+  return depth === MIN_CONTRACT_DEPTH || depth === 5 || depth === MAX_CONTRACT_DEPTH
+}

--- a/docs/public/current-state/BACKEND_NEXT.md
+++ b/docs/public/current-state/BACKEND_NEXT.md
@@ -23,8 +23,11 @@ updated: 2026-08-06
      (`death | extracted | returned_empty | abandon | calcined`), `run.types.ts` publie contrat,
      paliers, salles, indices et estimation de retour. L'ancien `inn` est **remplacé**, pas renommé :
      il était produit par la fin volontaire à l'auberge, sans contrat à honorer → migré en `abandon`.
-   - [#227](https://github.com/AdamDjo/Grimoire-game/issues/227) — `game-rules/dungeon.ts` et
-     `game-rules/run.ts` : génération des paliers, indices partiels, estimation du retour.
+   - ~~[#227](https://github.com/AdamDjo/Grimoire-game/issues/227)~~ — `game-rules/dungeon.ts` et
+     `game-rules/run.ts` : **livré**. Paliers plafonnés structurellement à 7, indices partiels qui
+     ne trahissent jamais l'ampleur, retour distinct et strictement plus court, estimation de
+     retour et détection de franchissement de seuil. Règles pures, sans Prisma. Reste à câbler :
+     la formulation en langage de personnage de l'avertissement (§4.2) revient à #228.
    - [#228](https://github.com/AdamDjo/Grimoire-game/issues/228) — extension Prisma `GameSession`,
      mode de jeu porté par la session, câblage dans `resolveTurn`.
    - [#229](https://github.com/AdamDjo/Grimoire-game/issues/229) — frontend (domaine Codex),

--- a/docs/public/current-state/BACKEND_STATUS.md
+++ b/docs/public/current-state/BACKEND_STATUS.md
@@ -125,6 +125,25 @@ updated: 2026-08-06
   `ChronicleEndReason` suit par alias, et le prompt de Chronique distingue désormais les deux
   retours. Les fins `extracted`/`returned_empty` sont **typées mais pas encore produites** : c'est
   le trajet de retour (#228) qui les émettra. `@see docs/public/raw/23-RUN-STRUCTURE.md` §5.
+- #227 (lot 2 de #214) — moteur de donjon et estimation de retour, en règles pures
+  (`game-rules/dungeon.ts` et `game-rules/run.ts`, zéro Prisma, `rng` injectable comme `dice.ts`).
+  `generateDescent` produit 3 salles par palier avec indice partiel et 2-3 suites au choix ; le
+  plafond de 7 paliers est **structurel** (clampé même sur une valeur hors barème), garant du
+  plafond dur de 2h30. La part de salles hostiles croît avec la profondeur, et un boss verrouille
+  la dernière salle des paliers 5+ — sans que l'indice le distingue d'un combat ordinaire
+  (règle de l'indice, §2). `generateReturn` génère un trajet **distinct** (identifiants et types
+  retirés à neuf, jamais la descente à l'envers) et **strictement plus court**
+  (1 salle par palier contre 3), sans boss : le retour tue par épuisement, jamais par embuscade.
+  `MINUTES_PER_ROOM = 3.75` est calibré sur le barème canon plutôt que choisi rond — le contrat
+  3 paliers est le contraignant (12 salles ≈ 45 min), les contrats plus profonds restant sous
+  leur propre cible (5 paliers ≈ 75 min, 7 paliers ≈ 105 min).
+  `computeReturnEstimate` chiffre salles, minutes, eau et vivres nécessaires plus un
+  `RETURN_SAFETY_MARGIN` d'une ration : la ressource la plus rare pilote le risque
+  (`safe | tight | critical`). `detectReturnWarnings` détecte le **franchissement** de seuil, y
+  compris quand c'est la descente — et non la consommation — qui rend le retour inabordable ; une
+  ressource déjà courte ne réalerte pas, pour que l'avertissement garde son poids. Ce lot produit
+  **la donnée, pas la phrase** : la formulation en langage de personnage (§4.2) revient à
+  l'injection de prompt (#228). `@see docs/public/raw/23-RUN-STRUCTURE.md` §1-§4.
 
 ## Pré-déploiement restant
 


### PR DESCRIPTION
Closes #227

Lot 2/4 de l'EPIC #214. Implémente les règles pures du donjon et de la boucle de run, sans Prisma ni accès DB.

## Ce que ça ajoute

- `game-rules/dungeon.ts` — génération des paliers de descente et du trajet de retour, indices partiels par salle.
- `game-rules/run.ts` — état de run (descendre / faire demi-tour / remonter), estimation de retour et détection de franchissement de seuil.
- 49 tests unitaires (`dungeon.test.ts`, `run.test.ts`).

## Garanties canon vérifiées par les tests

- **Plafond 7 paliers structurel** : appliqué dans `canDescend` *et* dans les générateurs, donc une valeur runtime aberrante (`targetDepth: 99`) ne peut pas rallonger un run.
- **Règle de l'indice (§2)** : un boss produit exactement le même `hint.kind` qu'une salle de combat. La nature du danger fuite, jamais son ampleur.
- **Retour distinct et strictement plus court (§4)** : espaces d'ids disjoints (`f{n}-r{n}` vs `r{n}-r{n}`), 1 salle par palier au retour contre 3 à la descente, et jamais de boss sur le chemin du retour.
- **« Le retour peut tuer, mais jamais par surprise » (§4)** : l'estimation inclut une marge de sécurité et est pilotée par la ressource la plus rare, et l'avertissement se déclenche aussi quand c'est **la descente seule** qui rend le retour inabordable (le joueur n'a rien dépensé, c'est le seuil qui a bougé).

## Deux décisions qui méritent une relecture

1. **`MINUTES_PER_ROOM = 3.75`** — pas un chiffre rond choisi au hasard : dérivé de la table de durées du canon (§1). Le contrat 3 paliers est le contraignant (9 salles de descente + 3 de retour = 12 salles ≈ 45 min) ; les contrats plus profonds atterrissent sous leur propre plafond (5 paliers ≈ 75 ≤ 90, 7 paliers ≈ 105 ≤ 150). Un test verrouille l'invariant.

2. **Ce lot produit la donnée, pas la phrase.** `detectReturnWarnings` renvoie *quelle* ressource a franchi *quel* seuil avec *quel* niveau de risque. La formulation en langage de personnage exigée par §4.2 — jamais un popup système — relève de l'injection de prompt et arrive avec #228.

## Note sur les minutes

Les estimations sont des fonctions pures de la profondeur : aucune horloge, aucun `Date.now()`. Une session laissée en AFK n'affecte ni la narration, ni le retour, ni la survie. Le plafond 2h30 du canon est implémenté comme un plafond de contenu (7 paliers), pas comme un timer.

## Vérification

`pnpm lint`, `pnpm type-check` et `pnpm test` verts — 459 tests backend (+49) et 113 frontend.