### PR TITLE
docs(gameplay): aligner le roguelike narratif v0.2.1

### DIFF
--- a/docs/public/current-state/BACKEND.md
+++ b/docs/public/current-state/BACKEND.md
@@ -16,8 +16,8 @@ default_agent: claude
 Priorité courante : refonte roguelike (décision du 2026-08-06, cf. [[PROJECT_STATUS]]).
 Canon de référence : `docs/public/raw/23-RUN-STRUCTURE.md`, `10-COMBAT.md`, `03-BESTIARY.md`.
 
-Ordre de dépendance : `#214 → #215 → #216 → #217 → #220/#221`.
-Transverse à #214 et #221 : la méta-progression de connaissance (`PlayerKnowledge`) persiste
+Ordre de dépendance produit : quête/run → combat → Auberge → artefacts → compagnons/exploits.
+Transverse à la boucle et aux exploits : la méta-progression de connaissance (`PlayerKnowledge`) persiste
 bestiaire, routes, contrats et sujets — **jamais de puissance** (`14-META-WORLD.md` §1bis).
 
 ## Décisions d'implémentation
@@ -34,24 +34,31 @@ calcined`. L'ancien `inn` confondait « rentré avec l'objectif » (payé) et «
   volontaire à l'auberge, sans contrat à honorer, les sessions existantes sont migrées en `abandon`
   (migration `split_session_end_reason_run_structure`). #226
 - **`GameMode` ≠ fin de session ≠ type de repos** — `inn | exploration | combat | return` est un
-  **mode de jeu**. Ne pas le confondre avec `rest_requested.type: 'inn'`, que le backend ignore
-  volontairement. #226
+  état serveur. Ne pas le confondre avec `rest_requested.type: 'inn'`, que le backend ignore
+  volontairement. Depuis le grilling du 2026-08-08, il n'impose plus quatre interfaces : il permet
+  surtout au frontend de transformer la scène quand un combat commence.
+- **Un contrat est une quête structurée, pas un niveau de donjon.** Un seul contrat principal est
+  actif ; le backend possède objectif, destination, commanditaire, danger, durée, récompense,
+  conditions d'échec et progression. L'IA habille ces données sans les modifier.
+- **Le run commence au départ de l'Auberge.** Le contrat reste modifiable avant le départ, puis se
+  verrouille. Les ressources et conséquences s'appliquent dès le voyage, pas seulement au premier
+  palier de donjon.
+- **L'objectif est injecté à chaque tour.** L'IA respecte les détours mais ne peut pas oublier la
+  quête ; réussite et échec sont des verdicts backend.
 - **Le plafond de 7 paliers est structurel**, clampé même sur une valeur hors barème : c'est le
   garant du plafond dur de 2h30. Trois garde-fous indépendants — clamp moteur, contrainte `CHECK`,
   et `readContract` qui rend nul plutôt que de fabriquer un run trop long. #227 #228
-- **`MINUTES_PER_ROOM = 3.75`** est calibré sur le barème canon, pas choisi rond. Le contrat
-  3 paliers est le contraignant (12 salles ≈ 45 min) ; les contrats plus profonds restent sous leur
-  propre cible (5 paliers ≈ 75 min, 7 paliers ≈ 105 min). #227
+- **`MINUTES_PER_ROOM = 3.75` reste un calibrage interne.** Il borne la durée des expéditions, mais
+  la profondeur, le nombre de salles et les minutes du retour ne sont jamais exposés en v0.2.1.
 - **Le retour est un trajet distinct**, jamais la descente à l'envers : identifiants et types tirés
   à neuf, 1 salle par palier contre 3, aucun boss. Le retour tue par épuisement, jamais par
   embuscade. #227
-- **L'indice dit la nature du danger, jamais son ampleur** — un boss verrouille la dernière salle
-  des paliers 5+ sans que l'indice le distingue d'un combat ordinaire (§2). #227
-- **`detectReturnWarnings` détecte le franchissement**, y compris quand c'est la _descente_ — et non
-  la consommation — qui rend le retour inabordable. Une ressource déjà courte ne réalerte pas, pour
-  que l'avertissement garde son poids. #227
-- **L'avertissement est injecté en langage de personnage** — jamais un nombre, jamais une alerte
-  d'interface (§4.2). #228
+- **La structure du donjon est secrète en v0.2.1.** Le moteur peut conserver salles, connexions,
+  paliers et profondeur pour arbitrer ; ni indices de danger, ni types de salles, ni carte, ni
+  estimation ne doivent atteindre le joueur.
+- **Les estimations et avertissements de retour ne sont plus des sorties produit.** Le moteur peut
+  calculer un coût interne pour garder un trajet cohérent, mais il ne l'injecte ni dans la prose ni
+  dans la réponse consommée par l'UI.
 - **⏱️ La progression est portée par le tour, jamais par le temps réel.** Une session laissée ouverte
   ou reprise le lendemain ne consomme rien : les minutes affichées sont une estimation honnête pour
   décider, pas une horloge que le moteur relit. #228
@@ -105,16 +112,15 @@ calcined`. L'ancien `inn` confondait « rentré avec l'objectif » (payé) et «
   l'état mécanique réel transmis (ratio PV, palier de Calamine, conditions, mourant). Aucun état
   d'acte/chapitre serveur, explicitement hors scope. #185
 
-### Images de scène — #207
+### Images de scène — révision v0.2.1
 
-- **La clé de cache est reclée sur la profondeur, jamais sur le texte IA.** Le contenu n'est pas un
-  monde ouvert à biomes mais une descente en paliers : la variable qui change l'image est la
-  **profondeur atteinte**. `depthBandOf` découpe les 7 paliers exactement là où le bestiaire découpe
-  ses tiers de danger (`surface | upper | mid | deep | abyss`), et la profondeur vient de l'état du
-  run — une image ne peut donc plus contredire le palier réel. `classifyBiome` a été **supprimé**.
-- **Un palier hors bornes retombe sur une bande valide plutôt que de lever** : un tour ne doit pas
-  échouer parce qu'il cherchait à s'illustrer. Toute panne (génération, upload, course sur la clé
-  unique) retombe sur `null` sans faire échouer le tour.
+- **Aucune génération runtime.** La génération Pollinations et son cache `SceneImage` deviennent
+  une implémentation à retirer ; qualité, coût et disponibilité d'un fournisseur ne doivent pas
+  bloquer un tour.
+- **Bibliothèque fermée de 45 à 60 assets pré-générés.** Le backend ou le contrat de scène référence
+  une famille et une variante connues ; il ne compose jamais une image depuis la prose IA.
+- **Fallback obligatoire.** Une clé absente retombe sur le décor de thème sans faire échouer le tour.
+- **L'image représente la scène actuelle et ne donne aucun indice sur la prochaine salle.**
 - Détail : `docs/public/tech/DYNAMIC_SCENE_IMAGES.md`.
 
 ### Sécurité et infrastructure — #162
@@ -141,8 +147,9 @@ calcined`. L'ancien `inn` confondait « rentré avec l'objectif » (payé) et «
 - **La mémoire interne est en pivot anglais fixe**, indépendante de la locale de narration : un
   changement de langue en cours de run ne doit jamais traduire ni corrompre le canon. #168
 - **Le client n'infère aucune règle** — `SceneResponse` et `InventoryActionResponse` portent
-  l'instantané de survie, les conditions actives, le fer persistant, le `run` complet
-  (`canDescend` inclus), le `CombatSnapshot` et le `endReason` autoritaire. #186 #228 #233
+  l'instantané de survie, les conditions actives, le fer persistant, l'objectif joueur, le
+  `CombatSnapshot` et le `endReason` autoritaire. La structure cachée du run (`canDescend`, paliers,
+  estimation) ne doit pas devenir une information affichable par accident.
 - **`POST /api/character/resolve-vocation` est stateless** (aucune écriture Prisma, toujours HTTP 200) : l'IA propose une des 4 vocations canon, le serveur reste souverain sur l'identifiant retenu
   via `z.enum`. Réponse en union discriminée `resolved` | `fallback`. #152
 

--- a/docs/public/current-state/FRONTEND.md
+++ b/docs/public/current-state/FRONTEND.md
@@ -16,12 +16,12 @@ default_agent: codex
 Priorité courante : refonte roguelike (décision du 2026-08-06, cf. [[PROJECT_STATUS]]).
 Canon de référence : `docs/public/raw/23-RUN-STRUCTURE.md`, `09-ACTION-LOOP.md` §2bis.
 
-**Le problème que la refonte doit résoudre** : le frontend rend _toutes_ les activités du jeu dans le
-même écran narratif. C'est la cause directe du ressenti « c'est toujours pareil ». Chaque mode doit
-avoir sa propre interface et son propre rythme (principe 12, `01-PILLARS` §9).
+**Décision du grilling du 2026-08-08** : le problème n'est pas l'interface narrative commune, mais
+l'absence de règles qui mettent l'histoire sous pression. Auberge, voyage, quête, donjon et retour
+gardent donc une seule coque narrative. Le combat est la seule transformation d'interface.
 
-Un écran de mode dépend du contrat backend correspondant : **ne pas démarrer un mode avant que
-`packages/shared` porte ses types.**
+Un composant mécanique dépend toujours du contrat backend correspondant : **ne pas l'implémenter
+avant que `packages/shared` porte ses types.**
 
 ## Décisions d'implémentation
 
@@ -29,16 +29,26 @@ Une entrée n'est ajoutée ici que si elle explique un **choix non évident**. L
 ticket soit livré se lit sur GitHub.
 
 - **Le mode courant vient du serveur, jamais déduit du texte de scène.** Corollaire frontend de la
-  souveraineté backend : le client dessine, il n'arbitre pas. #219
+  souveraineté backend : le client dessine, il n'arbitre pas. En v0.2.1, ce mode déclenche surtout
+  la transformation combat ; il ne sélectionne pas quatre applications visuellement séparées.
+- **Une seule coque narrative hors combat.** L'image, la voix et les composants contextuels changent,
+  mais la continuité Auberge → voyage → quête/donjon → retour ne casse jamais.
+- **L'Auberge est un hub de scènes, pas un tableau.** Comptoir, L'Aveugle, Contrats et Forge restent
+  accessibles comme destinations persistantes dans la fiction.
+- **Le donjon ne révèle pas son moteur en v0.2.1.** Aucun type de salle, indice, icône, carte,
+  palier, profondeur ou estimation de retour n'est rendu. Le HUD conserve uniquement l'objectif
+  principal repliable, les jauges et « Faire demi-tour » hors combat.
+- **Le combat transforme la scène au lieu d'ouvrir un mini-jeu étranger.** Le décor reste visible,
+  la dernière narration consultable et l'action libre disponible ; la fin rend la place au récit.
 - **`updatedStats` reste `Record<string, number>`** — `isDying` n'est pas transporté sur le réseau
   dans ce canal ; il est mis à jour côté backend et lu dans l'instantané de survie. #201
 - **Le HUD n'affiche que les jauges variables** (PV, Soif, Faim, Fatigue, Calamine) ; le Triptyque
   est rendu en scores fixes. Mélanger les deux brouillait ce que le joueur peut agir. #186
 - **Le Désavantage est explicite sur le jet**, avec sa cause — la transparence mécanique est une
   règle produit, pas un détail d'UI. #186
-- **La Forge ouvre directement le premier run** ; l'Auberge interactive est réservée aux sessions
-  commencées ou terminées. Elle tient en `100dvh` sur desktop, tablette et mobile, avec défilement
-  interne du dialogue uniquement. #186
+- **Tous les runs commencent à l'Auberge.** La Forge ne lance plus directement le premier run : un
+  contrat principal doit être accepté avant le départ. L'Auberge tient en `100dvh` sur desktop,
+  tablette et mobile, avec défilement interne du dialogue uniquement.
 - **Le brouillon de création est versionné** (`CharacterCreateDraft` v2 : nom personnalisé, trait
   narratif, compétences décalées) — un brouillon d'une version antérieure ne doit pas se déserialiser
   en silence. #152
@@ -54,6 +64,9 @@ ticket soit livré se lit sur GitHub.
   final. Détail `docs/public/tech/SECURITY.md`. #162
 - **L'inventaire est structuré selon les quatre catégories canon**, pas selon une commodité
   d'affichage. #183 #186
+- **Les scènes utilisent une bibliothèque pré-générée de 45 à 60 images.** Deux ou trois variantes
+  par famille sont réutilisables ; aucune génération runtime en v0.2.1 et aucun sens mécanique ne
+  dépend de l'image seule.
 - **Tailwind pour le responsive, jamais un hook JS.**
 
 ## Dette et suivis connus
@@ -62,10 +75,10 @@ ticket soit livré se lit sur GitHub.
   **jamais** été câblés à l'UI (tooltips SANG/SOUFFLE/CENDRE, Calamine, jauges, conditions). C'est de
   la valeur joueur déjà écrite et non livrée.
 - **#217 — coût en Calamine et usages restants doivent être visibles _avant_ activation**, pas après.
-- **#216 — l'écran de sac est là où se joue l'arbitrage vivres/butin** : c'est l'écran, pas un
-  panneau secondaire.
-- **#214 — l'encart de demi-tour est l'écran de décision central du jeu** (sac, eau, estimation de
-  retour, paliers).
+- L'arbitrage vivres/butin doit rester lisible dans l'inventaire sans transformer l'Auberge en
+  tableau de gestion.
+- L'ancien encart de demi-tour avec estimation et paliers est révoqué pour v0.2.1. « Faire
+  demi-tour » reste disponible en permanence hors combat, sans prédiction du trajet.
 - CSP de production à revérifier à #161.
 - #129 est **à re-scoper** : les golden paths testés ne décrivent plus le jeu après la refonte.
 

--- a/docs/public/current-state/PROJECT_STATUS.md
+++ b/docs/public/current-state/PROJECT_STATUS.md
@@ -18,8 +18,9 @@ gh issue list --milestone "v0.2.1 - Roguelike jouable" --state all
 ## Objectif actuel
 
 Livrer **v0.2.1 — Roguelike jouable** : refonder la couche de jeu par-dessus le socle existant, de
-sorte qu'un run ait une **destination** (contrat), une **structure** (paliers), une **décision
-centrale** (le demi-tour) et un **enjeu** (le retour). Voir `docs/public/raw/23-RUN-STRUCTURE.md`.
+sorte qu'un run soit une **quête narrative dirigée** par un contrat, mise sous pression par des
+règles roguelike cachées, des ressources, des combats et un retour joué. Voir
+`docs/public/raw/23-RUN-STRUCTURE.md`.
 
 > **🎲 Refonte roguelike du 2026-08-06.** Le playtest a rendu un verdict net : _« après une partie je
 > m'ennuie, il n'y a aucune raison de recommencer »_. Le diagnostic est que le projet a un
@@ -30,13 +31,25 @@ centrale** (le demi-tour) et un **enjeu** (le retour). Voir `docs/public/raw/23-
 > sert à rien de déployer un vertical slice ennuyeux. Les bloqueurs pré-déploiement #161, #129 et
 > #163 sont **gelés**, pas annulés.
 
+> **🎭 Continuité narrative du 2026-08-08.** Le grilling produit a révoqué les quatre interfaces
+> séparées et la structure de donjon visible. Auberge, voyage, quête, donjon et retour conservent la
+> même interface storytelling ; seul le combat transforme temporairement la scène. Paliers, salles,
+> indices, profondeur et estimation de retour restent cachés en v0.2.1.
+
 ## Ordre des chantiers
 
-Les 8 EPICs de coordination ont été fermés le 2026-08-08 : un ticket qui ne livre rien ne fait que
-recopier l'état de ses enfants. Ce qui avait de la valeur en eux — **l'ordre n'est pas indicatif,
-chaque chantier suppose le précédent livré** — est une décision, elle vit donc ici :
+Les EPICs servent de **carte de coordination**, jamais de preuve d'avancement : leurs issues enfants
+livrables portent le travail réel. L'ordre n'est pas indicatif ; chaque chantier suppose les
+contrats du précédent livrés :
 
-`boucle de run → combat → auberge → artefacts → lisibilité / UI par modes → compagnons / exploits`
+`quête et boucle narrative → Auberge vivante → combat → images → artefacts → compagnons / exploits`
+
+| Carte de coordination                   | EPIC GitHub |
+| --------------------------------------- | ----------- |
+| Quêtes et boucle narrative continue     | #251        |
+| Auberge vivante et préparation          | #252        |
+| Combat tactique intégré au storytelling | #250        |
+| Bibliothèque visuelle des scènes        | #253        |
 
 Le board ne porte plus que des tickets livrables, avec trois axes de label : `domain: *` (posé
 automatiquement par `.github/labeler.yml`), `release: *`, et `phase: *` qui pilote l'assignation de
@@ -66,12 +79,13 @@ peut inverser ce choix sans changer les règles du domaine.
 - qualité : lint, type-check, tests, build, CodeQL et previews Vercel dans la CI.
 
 Ce socle est **conservé** (décision 18) : la refonte roguelike s'écrit par-dessus, elle ne le remplace
-pas. Deux exceptions connues, portées par #214 :
+pas. Trois évolutions structurantes sont autorisées :
 
 - `SessionEndReason` : `inn` est scindé en `extracted` / `returned_empty`
   (`docs/public/raw/09-ACTION-LOOP.md` §7) — breaking change des contrats shared ;
-- la session porte désormais un **mode de jeu** explicite (exploration / combat / auberge / retour)
-  et une **position de palier**.
+- la session porte un état serveur explicite et une structure de progression cachée ; ils arbitrent
+  le jeu sans imposer quatre interfaces au frontend ;
+- le contrat devient une quête générique structurée, pas seulement une destination de donjon.
 
 ## Règle de tenue des docs
 

--- a/docs/public/current-state/RELEASE_READINESS.md
+++ b/docs/public/current-state/RELEASE_READINESS.md
@@ -6,7 +6,7 @@ source_of_truth: true
 owner: release-coordination
 ---
 
-# Release Readiness — v0.1.0 (décalée) → v0.2.0
+# Release Readiness — v0.1.0 (décalée) → v0.2.1
 
 Toute PR qui change un bloqueur `phase: predeploy` met à jour ce fichier selon l'état attendu après
 merge. La checklist opérationnelle détaillée vit dans l'issue #163.
@@ -17,9 +17,14 @@ merge. La checklist opérationnelle détaillée vit dans l'issue #163.
 > circonscrits et connus. Elle est décalée parce que **le jeu n'est pas satisfaisant** — verdict de
 > playtest : _« après une partie je m'ennuie, il n'y a aucune raison de recommencer »_ (décision 19).
 >
-> Le travail bascule sur la **refonte roguelike v0.2.0** (8 EPICs, #214→#221). Ce fichier reste la
+> Le travail bascule sur la **refonte roguelike narrative v0.2.1**. Ce fichier reste la
 > source de vérité du déploiement et sera réactivé une fois la boucle de jeu satisfaisante ; sa
 > checklist reste valable.
+
+> **Révision du 2026-08-08.** La release ne cherche plus à remplacer le storytelling par quatre
+> interfaces de modes. Elle conserve une interface narrative continue, ajoute le combat tactique et
+> garde la structure du donjon cachée. Le backlog correspondant vit dans le milestone GitHub
+> `v0.2.1 - Roguelike jouable`.
 
 ## Fondations livrées
 
@@ -59,7 +64,7 @@ parcours (landing → auberge → session) qui ne décrira plus le jeu après la
 
 Prérequis de fait au déploiement : le jeu doit être satisfaisant avant d'être publié.
 
-L'avancement des 8 EPICs (#214 → #221) se lit sur GitHub, jamais ici — un tableau recopié à la main
+L'avancement des EPICs et de leurs issues livrables se lit sur GitHub, jamais ici — un tableau recopié à la main
 devient faux au premier merge :
 
 ```bash
@@ -77,9 +82,9 @@ multi-provider (#159), pgvector (#114), World events (#117) et échange Souvenir
 
 `NO-GO`, pour deux raisons distinctes qu'il ne faut pas confondre :
 
-1. **Raison produit (bloquante, prioritaire)** — la boucle de jeu n'est pas satisfaisante. Les 8
-   EPICs de la Phase 0 doivent être livrés et le jeu jugé amusant par l'auteur avant de rouvrir la
-   question du déploiement.
+1. **Raison produit (bloquante, prioritaire)** — la boucle de jeu n'est pas satisfaisante. Les
+   chantiers pré-déploiement du milestone v0.2.1 doivent être livrés et le jeu jugé amusant par
+   l'auteur avant de rouvrir la question du déploiement.
 2. **Raison technique (circonscrite)** — l'API n'est pas déployée (#161) et le golden path n'est pas
    vert sur un environnement de release (#129, à re-scoper). La sécurité, elle, est qualifiée
    depuis #162.

--- a/docs/public/design/GAME_DESIGN.md
+++ b/docs/public/design/GAME_DESIGN.md
@@ -32,9 +32,11 @@ Promesse produit : **un monde qui se souvient**. Le joueur agit librement, le ba
 2. L'Aveugle demande son nom.
 3. Le joueur crée son personnage : vocation ou concept libre.
 4. L'IA réagit en prose, mais le backend garde les règles.
-5. Le joueur quitte l'auberge et entre dans le run.
-6. Les choix importants créent des faits persistants.
-7. La mort ou la fin génère une trace pour les runs suivants.
+5. Le joueur explore les scènes de l'Auberge, prépare son sac et choisit une quête principale.
+6. Le run commence dès le départ : voyage, quête, donjon et retour restent une narration continue.
+7. Le combat transforme temporairement l'interface en espace tactique.
+8. Les choix importants créent des faits persistants.
+9. La mort ou la fin génère une trace pour les runs suivants.
 
 ## Canon public minimal
 
@@ -52,14 +54,18 @@ Promesse produit : **un monde qui se souvient**. Le joueur agit librement, le ba
 - Tokens : toujours utiliser [`DESIGN_TOKENS.md`](DESIGN_TOKENS.md).
 - UI : dense, lisible, cinématique, jamais générique fantasy.
 - Les écrans gameplay doivent prioriser la narration, l'état du personnage, les conséquences et l'action libre.
+- Une seule coque narrative porte Auberge, voyage, quête, donjon et retour.
+- Aucun type de salle, carte, palier, profondeur ou estimation de retour n'est affiché en v0.2.1.
+- Le combat est la seule transformation complète : il reste visuellement ancré dans la scène.
 
 ## Écrans à construire
 
 - Landing : promesse claire + SEO bilingue, sans exposer le canon complet.
-- Auberge de L'Aveugle : hub de run, création, Souvenirs, artefacts.
+- Auberge de L'Aveugle : hub narratif à scènes, avec Comptoir, L'Aveugle, Contrats et Forge.
 - Character Create : 4 vocations + concept libre.
 - World Map : carte du Makhzen, régions, points d'intérêt.
-- Session : narration, action libre, choix, dés aux pivots, inventaire, survie.
+- Session : narration continue, objectif repliable, action libre, choix, dés, inventaire, survie.
+- Combat : transformation tactique cinématographique de la Session, jamais mini-jeu détaché.
 
 ## Composants attendus
 
@@ -68,6 +74,8 @@ Promesse produit : **un monde qui se souvient**. Le joueur agit librement, le ba
 - `SurvieGauge` : faim, soif, fatigue.
 - `VocationCard`.
 - Composants L'Aveugle : scène, dialogue, choix vocation, concept libre, échange Souvenirs.
+- Navigation Auberge : destinations persistantes sans casser la fiction.
+- Contrat : tags textuels de danger et durée, jamais score ou prévisualisation des rencontres.
 
 ## Règles IA côté design
 

--- a/docs/public/nav/log.md
+++ b/docs/public/nav/log.md
@@ -182,3 +182,29 @@ domaine. L'agent frontend Claude est conservé et protégé contre une suppressi
 - le dashboard Obsidian et les instructions d'agents legacy ont été réparés.
 - `.agents/skills/` est la source canonique unique des skills projet ; `.claude/skills/` utilise des
   liens relatifs contrôlés en CI, et les 10 skills passent le validateur officiel.
+
+---
+
+## 2026-08-08 — Grilling : le roguelike reste un storytelling continu
+
+Le grilling produit mené avec Adem révoque la séparation décidée le 2026-08-06 entre quatre
+interfaces Auberge / exploration / combat / retour. Cette séparation répondait au bon diagnostic —
+le jeu manquait de moteur — mais à la mauvaise cause : l'interface narrative n'est pas le problème.
+Ce sont les règles, le risque, les objectifs et les conséquences qui doivent créer le jeu.
+
+Décisions validées :
+
+- l'Auberge, le voyage, la quête, le donjon et le retour utilisent une seule coque storytelling ;
+- seul le combat transforme temporairement la scène en interface tactique ;
+- l'Auberge devient un hub de scènes avec Comptoir, L'Aveugle, Contrats et Forge ;
+- un contrat principal est obligatoire et devient une quête générique structurée par le backend ;
+- trois contrats ordinaires affichent seulement un tag textuel de danger et de durée ;
+- le run commence au départ de l'Auberge et l'IA reçoit l'objectif à chaque tour ;
+- pour v0.2.1, salles, indices, carte, paliers, profondeur et estimation de retour sont cachés ;
+- « Faire demi-tour » reste toujours disponible hors combat ; le retour est joué, distinct, plus
+  court et plus facile ;
+- les scènes utilisent 45 à 60 images pré-générées et réutilisables, sans génération runtime.
+
+Le compromis de mystère total est volontaire : l'état actuel du personnage reste lisible, mais le
+jeu ne prédit pas les dangers futurs. Les playtests v0.2.1 décideront si des avertissements doivent
+revenir. Coordination documentaire et backlog : #244 ; EPICs #250, #251, #252 et #253.

--- a/docs/public/raw/01-PILLARS.md
+++ b/docs/public/raw/01-PILLARS.md
@@ -64,9 +64,9 @@ Le joueur ne joue pas un "personnage générique". Il incarne une **vocation** �
 
 GRIMOIRE est un **roguelike narratif**. Chaque run est une aventure complète, avec un début, un milieu et une fin. À la fin, le joueur reçoit sa **Chronique** — le récit de ce qu'il a vécu. Il peut recommencer avec la même vocation ou une autre.
 
-> **⏱️ Durée d'un run : 2h30 maximum** (décision du 2026-08-06). Le joueur choisit sa durée cible
-> en acceptant un **contrat** à l'auberge : ~45 min pour 3 paliers, jusqu'à 2h30 pour 7 paliers.
-> Voir `23-RUN-STRUCTURE.md`.
+> **⏱️ Durée d'un run : 2h30 maximum** (décision du 2026-08-06). Le joueur choisit son engagement
+> en acceptant un **contrat** à l'auberge, présenté comme expédition courte, longue ou majeure. La
+> structure mécanique qui garantit cette durée reste cachée en v0.2.1. Voir `23-RUN-STRUCTURE.md`.
 >
 > _Pourquoi un plafond dur_ : au-delà, le cycle de relance propre au roguelike se casse, la mort
 > permanente devient intolérable au lieu d'être tendue, et le coût des appels IA explose. Un run
@@ -92,7 +92,7 @@ GRIMOIRE est un **roguelike** — ce qui signifie que la mort est définitive, m
 | ✅ Ce qui persiste                                                     | ❌ Ce qui ne persiste jamais            |
 | ---------------------------------------------------------------------- | --------------------------------------- |
 | **Connaissance du bestiaire** : ce qu'on a affronté, ses faiblesses    | Bonus permanent de PV ou de dégâts      |
-| **Accès** : contrats, destinations, paliers profonds débloqués         | Bonus permanent d'attribut              |
+| **Accès** : contrats et destinations plus dangereuses débloqués        | Bonus permanent d'attribut              |
 | **Sujets chez L'Aveugle** : le lore s'ouvre selon ce qu'on a vu        | Équipement cumulatif d'un run à l'autre |
 | **Compagnons recrutables** débloqués (`23-RUN-STRUCTURE`)              | Réduction permanente de la difficulté   |
 | **Exploits** (badges) et les accès qu'ils ouvrent                      | Toute forme de « build » qui monte      |
@@ -236,11 +236,11 @@ Objectif mature : **≥ 60% completion + ≥ 45% 2ᵉ run à J+7.**
 8. 🟢 **La survie est une pression, pas une punition.** Le joueur souffre, mais pas de façon qui le fait quitter.
 9. 🟢 **La magie est une tentation, pas un outil.** Toujours un prix, toujours un risque.
 10. 🟢 **Chaque vocation = une expérience fondamentalement différente.** Pas des skins sur le même jeu.
-11. 🟢 **La mort doit toujours être imputable à une décision que le joueur a vue venir.** Jamais un
-    pic de dégâts surprise, jamais une jauge qui se vide en silence. Le joueur doit pouvoir dire
-    _« j'aurais dû faire demi-tour »_ — pas _« je ne pouvais pas savoir »_.
-12. 🟢 **Chaque registre de jeu a sa propre tête.** Explorer, se battre, se préparer et rentrer ne
-    doivent pas se ressembler à l'écran. Le dynamisme naît de l'alternance, pas de la vitesse.
+11. 🟢 **L'état du joueur est lisible, le monde reste mystérieux.** PV, jauges, conditions et choix
+    de demi-tour ne sont jamais cachés ; les dangers futurs, la profondeur et la route de retour le
+    sont en v0.2.1. Le joueur décide avec ce que son personnage sait, pas avec une carte système.
+12. 🟢 **Le storytelling est la continuité du jeu.** Auberge, voyage, donjon et retour partagent la
+    même interface narrative. Seul le combat transforme temporairement la scène en espace tactique.
 13. 🟢 **Un mot inventé est toujours accompagné de sa fonction au premier affichage.** Ce qui est
     nécessaire pour jouer s'explique par un tooltip ; le lore se découvre auprès de L'Aveugle.
 
@@ -251,16 +251,16 @@ Objectif mature : **≥ 60% completion + ≥ 45% 2ᵉ run à J+7.**
 
 ## 10. Risques produit majeurs
 
-| Risque                                 | Impact | Mitigation                                                                 |
-| -------------------------------------- | ------ | -------------------------------------------------------------------------- |
-| Coût LLM (même gratuit, rate limits)   | 🔴     | OpenRouter + 1-2 appels/tour + caching                                     |
-| Incohérences narr. sur un run long     | 🔴     | Canon fixe en RAG + Validateur + prompt strict                             |
-| Run abandonné (trop long / trop plat)  | 🔴     | Plafond dur 2h30 + contrat à objectif clair + paliers (`23-RUN-STRUCTURE`) |
-| Boucle sans destination (« ennuyeux ») | 🔴     | Le contrat donne un objectif ; descendre/remonter donne une direction      |
-| "Survie" étouffe la narration          | 🟡     | Curseur "pas hardcore", events narratifs > micro-gestion                   |
-| Dés frustrants (échecs à répétition)   | 🟡     | Mods d'attributs compensent, échec = jeu pas punition                      |
-| Vocations trop similaires en pratique  | 🟡     | Fiches de contraintes strictes, lentilles testées séparément               |
-| Free tiers insuffisants (rate limits)  | 🔴     | Quota de runs/jour, fallback providers                                     |
+| Risque                                 | Impact | Mitigation                                                                          |
+| -------------------------------------- | ------ | ----------------------------------------------------------------------------------- |
+| Coût LLM (même gratuit, rate limits)   | 🔴     | OpenRouter + 1-2 appels/tour + caching                                              |
+| Incohérences narr. sur un run long     | 🔴     | Canon fixe en RAG + Validateur + prompt strict                                      |
+| Run abandonné (trop long / trop plat)  | 🔴     | Plafond dur 2h30 + contrat à objectif clair + structure cachée (`23-RUN-STRUCTURE`) |
+| Boucle sans destination (« ennuyeux ») | 🔴     | Le contrat donne une quête ; l'IA conserve cet objectif à chaque tour               |
+| "Survie" étouffe la narration          | 🟡     | Curseur "pas hardcore", events narratifs > micro-gestion                            |
+| Dés frustrants (échecs à répétition)   | 🟡     | Mods d'attributs compensent, échec = jeu pas punition                               |
+| Vocations trop similaires en pratique  | 🟡     | Fiches de contraintes strictes, lentilles testées séparément                        |
+| Free tiers insuffisants (rate limits)  | 🔴     | Quota de runs/jour, fallback providers                                              |
 
 ---
 

--- a/docs/public/raw/07-CHARACTER-CREATION.md
+++ b/docs/public/raw/07-CHARACTER-CREATION.md
@@ -251,9 +251,9 @@ Si le joueur ramène un artefact non identifié d'un run (cf. `11-INVENTORY-ECON
 
 ---
 
-## 6. Sortie de l'auberge — première scène du run
+## 6. Après la création — préparer le premier contrat
 
-Une fois la fiche compilée, L'Aveugle propose une **destination de départ** selon la vocation :
+Une fois la fiche compilée, L'Aveugle recommande une **première quête** selon la vocation :
 
 | Vocation / Concept | Destination suggérée                                                     |
 | ------------------ | ------------------------------------------------------------------------ |
@@ -263,9 +263,14 @@ Une fois la fiche compilée, L'Aveugle propose une **destination de départ** se
 | Tisse-Verbe        | _"Une femme à Tissan cherche quelqu'un comme toi. Elle paye en savoir."_ |
 | Concept libre      | _L'IA invente une accroche basée sur le trait narratif_                  |
 
-→ Le joueur **accepte** OU **clique ✍️ pour proposer autre chose**. L'IA s'adapte.
+Cette recommandation ne lance pas directement le run. Le joueur rejoint l'Auberge complète :
+Comptoir, L'Aveugle, Contrats et Forge. Il peut préparer son sac et choisir un autre contrat parmi
+les trois offres ordinaires.
 
-→ La **boucle d'action** (voir `09-ACTION-LOOP`) démarre. Plus de modal. On joue.
+→ Un contrat principal doit être accepté avant le départ.
+
+→ Le run et la consommation de ressources commencent au franchissement de la porte. La **boucle
+d'action** (voir `09-ACTION-LOOP`) reste la même pendant le voyage, la quête et le retour.
 
 ---
 
@@ -332,9 +337,13 @@ Fiche compilée (récap)
    ↓
 1ᵉʳ Souvenir gratuit (3 choix lore)
    ↓
-L'Aveugle suggère une destination de départ
+L'Aveugle recommande une première quête
    ↓
-Sortie de l'auberge — LA BOUCLE D'ACTION COMMENCE (09)
+Hub : Comptoir · L'Aveugle · Contrats · Forge
+   ↓
+Contrat accepté + préparation terminée
+   ↓
+Sortie de l'auberge — LE RUN COMMENCE (09, 23)
 
 
 RUN ≥ 2

--- a/docs/public/raw/09-ACTION-LOOP.md
+++ b/docs/public/raw/09-ACTION-LOOP.md
@@ -53,9 +53,9 @@ Un **tour de jeu** = une réponse IA + une action joueur. Le joueur **n'attend j
 
 ## 2. Les 3 modes de saisie
 
-> **Ne pas confondre avec les 4 modes de jeu** (exploration / combat / auberge / retour, cf. §2bis).
-> Ici il s'agit de **comment le joueur formule son action** ; là-bas, de **dans quel registre il
-> joue**. Les trois modes de saisie ci-dessous existent dans tous les modes de jeu.
+> Ici, « mode » décrit uniquement **comment le joueur formule son action**. Auberge, voyage,
+> exploration, donjon et retour conservent la même boucle narrative ; le combat transforme
+> temporairement cette boucle (cf. §2bis).
 
 Le joueur n'est jamais enfermé dans un seul mode. Il choisit naturellement à chaque tour.
 
@@ -84,37 +84,34 @@ Le joueur n'est jamais enfermé dans un seul mode. Il choisit naturellement à c
 
 ---
 
-## 2bis. Les 4 modes de jeu
+## 2bis. Continuité narrative et combat
 
-> **Ajout du 2026-08-06** (décisions 6, 7 et 10 de la refonte roguelike).
+> **Révision du 2026-08-08.** La séparation du 2026-08-06 en quatre interfaces est révoquée après
+> grilling produit. Elle confondait structure roguelike et changement d'écran, au détriment de
+> l'identité storytelling de GRIMOIRE.
 
-La boucle décrite dans ce fichier était **la seule** boucle du jeu : tout — auberge, exploration,
-combat — passait par le même écran, les mêmes 3-4 choix, la même mise en page. C'est la cause
-directe du ressenti « c'est toujours pareil ».
+La boucle §1 reste le langage commun de l'Auberge, du voyage, de la quête, du donjon et du retour.
+L'image, la voix, les destinations persistantes et les composants contextuels évoluent, mais le
+joueur ne quitte jamais son histoire pour ouvrir une carte de salles ou un tableau de gestion.
 
-Le jeu se joue désormais en **quatre modes**, chacun avec sa propre interface :
+| Registre           | Présentation                                                          |
+| ------------------ | --------------------------------------------------------------------- |
+| **Auberge**        | Scènes narratives + destinations Comptoir, L'Aveugle, Contrats, Forge |
+| **Voyage / quête** | Boucle §1, objectif repliable, survie et inventaire                   |
+| **Donjon**         | Boucle §1, structure moteur cachée, aucun type de salle ou profondeur |
+| **Retour**         | Boucle §1, trajet plus court et plus facile, sans estimation affichée |
+| **Combat**         | Transformation tactique temporaire, puis retour à la boucle §1        |
 
-| Mode               | Ce qu'on y fait                                       | Rythme                   | Boucle §1 ? |
-| ------------------ | ----------------------------------------------------- | ------------------------ | ----------- |
-| 🧭 **Exploration** | Descendre, choisir sa salle, gérer les jauges         | Posé, narratif           | ✅ oui      |
-| ⚔️ **Combat**      | Tours, initiative, actions catégorisées (`10-COMBAT`) | Tendu, tactique, chiffré | ❌ non      |
-| 🏚️ **Auberge**     | Contrat, achats, forge, sac (`23 §1`)                 | Calme, sans jet de dé    | ❌ non      |
-| ⬆️ **Retour**      | Remonter avec ce qu'il reste (`23 §4`)                | Pressé, comptable        | ✅ oui      |
+### Règles de continuité
 
-### Pourquoi cette séparation
-
-Principe 12 (`01-PILLARS §9`) : **chaque registre de jeu a sa propre tête, et le dynamisme naît de
-l'alternance.** Deux activités rendues de façon identique se ressentent comme une seule activité,
-quel que soit le texte affiché.
-
-### Règles de bascule
-
-1. **La bascule est toujours annoncée** par une transition explicite — jamais un changement d'écran
-   silencieux au milieu d'un paragraphe.
-2. **Le joueur ne choisit pas son mode.** Il choisit des actions ; le moteur bascule. Seule
-   exception : le demi-tour (`23 §3`), qui est explicitement une décision du joueur.
-3. **Un mode = un état serveur.** Le mode courant est porté par la session, pas déduit par le
-   frontend à partir du texte de la scène.
+1. **Une seule coque narrative** porte tout le run hors combat.
+2. **Le combat est la seule transformation franche** : il conserve le décor et la dernière scène
+   consultable, mais rend ennemis, initiative, actions et jets tactiques.
+3. **L'état serveur reste autoritaire.** Le frontend peut lire `GameMode` pour savoir quand rendre
+   le combat ; il ne l'infère jamais depuis la prose.
+4. **Le demi-tour est toujours accessible hors combat.** Il ne dépend pas d'un choix proposé par
+   l'IA.
+5. **L'action libre survit au combat.** Le backend la traduit vers une action tactique autorisée.
 
 ---
 
@@ -331,17 +328,19 @@ TOUR DE JEU
                        (loop ↑)
 
 
-STRUCTURE DU RUN (visible — cf. 23-RUN-STRUCTURE)
+STRUCTURE DU RUN (mécanique cachée — cf. 23-RUN-STRUCTURE)
 ───────────────────────────────────────
-  🏚️ AUBERGE — contrat, achats, forge, sac
+  🏚️ AUBERGE NARRATIVE — comptoir, L'Aveugle, contrats, forge
        ↓
-  ⬇️ DESCENTE — 3 à 7 paliers selon le contrat
-       ↓   (le dramatique 3-actes ci-dessus reste, mais
-       ↓    il habille les paliers, il ne les remplace plus)
+  📜 UN CONTRAT PRINCIPAL — danger et durée seulement
        ↓
-  🔀 DEMI-TOUR — la décision centrale du jeu
+  🏜️ VOYAGE → QUÊTE / DONJON — même interface narrative
+       ↕
+  ⚔️ COMBAT — transformation tactique temporaire
        ↓
-  ⬆️ RETOUR — trajet distinct, plus court, préparable
+  🔀 DEMI-TOUR — toujours disponible hors combat
+       ↓
+  ⬆️ RETOUR — distinct, plus court, plus facile, sans estimation
        ↓
   FIN
   ├── 🏆 extracted        — vivant, contrat rempli
@@ -357,12 +356,12 @@ STRUCTURE DU RUN (visible — cf. 23-RUN-STRUCTURE)
   🏚️ Retour à l'auberge — connaissance et accès acquis
 ```
 
-🟢 _Une boucle avec une destination. Le joueur sait pourquoi il descend, et ce qu'il risque en
-remontant. Acteur, jamais spectateur._
+🟢 _Une boucle avec une destination. Le joueur sait pourquoi il part, mais jamais exactement ce que
+le monde lui réserve. Acteur, jamais spectateur._
 
 > **Note sur les 3 actes (§6).** La structure dramatique invisible n'est pas supprimée : elle
-> continue de rythmer la narration **à l'intérieur** d'un run. Ce qui change, c'est qu'elle n'est
-> plus la seule structure — les paliers donnent au joueur la structure **visible** qui lui manquait.
+> continue de rythmer la narration **à l'intérieur** d'un run. La structure mécanique existe en
+> parallèle côté backend, mais reste invisible pour préserver le mystère.
 
 ---
 
@@ -388,11 +387,11 @@ Les trois crochets ci-dessus sont tous **narratifs**. Ils font revenir un joueur
 pas un joueur qui veut jouer. C'est ce qui manquait au diagnostic « aucune raison de rejouer ».
 
 Le quatrième crochet est **mécanique** : entre deux runs, le joueur gagne de la **connaissance** et
-de l'**accès** — pages de bestiaire, sujets débloqués chez L'Aveugle, contrats plus profonds, routes
-de retour connues, compagnons rencontrés. Jamais de la puissance (`01-PILLARS §5`).
+de l'**accès** — pages de bestiaire, sujets débloqués chez L'Aveugle, contrats plus dangereux,
+destinations et compagnons rencontrés. Jamais de la puissance (`01-PILLARS §5`).
 
 > Le run 6 n'est pas plus facile que le run 1. C'est **le joueur** qui est meilleur — parce qu'il
-> sait maintenant ce qu'il y a au palier 5, et qu'il a une carte du retour.
+> reconnaît une créature, comprend un avertissement et sait quelles provisions emporter.
 
 Voir `14-META-WORLD.md` et `23-RUN-STRUCTURE §7`.
 

--- a/docs/public/raw/10-COMBAT.md
+++ b/docs/public/raw/10-COMBAT.md
@@ -27,12 +27,13 @@ Le combat dans GRIMOIRE utilise les mêmes attributs et le même dé que le rest
 > La version précédente affirmait que le combat « n'est pas un mode de jeu » et n'était qu'une
 > application de la boucle narrative. **C'est révoqué** (décision 7 de la refonte roguelike).
 >
-> Le combat a **sa propre interface** : liste des ennemis avec leur état, ordre des tours, actions
-> catégorisées, journal des jets. Il ne se joue pas dans le même écran que l'exploration.
+> Le combat est la **seule transformation tactique de l'interface narrative** : liste des ennemis
+> avec leur état, ordre des tours, actions catégorisées et journal des jets. Le décor du lieu et la
+> dernière scène restent dans la continuité ; à la fin, le joueur revient au storytelling.
 >
-> _Pourquoi_ : principe 12 (`01-PILLARS §9`) — chaque registre de jeu a sa propre tête, et le
-> dynamisme naît de l'alternance. Un combat rendu comme un paragraphe de plus se **lit** comme un
-> paragraphe de plus, et le joueur ne sent jamais qu'il vient de changer d'activité.
+> _Pourquoi_ : principe 12 (`01-PILLARS §9`) — le storytelling porte tout le run, mais un combat
+> rendu comme un paragraphe de plus se **lit** comme un paragraphe de plus. La scène doit donc se
+> resserrer et révéler ses règles sans donner l'impression de quitter l'aventure.
 >
 > La bascule reste **narrative et annoncée** (§1) — ce qui change, c'est ce que le joueur voit à
 > l'écran une fois qu'elle a eu lieu.
@@ -50,7 +51,7 @@ Le combat dans GRIMOIRE utilise les mêmes attributs et le même dé que le rest
 ## 1. Quand un combat se déclenche
 
 Le combat n'est **jamais activé par le joueur** : c'est une **bascule narrative** annoncée par l'IA,
-qui fait entrer le jeu dans son mode dédié (§0).
+qui transforme temporairement la scène en combat (§0).
 
 ### Déclencheurs
 
@@ -282,10 +283,10 @@ Jet : d20 + SOUFFLE  vs  DC 12 (combat normal) ou 15 (encerclé / engagé)
 Dans la structure de run (`23-RUN-STRUCTURE`), fuir n'est pas seulement « sortir du combat » : le
 joueur choisit **vers où**.
 
-| Direction         | Effet                                                                            |
-| ----------------- | -------------------------------------------------------------------------------- |
-| ⬇️ **En avant**   | Le combat est évité, mais on s'enfonce d'un palier de plus — le retour s'allonge |
-| ⬆️ **En arrière** | Le joueur amorce le demi-tour et bascule sur le trajet de retour (`23 §3`)       |
+| Direction         | Effet                                                                   |
+| ----------------- | ----------------------------------------------------------------------- |
+| ⬇️ **En avant**   | Le combat est évité, mais le joueur poursuit sa quête et ses risques    |
+| ⬆️ **En arrière** | Le joueur amorce le demi-tour et commence le trajet de retour (`23 §5`) |
 
 C'est ce qui transforme un combat perdu d'avance en **décision** au lieu d'une punition : le joueur
 mal en point garde toujours une porte de sortie, mais elle coûte le butin qu'il espérait plus bas.

--- a/docs/public/raw/11-INVENTORY-ECONOMY.md
+++ b/docs/public/raw/11-INVENTORY-ECONOMY.md
@@ -89,20 +89,20 @@ intéressante**. Elle crée un arbitrage impossible à esquiver :
          ↓
    moins de place pour le butin
          ↓
-   descendre moins profond
+   devoir rentrer plus tôt
 
    Emporter moins
          ↓
    plus de place pour le butin
          ↓
-   descendre plus profond… mais le retour devient mortel
+   avancer plus longtemps… mais le retour devient mortel
 ```
 
 Le joueur doit **garder des slots libres à l'aller** pour ce qu'il compte ramener. Un sac plein au
-palier 3 signifie qu'on ne peut plus rien prendre — ou qu'il faut jeter quelque chose de vital.
+milieu d'une quête signifie qu'on ne peut plus rien prendre — ou qu'il faut jeter quelque chose de vital.
 
 🔴 _Anti-règle : ne jamais assouplir la capacité pour « confort ». Sans cette contrainte, la
-préparation à l'auberge n'est qu'un clic, et le choix de profondeur perd son poids._
+préparation à l'auberge n'est qu'un clic, et la décision de continuer perd son poids._
 
 ---
 
@@ -277,12 +277,13 @@ se décident sans calcul._
 
 > **L'usure ne doit jamais être une taxe silencieuse.**
 
-Chaque franchissement de palier est annoncé au joueur, en langage de personnage :
+Chaque changement d'état de l'objet est annoncé au joueur, en langage de personnage :
 
 > _« Ta lame a mordu quelque chose de plus dur qu'elle. Elle ne coupe plus comme avant. »_
 
-C'est une application directe du principe 11 (`01-PILLARS §9`) : un objet qui passe à **usé** en
-profondeur est un **avertissement** — un signal de plus qui dit qu'il est temps de faire demi-tour.
+C'est une application directe du principe 11 (`01-PILLARS §9`) : le monde futur reste mystérieux,
+mais la dégradation déjà subie n'est jamais cachée. Une arme **usée** est une information réelle sur
+laquelle le joueur peut décider de faire demi-tour.
 
 ### L'arbitrage de la forge
 
@@ -528,21 +529,21 @@ Les **donjons** sont là où dorment les artefacts (cf. décision L5).
 - **Donjon majeur** (5-7 salles, boss, artefact garanti)
 - **Donjon archontique** (rare, 7-10 salles, plusieurs artefacts, boss épique)
 
-### ⛏️ Le donjon est un palier, pas un run
+### ⛏️ Le donjon est un lieu de quête, pas nécessairement le run entier
 
-> **Précision du 2026-08-06.** Cette section décrit la structure d'**un palier** de la descente
-> (`23-RUN-STRUCTURE §2`), pas la structure d'un run complet. Un run enchaîne **3 à 7 paliers**
-> selon le contrat accepté à l'auberge.
+> **Révision du 2026-08-08.** Un contrat peut conduire à un donjon, mais aussi à une escorte, une
+> enquête, une chasse ou un dilemme. Le moteur peut segmenter un donjon en salles et paliers
+> internes ; cette structure reste cachée au joueur en v0.2.1 (`23-RUN-STRUCTURE §4`).
 
 Deux conséquences directes sur les règles ci-dessus :
 
-| Règle §9                                     | Lecture dans la boucle de run                                                                                     |
-| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| « Le joueur ne sort jamais les mains vides » | Vrai **par palier**. Un run, lui, peut parfaitement se terminer les mains vides — c'est le prix du demi-tour raté |
-| Loot garanti (artefact / fer / Tier 2)       | Garanti **à l'atteinte** du palier, pas à la remontée. Le loot n'est acquis que s'il **rentre à l'auberge**       |
-| Salle boss « optionnelle »                   | Devient le **palier terminal** du contrat : c'est là que se trouve l'objectif du contrat                          |
+| Règle §9                                     | Lecture dans la boucle de run                                                                       |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| « Le joueur ne sort jamais les mains vides » | Vrai pour un donjon complété. Un run interrompu peut finir à vide si le joueur rentre sans objectif |
+| Loot garanti (artefact / fer / Tier 2)       | Garanti à la résolution du lieu, mais acquis seulement si le joueur rentre vivant à l'Auberge       |
+| Salle boss « optionnelle »                   | Peut porter l'objectif d'un contrat de donjon sans que sa présence soit annoncée à l'avance         |
 
-C'est la nuance qui rend la boucle tendue : **descendre est récompensé, remonter est ce qui compte.**
+C'est la nuance qui rend la boucle tendue : **continuer est récompensé, rentrer est ce qui compte.**
 Le butin n'est jamais compté au moment où on le ramasse, seulement au moment où on ressort vivant.
 
 ---

--- a/docs/public/raw/14-META-WORLD.md
+++ b/docs/public/raw/14-META-WORLD.md
@@ -51,8 +51,8 @@ GRIMOIRE n'est pas un MMO. Pas de saisons, pas de raids, pas de classement publi
 
 - Lié au **joueur**, survit à la mort du perso
 - **Ce n'est pas de la narration : c'est de la progression de jeu**
-- Débloque de la **connaissance** (bestiaire, routes, faiblesses) et de l'**accès** (contrats plus
-  profonds, sujets chez L'Aveugle, compagnons, exploits)
+- Débloque de la **connaissance** (bestiaire, destinations, faiblesses) et de l'**accès** (contrats
+  plus dangereux, sujets chez L'Aveugle, compagnons, exploits)
 - **Jamais de puissance** — voir la règle absolue en §1bis
 
 ---
@@ -74,8 +74,8 @@ joueur une raison **mécanique** de relancer un run. C'est le trou identifié da
 | ✅ Persiste entre les runs                         | ❌ Ne persiste jamais                         |
 | -------------------------------------------------- | --------------------------------------------- |
 | Pages de bestiaire (CA, faiblesses, comportements) | Bonus permanents de PV, dégâts ou attribut    |
-| Routes de retour connues                           | Équipement cumulé d'un run à l'autre          |
-| Contrats plus profonds débloqués                   | Réduction de difficulté                       |
+| Destinations et dangers déjà rencontrés            | Équipement cumulé d'un run à l'autre          |
+| Contrats plus dangereux débloqués                  | Réduction de difficulté                       |
 | Sujets de conversation chez L'Aveugle              | Tout « build » qui monte run après run        |
 | Compagnons rencontrés (rappelables plus tard)      | Monnaie accumulée sans plafond                |
 | Exploits/badges → déblocages d'accès               | Toute récompense d'exploit qui rend plus fort |
@@ -87,9 +87,9 @@ Trois raisons, dans l'ordre d'importance :
 
 1. **La difficulté reste honnête.** Si le run 10 est mécaniquement plus facile que le run 1, la mort
    au run 3 n'était qu'une taxe de temps. Avec du savoir seul, une mort reste **imputable au joueur**
-   — ce qui est exactement le principe 11 (`01-PILLARS §9`).
+   — l'état du personnage reste lisible, même si le monde conserve ses secrets (`01-PILLARS §9`).
 2. **Le joueur progresse vraiment.** Ce qui s'améliore, c'est sa lecture du jeu : il sait quoi
-   emporter, où faire demi-tour, quelle créature fuir. C'est la progression la plus durable — et la
+   emporter, quelle créature fuir et quel avertissement narratif reconnaître. C'est la progression la plus durable — et la
    seule qui ne se dévalue jamais.
 3. **Ça reste finançable.** Une progression de puissance oblige à rééquilibrer tout le bestiaire à
    chaque palier de build. Une progression de connaissance ne coûte que du contenu.
@@ -102,8 +102,8 @@ perso et n'est jamais rattachée à un `Character`.
 ```
 PlayerKnowledge
   ├── bestiary        : créatures rencontrées → ce qu'on en sait
-  ├── routes          : trajets de retour connus par palier
-  ├── contracts       : profondeurs débloquées
+  ├── destinations    : lieux et risques déjà rencontrés
+  ├── contracts       : familles de quêtes et dangers débloqués
   ├── topics          : sujets ouverts chez L'Aveugle
   └── feats           : exploits accomplis → accès débloqués
 ```
@@ -115,9 +115,9 @@ backend ni l'UI ne peuvent l'afficher de façon fiable.
 ### Ce que le joueur en voit
 
 La connaissance doit être **consultable**, sinon elle n'existe pas pour lui : une page bestiaire qui
-se remplit, une carte de retour qui se dessine, une liste de contrats dont certains sont encore
-grisés. C'est ce qui rend le progrès **visible entre deux runs** — le moment où l'on décide de
-relancer.
+se remplit, des destinations connues et une liste de contrats dont certains sont encore grisés.
+La v0.2.1 n'affiche pas de carte de donjon, profondeur ou route de retour : le progrès devient
+visible entre les runs sans révéler la structure d'un run futur.
 
 ---
 

--- a/docs/public/raw/15-GAME-MASTER.md
+++ b/docs/public/raw/15-GAME-MASTER.md
@@ -16,6 +16,25 @@ Si l'IA tente de décider (« le marchand baisse son prix de 30% », « tu trouv
 
 C'est la règle qui protège le jeu de l'effondrement : sans elle, l'IA dérive en quelques tours vers une fanfiction incohérente, et le joueur perd confiance.
 
+### §0bis — Contrat actif et continuité de quête
+
+Un contrat est une quête structurée par le backend. À chaque tour hors Auberge, le prompt reçoit :
+
+- l'objectif principal et la destination ;
+- les étapes accomplies et les faits qui conditionnent la suite ;
+- les conditions de réussite ou d'échec déjà déclenchées ;
+- le décor courant sélectionné par le jeu ;
+- les derniers détours réellement choisis par le joueur.
+
+L'IA doit respecter l'action libre, même si elle éloigne temporairement de l'objectif. Elle adapte
+la scène, rappelle la quête quand le contexte le justifie et propose régulièrement au moins une voie
+naturelle pour reprendre sa progression. Elle ne téléporte pas le joueur, ne refuse pas un détour et
+ne déclare jamais seule un contrat réussi ou échoué.
+
+La structure cachée du run n'entre pas dans la prose joueur : aucun type de prochaine salle, indice,
+palier, profondeur ou estimation de retour. Les calculs internes éventuellement fournis au moteur ne
+doivent pas apparaître dans le contexte narratif du modèle.
+
 ---
 
 ## §1 — Les 3 voix d'écriture (Pilier #6)
@@ -71,6 +90,11 @@ GRIMOIRE n'a **aucun audio en V1**. Tout passe par le **texte**. Mais le texte a
 | **Changepeau** | Elliptique, énigmatique    | Phrases inachevées, pronoms flous        | _« On t'attendait. Enfin — on disait. Tu décideras toi-même. »_                                                 |
 
 **Tous les PNJ génériques** (marchands, gardes, ivrognes, pèlerins) tombent dans une de ces 5 voix selon leur origine. **Pas de voix unique par PNJ secondaire** — économie de prompt.
+
+Le tenancier du Comptoir de l'Auberge appartient à cette catégorie tant qu'une identité canonique
+distincte n'est pas écrite. Il vend eau, vivres, soins et ressources. L'Aveugle reste la voix du
+lore, des Souvenirs, des recommandations et des contrats spéciaux ; il n'absorbe pas toutes les
+fonctions commerciales de l'Auberge.
 
 ---
 

--- a/docs/public/raw/18-RETENTION.md
+++ b/docs/public/raw/18-RETENTION.md
@@ -27,7 +27,7 @@ m'ennuie, il n'y a aucune raison de recommencer »_.
 L'ordre est donc :
 
 ```
-0. La boucle est bonne   ← 23-RUN-STRUCTURE (contrat → paliers → demi-tour → retour)
+0. La boucle est bonne   ← 23-RUN-STRUCTURE (quête → voyage → mystère → combat → retour)
    1. Souvenirs nommés
       2. Chronique
          3. Monde qui change

--- a/docs/public/raw/22-GLOSSARY.md
+++ b/docs/public/raw/22-GLOSSARY.md
@@ -110,7 +110,8 @@ Avantage Premium : queue Redis 2 niveaux (`priority:high` Premium / `priority:no
 → [19-MONETIZATION §2](19-MONETIZATION.md), [20-ARCHITECTURE §6](20-ARCHITECTURE.md)
 
 **FLUX schnell / FLUX dev** _🤖 IA / Tech_
-Modèles de génération d'images. **FLUX schnell** = rapide + gratuit (utilisé pour tous). **FLUX dev** = qualité supérieure (utilisé pour illustration Chronique Premium uniquement).
+Modèles de génération d'images historiquement envisagés pour la Chronique. Les **images de scène
+v0.2.1 sont pré-générées pendant le développement** et ne déclenchent aucun modèle au runtime.
 → [17-RUN-CHRONICLE §4](17-RUN-CHRONICLE.md), [19-MONETIZATION §1.3](19-MONETIZATION.md)
 
 ## G
@@ -127,8 +128,9 @@ Tier d'utilisateur avec compte créé (email + magic link). Cap = **150 requête
 ## H
 
 **Hub permanent** _⚙️ Mécanique_
-L'Auberge de L'Aveugle — point d'entrée unique de chaque run. Pas de menu, pas de lobby. Le joueur arrive toujours là.
-→ [07-CHARACTER-CREATION §3](07-CHARACTER-CREATION.md)
+L'Auberge de L'Aveugle — point d'entrée unique de chaque run. Pas de menu, pas de lobby : quatre
+destinations fictionnelles restent accessibles, Comptoir, L'Aveugle, Contrats et Forge.
+→ [07-CHARACTER-CREATION](07-CHARACTER-CREATION.md), [23-RUN-STRUCTURE §1](23-RUN-STRUCTURE.md)
 
 ## L
 
@@ -239,8 +241,11 @@ Peuple des oasis fertiles, érudits et marchands. Voix PNJ lyrique, métaphores 
 → [GAME_DESIGN §5](../docs/GAME_DESIGN.md), [15-GAME-MASTER §1](15-GAME-MASTER.md)
 
 **Run** _⚙️ Mécanique_
-Une session de jeu complète (2-4h en V1, 3-15h annoncé long terme). Commence à l'Auberge, finit par mort ou choix de fin. Génère une Chronique.
-→ [09-ACTION-LOOP](09-ACTION-LOOP.md), [17-RUN-CHRONICLE](17-RUN-CHRONICLE.md)
+Une session de jeu complète de 2h30 maximum. Elle commence à l'Auberge, devient mécaniquement active
+au départ avec un contrat principal, puis finit par retour, mort, Calamine ou abandon. Auberge,
+voyage, quête, donjon et retour partagent la même interface narrative ; chaque fin génère une
+Chronique.
+→ [09-ACTION-LOOP](09-ACTION-LOOP.md), [23-RUN-STRUCTURE](23-RUN-STRUCTURE.md), [17-RUN-CHRONICLE](17-RUN-CHRONICLE.md)
 
 ## S
 

--- a/docs/public/raw/23-RUN-STRUCTURE.md
+++ b/docs/public/raw/23-RUN-STRUCTURE.md
@@ -1,331 +1,286 @@
 # 23 — Structure du Run
 
-> _Descendre est facile. C'est remonter qui tue._
+> _Le monde ne te montre pas sa carte. Il te laisse seulement choisir si tu continues._
 
 ---
 
 ## 0. Principe
 
-Ce fichier définit **la forme d'un run** : ce que le joueur part faire, jusqu'où il descend, et
-comment il rentre. Il est né du grilling de conception du **2026-08-06**, qui a identifié la cause
-du symptôme _« je teste une fois, puis je n'ai plus envie de jouer »_ :
+Ce fichier définit la forme d'un run : pourquoi le joueur part, comment la quête reste cohérente,
+où vit la structure roguelike et comment il rentre. La révision du **2026-08-08** remplace la
+séparation en quatre interfaces décidée le 2026-08-06.
 
-> **Le jeu avait un excellent moteur de narration et zéro moteur de jeu.**
-> La survie, les dés, les conditions et l'inventaire existaient — mais **rien ne les mettait sous
-> pression**, parce que le run n'avait ni objectif, ni structure, ni fin désirable.
+> **GRIMOIRE reste un storytelling continu.** Le roguelike vient des règles, des ressources, du
+> risque, de la mort et des conséquences — pas d'une carte de salles ni d'un changement d'écran.
 
-Un run n'est pas une promenade conversationnelle. C'est un **aller-retour sous contrainte** :
+Le run complet suit cette continuité :
 
-```
-AUBERGE (préparation)  →  DESCENTE (paliers)  →  DEMI-TOUR  →  RETOUR  →  AUBERGE
-```
-
-Tout ce qui suit sert une seule tension : **prendre encore un palier, ou rentrer avec ce qu'on a ?**
-
----
-
-## 1. Le contrat
-
-Le joueur ne part pas « à l'aventure ». Il **accepte un contrat** à l'auberge, qui fixe :
-
-| Le contrat définit         | Effet                                                     |
-| -------------------------- | --------------------------------------------------------- |
-| 🎯 **La destination**      | Quel type de lieu (voir les 4 archétypes, `03-BESTIARY`)  |
-| 📏 **La profondeur visée** | Nombre de paliers — détermine risque et récompense        |
-| ⏱️ **La durée cible**      | ~45 min (3 paliers) → 2h30 maximum (7 paliers)            |
-| 🪙 **La récompense**       | Ce que le commanditaire paye au retour, **si** on revient |
-
-### Barème de durée
-
-| Paliers | Durée cible  | Profil                                     |
-| ------- | ------------ | ------------------------------------------ |
-| 3       | ~45 min      | Court, tendu, idéal pour une session brève |
-| 5       | ~1h30        | Standard                                   |
-| 7       | **2h30 max** | Long, réservé aux joueurs préparés         |
-
-> **⏱️ Le plafond de 2h30 est dur.** Aucun contrat ne peut le dépasser (`01-PILLARS §2`).
-> Le joueur choisit sa durée : c'est **lui** qui décide de l'engagement qu'il prend ce soir-là.
-
-🟢 _Le contrat résout d'un coup trois problèmes : le run a un objectif, la durée est prévisible, et
-le joueur sait pourquoi il part._
-
----
-
-## 2. Les paliers
-
-Un run descend par **paliers successifs**. Chaque palier est plus dangereux et plus riche que le
-précédent — c'est la courbe qui crée la tentation.
-
-```
-        AUBERGE
-           │
-     ┌─────▼─────┐
-     │ PALIER 1  │  créatures faibles · loot commun
-     ├───────────┤
-     │ PALIER 2  │
-     ├───────────┤
-     │ PALIER 3  │  ← profondeur minimale d'un contrat
-     ├───────────┤
-     │    ...    │  danger ↗   loot ↗   coût du retour ↗
-     ├───────────┤
-     │ PALIER 7  │  ← profondeur maximale · boss · artefacts
-     └───────────┘
+```text
+AUBERGE → CONTRAT → VOYAGE → QUÊTE / DONJON → DEMI-TOUR → RETOUR → AUBERGE
+                               ↕
+                         COMBAT TACTIQUE
 ```
 
-### Salles à choix
-
-Chaque palier se traverse par des **salles**. À chaque salle franchie, le joueur choisit sa suite
-parmi 2-3 salles, décrites par des **indices partiels** :
-
-```
-        ┌──────────────────────────────┐
-        │  Devant toi, trois passages. │
-        └──────────────────────────────┘
-                       │
-     ┌─────────────────┼─────────────────┐
-     ▼                 ▼                 ▼
- « Ça sent le     « Un courant     « Des marques
-   sang froid »     d'air sec »      griffées »
-  [risque élevé]   [neutre]        [inconnu]
-```
-
-**Règle de l'indice** : l'indice renseigne sur la **nature** du danger, jamais sur son **ampleur**.
-Le joueur choisit en connaissance de cause sans que le jeu lui donne la solution.
-
-🟢 _Emprunté à Slay the Spire : le choix de salle est le geste de jeu le plus fréquent. C'est là que
-se joue la rejouabilité, bien plus que dans la variété des ennemis._
-
-### Types de salles
-
-| Type               | Contenu                                                      |
-| ------------------ | ------------------------------------------------------------ |
-| ⚔️ **Combat**      | Rencontre hostile (`10-COMBAT`)                              |
-| 🔍 **Exploration** | Énigme, fouille, découverte de lore                          |
-| 🎭 **Rencontre**   | PNJ, dilemme moral, marchand isolé, compagnon recrutable     |
-| 🔥 **Répit**       | Repos court, soin, réparation de fortune — rare et précieux  |
-| 💰 **Trésor**      | Loot, parfois gardé, parfois piégé                           |
-| 💀 **Boss**        | Fin de palier profond — verrouille l'accès au palier suivant |
+L'Auberge, le voyage, le donjon et le retour utilisent la **même interface narrative**. Seul le
+combat transforme temporairement la scène en interface tactique dédiée.
 
 ---
 
-## 3. Le demi-tour — le cœur du jeu
+## 1. L'Auberge — point d'entrée unique
 
-À la fin de chaque palier, le jeu pose **la seule question qui compte** :
+Chaque partie commence à l'Auberge de L'Aveugle. Ce n'est ni un menu ni un tableau de gestion :
+c'est un lieu vivant composé de scènes illustrées et de dialogues.
 
-```
-┌────────────────────────────────────────────────────┐
-│  Tu as atteint le palier 4.                        │
-│                                                     │
-│  🎒 Sac : 9/12 · 💧 Eau : 2 rations                │
-│  ⏱️ Retour estimé : ~25 min · 3 paliers à remonter │
-│                                                     │
-│  [ DESCENDRE ENCORE ]      [ FAIRE DEMI-TOUR ]     │
-└────────────────────────────────────────────────────┘
-```
+Quatre destinations restent accessibles sans coût depuis l'interface narrative :
 
-Le joueur voit **toujours** son estimation de retour avant de décider. C'est l'application directe
-du principe 11 (`01-PILLARS §9`) : _la mort doit être imputable à une décision vue venir._
+| Destination   | Fonction                                                       |
+| ------------- | -------------------------------------------------------------- |
+| **Comptoir**  | Acheter eau, vivres, soins et ressources                       |
+| **L'Aveugle** | Lore, Souvenirs, commentaire des contrats et contrats spéciaux |
+| **Contrats**  | Consulter les trois quêtes ordinaires disponibles              |
+| **Forge**     | Réparer et préparer l'équipement                               |
 
----
-
-## 4. Le retour
-
-> **Le retour n'est pas une cinématique. C'est la deuxième moitié du jeu.**
-
-C'est la décision de design la plus structurante de ce document. Dans la plupart des jeux, une fois
-l'objectif atteint, on appuie sur « rentrer ». Ici, **rentrer est un trajet**.
-
-### Ses trois propriétés
-
-| Propriété              | Détail                                                                 |
-| ---------------------- | ---------------------------------------------------------------------- |
-| 🧭 **Trajet distinct** | Ce n'est pas la descente rejouée à l'envers — le chemin a changé       |
-| ⚡ **Plus court**      | Le retour est nettement plus rapide que la descente : on ne rejoue pas |
-| 🎒 **Préparable**      | Ce qu'on a gardé dans le sac à l'aller décide de la survie au retour   |
-
-### Pourquoi plus court
-
-Un retour aussi long que la descente serait **du remplissage** : le joueur a déjà vu ces lieux, la
-tension retomberait et le run dépasserait 2h30. Le retour est court **et plus dense** : moins de
-salles, mais aucune n'est gratuite.
-
-### Ce qui rend le retour dangereux
-
-- Le sac est **lourd** du butin : moins de place pour l'eau et les soins
-- Les jauges de survie sont **déjà entamées** (`06-SURVIVAL`)
-- L'équipement s'est **usé** en profondeur (`11-INVENTORY-ECONOMY`)
-- La Calamine accumulée par les artefacts **ne redescend pas** toute seule
-
-### La règle absolue du retour
-
-> **Le retour peut tuer, mais jamais par surprise.**
-
-Concrètement, le moteur doit garantir :
-
-1. Une **estimation de retour** visible avant chaque décision de descendre
-2. Un **avertissement au franchissement de seuil** : quand une ressource passe sous le nécessaire
-   pour rentrer, le jeu le dit — clairement, en langage de personnage, pas en pop-up système
-3. Aucun **pic de dégâts non annoncé** au retour : la mort au retour vient de l'épuisement du
-   joueur, résultat de ses arbitrages, jamais d'une embuscade arbitraire
-
-🔴 _Anti-règle : jamais de « gotcha » au retour. Si le joueur meurt à trois salles de la sortie, il
-doit pouvoir nommer la décision qui l'a tué._
+Ces destinations sont des raccourcis de navigation, pas des écrans étrangers à la fiction. Chacune
+ouvre une scène avec son propre décor, son interlocuteur et ses choix narratifs.
 
 ---
 
-## 5. Les fins de run
+## 2. Le contrat est une quête
 
-La fin d'un run n'est plus binaire. `SessionEndReason` distingue :
+Le joueur ne choisit pas un « niveau ». Il accepte une **quête principale** qui donne une direction
+à son histoire.
 
-| Fin                  | Déclencheur                                          | Récompense                                             |
-| -------------------- | ---------------------------------------------------- | ------------------------------------------------------ |
-| 🏆 **Retour réussi** | Le joueur rentre **avec** le butin du contrat        | Butin + paiement du contrat + connaissance + Chronique |
-| 🥀 **Retour à vide** | Le joueur rentre vivant mais sans remplir le contrat | Ce qu'il a ramassé + connaissance + Chronique          |
-| 💀 **Mort**          | 0 PV, l'IA tranche l'inconscience (`10-COMBAT §8`)   | Chronique + héritage transmis                          |
-| 🌀 **Calciné**       | Calamine à 100                                       | Chronique spéciale, **pas d'héritage**                 |
-| 🚪 **Abandon**       | Le joueur quitte volontairement                      | Chronique minimale                                     |
+Un contrat peut être une exploration de donjon, une escorte, une enquête, une chasse, une
+récupération, une négociation ou un dilemme. La majorité des contrats majeurs mène vers un lieu
+très dangereux, mais le système ne suppose jamais que toute quête est un donjon.
 
-> ⚠️ **Correction de contrat** : l'ancien `endReason: "inn"` confondait « rentré victorieux » et
-> « rentré bredouille ». Ces deux fins ne racontent pas la même histoire et ne payent pas pareil.
-> Elles doivent être distinguées dans `session.types.ts`.
+### Ce que le backend possède
 
-### Ce que rapporte un run
+| Champ               | Rôle                                                               |
+| ------------------- | ------------------------------------------------------------------ |
+| Objectif            | Condition mécanique de réussite                                    |
+| Destination         | Lieu ou personne vers laquelle la narration doit converger         |
+| Commanditaire       | Source et voix de la quête                                         |
+| Danger              | Niveau qualitatif utilisé pour la génération et l'équilibrage      |
+| Durée cible         | Engagement court, long ou majeur                                   |
+| Récompense          | Paiement et conséquences en cas de réussite                        |
+| Conditions d'échec  | États qui rendent la quête impossible ou marquent le retour à vide |
+| État de progression | Étapes accomplies, objectif sécurisé, réussite ou échec            |
 
-Trois choses, dans cet ordre d'importance :
+Le backend choisit et valide cette structure. L'IA lui donne sa prose, ses personnages et ses
+scènes ; elle ne peut ni inventer la condition de victoire ni déclarer seule la quête terminée.
 
-1. 🪙 **Le butin** — finance le run suivant (équipement, réparations, contrats plus ambitieux)
-2. 🧠 **La connaissance** — bestiaire, faiblesses, sujets débloqués chez L'Aveugle, accès
-3. 📖 **La Chronique** — le récit de ce qui vient de se passer (`17-RUN-CHRONICLE`)
-4. 🏅 **Les exploits** éventuellement obtenus (badges, voir §7)
+### Le panneau
 
-**Jamais de puissance permanente** (`01-PILLARS §2`, pilier 5).
+- présente **trois contrats ordinaires** simultanément ;
+- conserve la sélection jusqu'à la fin d'un run ou un événement du monde ;
+- affiche un **tag textuel de danger** et un **tag de durée**, sans score ni icône ;
+- ne révèle jamais les rencontres, la structure du lieu ni les récompenses cachées.
 
----
+L'Aveugle peut commenter ces contrats, en recommander un selon l'histoire du joueur et révéler des
+contrats spéciaux débloqués par le lore ou les Souvenirs. Les contrats ordinaires restent cependant
+disponibles sans dépendre d'une décision du modèle IA.
 
-## 6. Les modes de jeu
+### Liberté et verrouillage
 
-Un run traverse quatre **modes**, chacun avec sa propre interface (`09-ACTION-LOOP`, principe 12) :
-
-| Mode               | Ce que l'écran doit faire ressentir                                     |
-| ------------------ | ----------------------------------------------------------------------- |
-| 🏠 **Auberge**     | Calme, tabulaire. On compare, on arbitre. Aucun danger                  |
-| 🧭 **Exploration** | Le texte respire. On lit, on choisit, l'image porte l'ambiance          |
-| ⚔️ **Combat**      | Ça se resserre. Tour par tour, état des ennemis, tension                |
-| 🏃 **Retour**      | Compte à rebours implicite. Les ressources fondent, la pression se voit |
-
-🟢 _Le passage d'un mode à l'autre est une **transition franche**. C'est l'alternance qui crée le
-dynamisme — pas la vitesse d'affichage du texte._
-
----
-
-## 7. Les exploits (badges)
-
-Objectifs optionnels détectés en fin de run. Exemples :
-
-- Collecter 3 artefacts dans un seul run
-- Terminer un run sans boire une seule potion
-- Vaincre L'Haragon
-
-> **⚖️ Un exploit débloque de l'accès ou de la connaissance, jamais de la puissance.**
-> Un contrat inédit, une destination, un compagnon recrutable, un sujet chez L'Aveugle, une entrée
-> de bestiaire — jamais des PV, des dégâts ou un bonus d'attribut.
-
-🟢 _Fonction réelle : les exploits **enseignent le jeu par l'expérimentation**. « Finir un run sans
-potion » apprend la gestion de ressources bien mieux qu'un tutoriel._
-
-Les exploits sont détectés **côté backend** à partir de l'historique réel du run, jamais déclarés
-par l'IA.
+- Un seul contrat principal peut être actif.
+- Un contrat est obligatoire pour quitter l'Auberge en v0.2.1.
+- Le joueur peut en changer sans pénalité tant qu'il n'est pas parti.
+- Le contrat se verrouille au franchissement de la porte de l'Auberge.
+- Aucun contrat n'est bloqué selon l'équipement : le jeu avertit, le joueur décide.
+- Des objectifs secondaires peuvent émerger, sans devenir des contrats supplémentaires.
 
 ---
 
-## 8. Les compagnons
+## 3. Le run commence au départ
 
-Le joueur peut emmener **1 à 2 compagnons**, jamais plus.
+Le run ne commence pas à l'entrée d'un donjon. Il commence lorsque le joueur quitte l'Auberge :
+les ressources sont engagées, les conséquences persistent et la quête devient active.
 
-| Propriété              | Détail                                                                        |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| 🤝 **Semi-autonomes**  | Ils agissent seuls en combat — aucun micro-management                         |
-| ❤️ **Loyauté**         | Ils réagissent aux décisions du joueur (fuir, sacrifier, abandonner du butin) |
-| 💀 **Mort permanente** | Un compagnon mort ne revient pas                                              |
-| 🎒 **Coûteux**         | Ils consomment vivres et eau, et prennent de la place                         |
+Le voyage est déjà du roguelike narratif : il peut consommer de l'eau ou des vivres, produire une
+rencontre, offrir un objet, infliger une condition ou déclencher un combat. Le joueur continue
+d'utiliser la boucle normale : narration, image, choix proposés et action libre.
 
-_Pourquoi si peu_ : un groupe de quatre transforme le jeu en gestion tactique et dilue la survie —
-le joueur cesse d'être vulnérable. Le charisme d'un compagnon ne vient pas du nombre, il vient du
-fait qu'on **peut le perdre par sa faute**.
+### Cohérence de la quête
 
-> **Garde-fou** : un compagnon ne doit jamais rendre le run plus facile **en net**. Il apporte une
-> capacité que le joueur n'a pas, mais il consomme des ressources et il peut mourir.
+Le backend réinjecte l'objectif et son état au narrateur à chaque tour. L'IA doit :
 
-Le rôle **Commandement** de CENDRE (`10-COMBAT §5`) trouve ici son emploi réel.
+1. respecter toute action libre du joueur ;
+2. adapter la scène aux détours réellement choisis ;
+3. ne jamais oublier le contrat actif ;
+4. proposer régulièrement au moins une voie naturelle vers l'objectif ;
+5. rappeler la quête dans la prose lorsqu'elle devient pertinente, sans répéter la même phrase.
 
----
-
-## 9. Risques & garde-fous
-
-| Risque                                          | Mitigation                                                                                |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| **Le joueur descend toujours au maximum**       | La courbe de danger doit rendre le palier suivant réellement menaçant ; le sac se remplit |
-| **Le joueur rentre toujours au premier palier** | Le paiement du contrat n'est dû qu'à l'objectif atteint — rentrer trop tôt coûte          |
-| **Le retour devient du remplissage**            | Retour nettement plus court que la descente, chemin distinct, aucune salle gratuite       |
-| **Mort au retour ressentie comme injuste**      | Estimation visible + avertissements de seuil + aucun pic non annoncé (§4)                 |
-| **Run qui dépasse 2h30**                        | Plafond dur au niveau du contrat ; le moteur ne peut pas générer plus de 7 paliers        |
-| **Paliers répétitifs**                          | Salles à choix + variantes contrôlées du bestiaire (`03-BESTIARY`)                        |
-| **Méta-progression qui rend le jeu facile**     | Règle absolue : connaissance et accès uniquement (`01-PILLARS §2`)                        |
-| **Compagnon qui trivialise la survie**          | Coût en ressources + mort permanente + pas de micro-gestion (§8)                          |
+Le HUD porte un rappel repliable de l'objectif principal. Il n'affiche ni checklist ni flèche de
+direction. Un détour n'échoue pas automatiquement : la quête échoue seulement si le joueur revient
+sans l'objectif, l'abandonne explicitement ou accomplit une action qui la rend impossible.
 
 ---
 
-## 10. Synthèse
+## 4. Donjons — structure cachée, expérience narrative
 
-```
-                    🏠 AUBERGE
-                        │
-          ┌─────────────▼─────────────┐
-          │  Contrat  : destination,  │
-          │             profondeur,   │
-          │             durée         │
-          │  Sac      : trop petit    │
-          │  Forge    : réparer ?     │
-          │  Compagnon: qui emmener ? │
-          └─────────────┬─────────────┘
-                        ▼
-              ⛏️  DESCENTE (paliers)
-                        │
-        ┌───────────────▼───────────────┐
-        │  Salle à choix (indice partiel)│
-        │  Combat · Explo · Rencontre    │
-        │  Répit · Trésor · Boss         │
-        └───────────────┬───────────────┘
-                        ▼
-            ┌───────────────────────┐
-            │  DESCENDRE ENCORE ?   │ ◄── le cœur du jeu
-            │  (estimation visible) │
-            └───────┬───────────┬───┘
-               oui  │           │  non
-                    ▲           ▼
-              (remonte)   🏃 RETOUR
-                          (distinct, court,
-                           préparable)
-                                │
-                    ┌───────────▼───────────┐
-                    │  🏆 Réussi            │
-                    │  🥀 À vide            │
-                    │  💀 Mort              │
-                    │  🌀 Calciné           │
-                    └───────────┬───────────┘
-                                ▼
-                    Butin · Connaissance
-                    Chronique · Exploits
-                                │
-                                ▼
-                          🏠 AUBERGE
+Le moteur peut continuer à générer des paliers, des salles, des connexions, des rencontres et une
+profondeur. Ces données servent les règles, la persistance, le bestiaire et la durée du run. Elles
+ne deviennent pas une carte affichée au joueur.
+
+Pour la v0.2.1, l'interface ne révèle jamais :
+
+- le type mécanique d'une salle ;
+- une icône combat, trésor, repos ou rencontre ;
+- un indice annonçant ce qui attend derrière un passage ;
+- le numéro du palier ou la profondeur maximale ;
+- la carte ou les connexions du donjon ;
+- une estimation chiffrée ou qualitative du retour.
+
+L'image montre le **lieu présent**, jamais la prochaine conséquence. La narration décrit ce que le
+personnage voit maintenant ; les choix restent des actions fictionnelles, pas des cartes de salles.
+
+Exemple :
+
+> _Le corridor se divise autour d'un pilier fendu. Une galerie descend sous les racines de pierre ;
+> l'autre disparaît derrière une porte sans poignée._
+
+Le backend sait où mènent ces choix. Le joueur, lui, avance dans l'inconnu.
+
+> **Compromis assumé v0.2.1 :** le mystère prime sur la prévisibilité du trajet. Les jauges et
+> l'état du personnage restent lisibles, et le demi-tour reste toujours disponible, mais le jeu ne
+> prédit pas les dangers futurs. Ce choix doit être réévalué après playtest si les morts paraissent
+> arbitraires.
+
+---
+
+## 5. Le demi-tour
+
+« Faire demi-tour » est une action permanente hors combat. Elle ne dépend pas d'une proposition de
+l'IA et n'attend pas la fin d'un palier. Le joueur reste libre de renoncer dès qu'il estime son état
+trop fragile.
+
+En combat, le demi-tour passe par l'action de fuite et ses règles propres (`10-COMBAT.md §7`). Une
+fuite vers l'arrière engage le retour ; une fuite vers l'avant poursuit la quête.
+
+---
+
+## 6. Le retour
+
+> **Le retour n'est pas une téléportation.**
+
+Il se joue dans la même interface narrative que l'aller. Il reste :
+
+| Propriété         | Décision                                                               |
+| ----------------- | ---------------------------------------------------------------------- |
+| **Distinct**      | Le moteur génère un trajet différent, jamais l'aller rejoué à l'envers |
+| **Plus court**    | Quelques scènes seulement pour éviter le remplissage                   |
+| **Plus facile**   | Moins de rencontres dures que pendant la progression                   |
+| **Encore risqué** | Les ressources et blessures accumulées continuent de peser             |
+
+Le jeu ne montre aucune estimation avant ou pendant ce trajet en v0.2.1. Les règles internes
+peuvent calculer sa longueur et son coût pour garantir la cohérence, sans exposer ces valeurs au
+frontend ni les transformer en avertissement narratif.
+
+---
+
+## 7. Le combat — seule transformation d'interface
+
+Quand un combat commence, la scène narrative se transforme de façon cinématographique : le décor
+reste reconnaissable, mais l'espace central révèle ennemis, initiative, actions, états et jets.
+
+Le joueur conserve l'action libre. Le backend rattache l'intention à une action tactique autorisée
+— attaque, défense, commandement, artefact ou fuite — puis arbitre. L'IA raconte le verdict sans
+inventer de règle. À la fin du combat, l'interface revient naturellement au storytelling.
+
+---
+
+## 8. Les images de scène
+
+La v0.2.1 utilise une bibliothèque pré-générée et contrôlée, sans génération au runtime :
+
+| Famille   | Cible initiale |
+| --------- | -------------- |
+| Auberge   | 6 à 8 images   |
+| Voyages   | 12 à 15 images |
+| Donjons   | 25 à 35 images |
+| **Total** | **45 à 60**    |
+
+Une même image peut servir à plusieurs scènes de la même famille, avec deux ou trois variantes pour
+limiter la répétition. La narration rend la scène unique. Une image manquante ou impossible à
+charger retombe sur un décor de thème ; aucune information nécessaire pour jouer ne dépend de
+l'image seule.
+
+---
+
+## 9. Les fins de run
+
+| Fin               | Déclencheur                                     | Récompense                                  |
+| ----------------- | ----------------------------------------------- | ------------------------------------------- |
+| **Retour réussi** | Le joueur rentre avec l'objectif du contrat     | Butin + paiement + connaissance + Chronique |
+| **Retour à vide** | Le joueur rentre vivant sans remplir le contrat | Connaissance + Chronique, pas de paiement   |
+| **Mort**          | Mort effective arbitrée par le moteur           | Chronique + héritage transmis               |
+| **Calciné**       | Calamine à 100                                  | Chronique spéciale, pas d'héritage          |
+| **Abandon**       | Le joueur quitte volontairement                 | Chronique minimale                          |
+
+`SessionEndReason` reste fermé sur `death | extracted | returned_empty | abandon | calcined`.
+L'IA reçoit la fin autoritaire et écrit la Chronique correspondante.
+
+---
+
+## 10. Ce que rapporte un run
+
+1. **Butin** — finance la préparation suivante.
+2. **Connaissance** — bestiaire, routes, sujets et contrats débloqués.
+3. **Chronique** — histoire exacte des décisions et conséquences du joueur.
+4. **Exploits** — accès ou connaissance, jamais puissance permanente.
+
+La méta-progression reste de la connaissance et de l'accès uniquement (`01-PILLARS.md §2`).
+
+---
+
+## 11. Risques et garde-fous
+
+| Risque                                 | Garde-fou                                                           |
+| -------------------------------------- | ------------------------------------------------------------------- |
+| L'IA oublie la quête                   | État objectif backend injecté à chaque tour                         |
+| Le joueur tourne en rond               | Rappels naturels + voie vers l'objectif dans les choix proposés     |
+| Le contrat devient un menu de niveau   | Quête fictionnelle, commanditaire, destination et conséquences      |
+| Le joueur part sans direction          | Un contrat principal obligatoire en v0.2.1                          |
+| Le donjon ressemble à un jeu de cartes | Aucun type, icône, carte ou palier visible                          |
+| Le mystère paraît injuste              | Jauges lisibles + demi-tour permanent + audit playtest après v0.2.1 |
+| Le retour devient du remplissage       | Trajet distinct, plus court et plus facile                          |
+| Les images coûtent ou ralentissent     | Bibliothèque pré-générée, réutilisée et servie statiquement         |
+| L'image contredit le texte             | Familles de scènes bornées + narration contrainte au décor courant  |
+| L'action libre casse les règles        | Backend souverain ; l'IA n'arbitre jamais                           |
+
+---
+
+## 12. Synthèse
+
+```text
+🏠 AUBERGE NARRATIVE
+   Comptoir · L'Aveugle · Contrats · Forge
+        ↓
+📜 UN CONTRAT PRINCIPAL
+   danger + durée visibles, contenu inconnu
+        ↓
+🏜️ VOYAGE NARRATIF
+   ressources · rencontres · détours · objectif persistant
+        ↓
+🕯️ QUÊTE / DONJON
+   même interface · structure mécanique entièrement cachée
+        ↕
+⚔️ COMBAT
+   transformation tactique temporaire
+        ↓
+↩️ DEMI-TOUR TOUJOURS POSSIBLE
+        ↓
+🌒 RETOUR NARRATIF
+   distinct · court · plus facile · non instantané
+        ↓
+📖 CHRONIQUE → 🏠 AUBERGE
 ```
 
 ---
 
-_Le **combat** qui remplit les salles est détaillé dans `10-COMBAT.md`._
-_Les **créatures** et les archétypes de lieu sont détaillés dans `03-BESTIARY.md`._
-_Le **sac**, l'**usure** et les **artefacts** sont détaillés dans `11-INVENTORY-ECONOMY.md`._
-_Les **jauges de survie** qui rendent le retour dangereux sont détaillées dans `06-SURVIVAL.md`._
-_La **méta-progression** est cadrée par `01-PILLARS.md §2` (pilier 5) et `14-META-WORLD.md`._
-_La **Chronique** de fin de run est détaillée dans `17-RUN-CHRONICLE.md`._
+_Le combat est détaillé dans `10-COMBAT.md`._
+_La boucle narrative est détaillée dans `09-ACTION-LOOP.md`._
+_Le sac, l'usure et les artefacts sont détaillés dans `11-INVENTORY-ECONOMY.md`._
+_La méta-progression est détaillée dans `14-META-WORLD.md`._
+_La Chronique est détaillée dans `17-RUN-CHRONICLE.md`._

--- a/docs/public/tech/DYNAMIC_SCENE_IMAGES.md
+++ b/docs/public/tech/DYNAMIC_SCENE_IMAGES.md
@@ -3,171 +3,110 @@ type: tech-plan
 visibility: public
 rag: true
 source_of_truth: true
-updated: 2026-08-07
 ---
 
-> Statut : **livré** (#207). Ce document garde son rôle de plan de conception ;
-> les sections marquées « livré » décrivent l'implémentation réelle.
+# Bibliothèque d'images de scène
 
-# Images de scène dynamiques (#207)
+> **Révision du 2026-08-08.** La génération dynamique livrée par #207 est remplacée pour v0.2.1
+> par une bibliothèque pré-générée, contrôlée et sans appel image au runtime.
 
-> Remplace l'image de fond statique unique (`public/scenes/`, voir
-> [[UI_KIT]] §Scènes) par une bibliothèque d'images générées et partagées
-> entre tous les joueurs.
+## Décision
 
-## Problème
+GRIMOIRE utilise les images comme décors de la narration, pas comme sortie improvisée d'un modèle à
+chaque partie. La v0.2.1 ne génère aucune image pendant un tour, un run ou la découverte d'un lieu.
 
-Aujourd'hui le Hub et la Session utilisent une seule image statique pré-faite
-par univers (`public/scenes/`). Générer une image par run/joueur serait
-coûteux en trois dimensions à la fois : appels de génération (ressource la
-plus fragile en free tier), stockage, et duplication — deux joueurs sur un
-même type de scène régénéreraient deux fois le même contenu visuel.
+Cette décision privilégie :
 
-## Décision : cache partagé, pas de génération par run
+- une direction artistique cohérente entre L'Aveugle, le comptoir, les voyages et les donjons ;
+- aucun temps d'attente lié à une génération ;
+- aucun coût proportionnel au nombre de joueurs ;
+- aucun échec de partie causé par un fournisseur d'images ;
+- un contrôle humain sur les images réellement montrées.
 
-Au lieu de générer à la demande par session, le backend construit une
-**bibliothèque d'images réutilisables**, indexée par une clé structurée et
-finie plutôt que par session ou par joueur. Le remplissage est automatique :
-le premier chunk qui matche une combinaison inédite déclenche une génération
-et un stockage ; tous les chunks suivants (tous joueurs confondus) qui
-matchent la même combinaison réutilisent l'URL existante sans nouvel appel.
-Aucune intervention manuelle, aucune liste d'images à maintenir à la main.
+## Volume initial
 
-Fréquence de déclenchement : **par chunk N2** (compression mémoire, tous les
-~8 tours), pas par tour — cohérent avec le rythme de bascule narrative déjà
-en place (#111/#120).
+| Famille          | Cible       | Exemples                                                    |
+| ---------------- | ----------- | ----------------------------------------------------------- |
+| Auberge          | 6 à 8       | entrée, comptoir, L'Aveugle, contrats, forge, sac           |
+| Voyages          | 12 à 15     | routes, désert, rivage, marais, variations de lumière       |
+| Donjons          | 25 à 35     | ruines, cryptes, cavernes, profondeurs, salles remarquables |
+| **Total v0.2.1** | **45 à 60** | deux ou trois variantes par famille de décor                |
 
-## Clé de cache
+Une image peut servir à plusieurs scènes proches. La narration et l'état du monde rendent chaque
+scène unique ; l'image fournit le lieu, la lumière et la matière.
 
-La clé ne doit **jamais** dériver du texte libre généré par l'IA (`location`,
-`narrative`) — deux formulations différentes de la même scène ("Salt Road" vs
-"la route du sel poussiéreuse") casseraient la réutilisation. La clé est
-entièrement composée de champs structurés que le **backend** possède déjà ou
-assigne lui-même :
+## Sélection
 
-```
-cacheKey = `${sceneType}_${depthBand}_${lieuType}`
-```
+La sélection repose sur des identifiants fermés et versionnés, jamais sur le texte libre de l'IA.
 
-- **`sceneType`** (6 valeurs, déjà un enum Zod strict — `scene-validator.ts:114`) :
-  `exploration | combat | dialog | event | shop | rest`
-- **`depthBand`** (5 valeurs, dérivées de la profondeur du run par
-  `depthBandOf` — `game-rules/dungeon.ts`) :
-  `surface | upper | mid | deep | abyss`
-- **`lieuType`** (5 valeurs, dérivées des types de donjons canon
-  `03-BESTIARY.md` §9, lignes 239-244, + un type générique extérieur) :
-  `plein_air | ruines_archontiques | cryptes | cavernes_cendre | donjon_profond`
+```ts
+type SceneImageFamily = "inn" | "travel" | "dungeon";
 
-**Pourquoi la profondeur a remplacé le biome.** La clé d'origine supposait un
-monde ouvert parcouru horizontalement, où le biome était ce qui changeait
-d'une scène à l'autre. La refonte roguelike ([[23-RUN-STRUCTURE]]) a rendu le
-contenu **vertical** : le joueur descend des paliers, et ce qui doit changer
-l'image est la profondeur atteinte — un palier 1 et un palier 7 ne se
-ressemblent pas, deux `tissan` à des paliers différents si. Le biome était de
-surcroît **deviné** dans la prose de l'IA, alors que la profondeur est une
-donnée que le moteur possède déjà : une image ne peut donc plus contredire le
-palier où le joueur se trouve réellement.
-
-Les bandes découpent les 7 paliers exactement là où le bestiaire découpe ses
-tiers de danger (`03-BESTIARY.md` §6bis) : `upper` = 1-2 « je gère »,
-`mid` = 3-4 « ça coûte », `deep` = 5-6 « je devrais peut-être remonter »,
-`abyss` = 7 « c'est là que je meurs ou que je gagne le run ». `surface`
-couvre le hors-run (palier 0). L'image suit donc la même montée de tension
-que la faune, sans qu'aucun des deux systèmes ait à connaître l'autre.
-
-Espace théorique max : 6 × 5 × 5 = 150 combinaisons, mais beaucoup ne sont pas
-plausibles en jeu (pas de `shop` en `abyss`, pas de `cryptes` en `surface`) —
-le nombre réel rencontré en pratique sera plutôt de l'ordre de 30-50
-combinaisons, un espace fini qui se sature après quelques dizaines de parties.
-
-**Qui assigne `depthBand` et `lieuType`** : le backend, jamais l'IA — cohérent
-avec la règle du projet "le backend possède toutes les règles, l'IA ne décide
-rien" ([[ARCHITECTURE_RULES]]). L'IA continue d'écrire `location` en texte
-libre pour l'immersion narrative ; ce texte n'entre jamais dans la clé de
-cache.
-
-## Génération
-
-Service gratuit recommandé : **Pollinations.ai** (`image.pollinations.ai/prompt/...`)
-— gratuit sans clé API, simple GET avec prompt encodé. Pas de SLA garanti :
-en cas d'échec ou timeout, fallback sur l'image statique de thème actuelle
-(même pattern défensif que `buildStubScene` côté texte).
-
-Alternatives si Pollinations s'avère insuffisant en qualité/fiabilité :
-quota gratuit Gemini image gen, ou Hugging Face Inference API (free tier,
-latence de cold-start plus élevée).
-
-## Stockage
-
-**Supabase Storage**, pas de nouveau service tiers — déjà utilisé pour
-DB/auth. Le volume reste borné par le nombre de combinaisons de cache
-(quelques dizaines d'images, pas une par run/joueur), donc largement dans le
-free tier (1 Go).
-
-## Schéma (livré)
-
-Table Prisma `SceneImage` :
-
-```prisma
-model SceneImage {
-  id        String   @id @default(uuid())
-  cacheKey  String   @unique // sceneType_depthBand_lieuType
-  url       String
-  createdAt DateTime @default(now())
+interface SceneImageDefinition {
+  id: string;
+  family: SceneImageFamily;
+  locationType: string;
+  variant: string;
+  url: string;
+  fallbackId: string;
 }
 ```
 
-`GameSession` gagne une colonne `currentImageUrl String?`.
+Le backend choisit une image compatible avec la scène structurée actuelle. L'IA reçoit ce décor en
+contexte et écrit une prose compatible ; elle ne demande pas une image et ne construit pas sa clé.
 
-## Profondeur et lieuType (livré)
+### Règle anti-spoiler
 
-Les deux composantes non-`sceneType` de la clé ne sont **pas** obtenues de la
-même façon, et c'est délibéré :
+L'image représente uniquement **le lieu où se trouve déjà le personnage**. Elle ne doit jamais :
 
-- **`depthBand`** est _lu_, jamais deviné. `depthBandOf(depth)` traduit la
-  profondeur du run — `GameSession.currentDepth`, une donnée que le moteur
-  possède — en bande. Aucun texte n'intervient. Un palier hors bornes (négatif,
-  `NaN`, au-delà de 7) est **clampé** vers une bande valide au lieu de lever :
-  un tour ne doit jamais échouer parce qu'il cherchait à s'illustrer.
-- **`lieuType`** reste _classifié_, par `classifyLieuType(location)` :
-  pattern-matching de mots-clés canon sur le texte libre `location` écrit par
-  l'IA, avec `plein_air` comme défaut sûr. C'est le seul endroit où la prose
-  influence la clé, et seulement pour choisir entre cinq décors — jamais pour
-  décider du niveau de danger représenté.
+- révéler le type de la prochaine salle ;
+- montrer un ennemi avant son apparition narrative ;
+- annoncer un trésor, un repos ou un piège à venir ;
+- encoder visuellement la profondeur ou la difficulté cachée.
 
-`classifyBiome` a été **supprimé** avec la refonte roguelike : il devinait dans
-la prose une information que le moteur détient désormais de façon fiable.
+## Production et stockage
 
-## Pont asynchrone image ↔ tour (livré)
+1. Les masters sont générés et sélectionnés pendant le développement.
+2. Chaque asset est recadré au ratio réel de l'interface et compressé en WebP/AVIF.
+3. Les fichiers optimisés sont téléversés une seule fois dans le bucket Supabase `scene-images`.
+4. Un manifeste versionné dans le dépôt lie les identifiants stables aux URLs.
+5. Le frontend précharge seulement l'image courante et, si connue sans spoiler, la transition
+   immédiate suivante.
 
-`resolveTurn()` (`session.service.ts`) construit et renvoie le `SceneResponse`
-de façon synchrone, puis déclenche `compressScene()` en asynchrone (non
-attendu, tous les ~8 tours). L'image ne peut donc pas atteindre la réponse du
-même tour : l'URL résolue est persistée sur `GameSession.currentImageUrl` (via
-`resolveAndPersistSceneImage()` dans `memory.service.ts`) et relue par tous
-les points de construction de scène suivants (`resumeLatestScene`,
-`buildOpeningScene`, `resolveTurn`) pour peupler `Scene.imageUrl`.
+Le stockage distant évite d'alourdir le bundle et le dépôt. Le manifeste garde le contrat
+reproductible ; un changement d'URL passe par une PR.
 
-## Génération et stockage (livré)
+## Fallback et accessibilité
 
-**Pollinations.ai** (`image.pollinations.ai/prompt/...`), GET simple avec
-prompt encodé, timeout 15s via `AbortController`. Échec ou timeout → `null`,
-le frontend retombe sur l'image de thème statique existante.
+- Une image absente, lente ou invalide retombe sur le décor de thème de sa famille.
+- Le tour et la navigation ne dépendent jamais du chargement de l'image.
+- La narration doit rester suffisante pour comprendre et jouer sans visuel.
+- Les informations mécaniques essentielles vivent dans le texte ou le HUD, jamais dans l'image
+  seule.
+- Le combat conserve le décor courant quand il transforme l'interface.
 
-Bucket **Supabase Storage `scene-images`**, créé **public** (`getPublicUrl()`
-direct, pas d'URL signée). Les écritures (`uploadSceneImage`) utilisent la clé
-service-role qui bypass RLS ; les lectures sont publiques — donc aucune
-policy RLS Storage additionnelle nécessaire.
+## Migration depuis #207
 
-`resolveSceneImage()` gère la course concurrentielle : si deux requêtes
-tentent de créer la même `cacheKey` en même temps, l'échec de contrainte
-unique déclenche une relecture par `cacheKey` pour réutiliser la ligne
-gagnante plutôt que de traiter ça comme une erreur.
+L'implémentation actuelle génère via Pollinations, persiste `SceneImage` et choisit une clé
+`sceneType_depthBand_lieuType`. Elle devient une dette de migration, pas la cible produit.
 
-## Hors scope de ce plan
+La migration doit :
 
-- Génération par tour individuel (retenu : par chunk N2 uniquement).
-- Personnalisation de l'image par joueur (délibérément partagée/anonyme).
-- Redis et pgvector : évalués et différés séparément, voir
-  [[BACKEND]] (post-déploiement, #114) et `20-ARCHITECTURE.md:56`
-  (Redis dès 2+ instances backend, pas avant).
+1. introduire le manifeste et les identifiants fermés ;
+2. remplacer `resolveSceneImage()` par une résolution locale déterministe ;
+3. supprimer l'appel Pollinations et son timeout ;
+4. décider si la table `SceneImage` peut être retirée après migration ;
+5. conserver `GameSession.currentImageUrl` ou le remplacer par `currentImageId` selon le contrat
+   shared retenu ;
+6. garder le fallback défensif de bout en bout.
+
+## Hors périmètre v0.2.1
+
+- génération par tour, joueur, run ou nouvelle combinaison ;
+- personnalisation d'image selon le texte libre ;
+- image unique pour chaque salle procédurale ;
+- galerie d'administration des assets ;
+- retour automatique à un fournisseur payant ou gratuit.
+
+Une génération dynamique avec cache pourra être réévaluée après playtest si la répétition visuelle
+est réellement mesurée. Elle ne doit pas être anticipée avant ce signal.


### PR DESCRIPTION
## Résumé

- Aligne le canon sur une seule interface narrative, de l'Auberge au retour de quête.
- Formalise les quêtes structurées, le mystère total des donjons et la transformation tactique du combat.
- Remplace la génération d'images en temps réel par une bibliothèque de 45 à 60 décors pré-générés.
- Reflète la nouvelle organisation du backlog v0.2.1 dans les documents de référence.

## Issue liée

Closes #244

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Bug fix
- [ ] Refactoring sans changement de comportement
- [ ] Chore / Tooling / Config
- [x] Documentation uniquement

## Phase et domaine

- **Phase** : phase: predeploy
- **Domaine** : domain: frontend, domain: backend
- **Propriétaire** : Codex — documentation transverse frontend/backend

## Décisions à consigner

- [ ] Aucune décision non évidente — aucun document modifié
- [x] `BACKEND.md` mis à jour (décision backend/shared/AI)
- [x] `FRONTEND.md` mis à jour (décision frontend)
- [x] `RELEASE_READINESS.md` mis à jour (un bloqueur `phase: predeploy` change)
- [x] `nav/log.md` complété (pivot ou décision structurante)

Décision consignée : la v0.2.1 devient un roguelike narratif continu, guidé par une quête structurée et illustré par des décors pré-générés.

- [x] Refonte transverse des docs

Justification docs transverses: Le nouveau canon roguelike narratif redéfinit ensemble les contrats frontend et backend.

## Checklist technique

- [x] Conventions du domaine respectées
- [x] Types partagés dans `packages/shared`, jamais dupliqués
- [x] Type-check et lint non applicables : documentation uniquement
- [x] Tests pertinents passent
- [x] Aucun `console.log` oublié
- [x] Test manuel décrit ci-dessous

## Test manuel effectué

- `pnpm check:project-memory`
- `pnpm check:doc-links`
- `pnpm test:current-state`
- `PR_BODY=... pnpm check:current-state`
- `pnpm exec prettier --check` sur les 17 documents modifiés
- `git diff origin/develop...HEAD --check`
- Vérification des issues, labels, assignations, milestone et éléments du Scrum Board avec `gh`

## Captures d'écran

Non applicable : documentation uniquement.

## Notes pour la review

- La structure interne des donjons peut conserver salles et paliers, mais aucune indication de type, profondeur, carte ou durée de retour ne sera exposée au joueur en v0.2.1.
- La ligne de release reste le label `release: v0.2`; la version exacte est portée par le milestone `v0.2.1 - Roguelike jouable`.
- La génération Pollinations devient une dette de migration suivie par #248.
