### PR TITLE
fix(#238): arbitrer le risque et le type de l'action libre

### DIFF
--- a/apps/backend/src/services/session.service.test.ts
+++ b/apps/backend/src/services/session.service.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { resolveChoice } from '../game-rules/consequences'
+
+import type { Attributes, SurvivalStats } from '@grimoire/shared'
+
 // Mock the DB so `resolveChosenChoice` reads a scene we control.
 const sceneFindFirst = vi.fn()
 vi.mock('../lib/prisma', () => ({
@@ -38,13 +42,167 @@ describe('resolveChosenChoice', () => {
     expect(choice).toBe(INVALID_CHOICE)
   })
 
-  it('treats a free action (no choiceId) as a deliberate safe, no-roll turn', async () => {
-    const choice = await resolveChosenChoice('s1', undefined, undefined, 'look around')
+  it('makes a free action inherit the scene worst stakes, so prose is not invulnerable (#238)', async () => {
+    // A scene that offers a deadly option is a deadly situation: typing an
+    // action must be arbitrated exactly like clicking one.
+    sceneFindFirst.mockResolvedValue(
+      scene([
+        { id: 'c1', text: 'step back', type: 'action', riskLevel: 'low' },
+        { id: 'c2', text: 'charge the wraith', type: 'combat', riskLevel: 'deadly' },
+      ])
+    )
+
+    const choice = await resolveChosenChoice('s1', undefined, undefined, 'I stab the wraith')
+
+    if (typeof choice === 'symbol') throw new Error('expected a resolved choice')
+    expect(choice.riskLevel).toBe('deadly')
+    // The type comes from the same choice as the risk: only combat/flee cost HP,
+    // so inheriting `deadly` as a plain `action` would roll a die that can never kill.
+    expect(choice.type).toBe('combat')
+    expect(choice.text).toBe('I stab the wraith')
+    expect(choice.id).toBe('free-action')
+  })
+
+  it('keeps a free action safe when the scene itself is calm', async () => {
+    sceneFindFirst.mockResolvedValue(
+      scene([{ id: 'c1', text: 'greet the innkeeper', type: 'dialog', riskLevel: 'safe' }])
+    )
+
+    const choice = await resolveChosenChoice('s1', undefined, undefined, 'I look around')
 
     if (typeof choice === 'symbol') throw new Error('expected a resolved choice')
     expect(choice.riskLevel).toBe('safe')
-    expect(choice.text).toBe('look around')
-    // Free actions never touch the scene log.
-    expect(sceneFindFirst).not.toHaveBeenCalled()
+  })
+
+  it('treats a choice with no declared riskLevel as safe when inheriting', async () => {
+    sceneFindFirst.mockResolvedValue(
+      scene([
+        { id: 'c1', text: 'wait', type: 'action' },
+        { id: 'c2', text: 'push the door', type: 'action', riskLevel: 'medium' },
+      ])
+    )
+
+    const choice = await resolveChosenChoice('s1', undefined, undefined, 'I wait a bit')
+
+    if (typeof choice === 'symbol') throw new Error('expected a resolved choice')
+    expect(choice.riskLevel).toBe('medium')
+  })
+
+  it('falls back to safe when the session has no scene yet', async () => {
+    // First turn: nothing persisted, so there are no stakes to inherit.
+    sceneFindFirst.mockResolvedValue(null)
+
+    const choice = await resolveChosenChoice('s1', undefined, undefined, 'I look around')
+
+    if (typeof choice === 'symbol') throw new Error('expected a resolved choice')
+    expect(choice.riskLevel).toBe('safe')
+  })
+
+  it('falls back to safe when the persisted choices cannot be parsed', async () => {
+    sceneFindFirst.mockResolvedValue(scene('not-an-array'))
+
+    const choice = await resolveChosenChoice('s1', undefined, undefined, 'I look around')
+
+    if (typeof choice === 'symbol') throw new Error('expected a resolved choice')
+    expect(choice.riskLevel).toBe('safe')
+    expect(choice.type).toBe('action')
+  })
+})
+
+/**
+ * #238's real bar: a dangerous free-form action must be able to *kill*, not just
+ * to fail. Rolling a d20 is not enough — HP is only ever lost on a failed
+ * `combat`/`flee` check — so this drives the inherited choice through the actual
+ * rules engine rather than asserting on its shape.
+ */
+describe('free-form action mortality (#238)', () => {
+  const ATTRIBUTES: Attributes = { blood: 15, breath: 10, ash: 10 }
+
+  const survival = (overrides: Partial<SurvivalStats> = {}): SurvivalStats => ({
+    hp: 12,
+    maxHp: 12,
+    thirst: 100,
+    hunger: 100,
+    energy: 100,
+    calamine: 0,
+    isDying: false,
+    neglectStreak: 0,
+    ...overrides,
+  })
+
+  /** rng that forces `rollCheck` to produce exactly `roll` (1–20). */
+  const fixedRoll = (roll: number) => () => (roll - 1) / 20
+
+  const deadlyCombatScene = () =>
+    scene([
+      { id: 'c1', text: 'step back', type: 'action', riskLevel: 'low' },
+      { id: 'c2', text: 'charge the wraith', type: 'combat', riskLevel: 'deadly' },
+    ])
+
+  beforeEach(() => {
+    sceneFindFirst.mockReset()
+  })
+
+  it('a losing free action in a deadly scene draws blood and starts dying', async () => {
+    sceneFindFirst.mockResolvedValue(deadlyCombatScene())
+    const choice = await resolveChosenChoice('s1', undefined, undefined, 'I stab the wraith')
+    if (typeof choice === 'symbol') throw new Error('expected a resolved choice')
+
+    const result = resolveChoice({
+      attributes: ATTRIBUTES,
+      survival: survival(),
+      choice,
+      activeConditions: [],
+      turnNumber: 1,
+      locale: 'en',
+      rng: fixedRoll(1),
+    })
+
+    // 12 HP against a `deadly` failure (20) → clamped to 0, and the canon's
+    // one-turn reprieve applies exactly as it would for the clicked choice.
+    expect(result.diceRoll?.success).toBe(false)
+    expect(result.updatedSurvival.hp).toBe(0)
+    expect(result.updatedSurvival.isDying).toBe(true)
+    expect(result.gameOver).toBe(false)
+  })
+
+  it('a second losing free action while dying is definitive death', async () => {
+    sceneFindFirst.mockResolvedValue(deadlyCombatScene())
+    const choice = await resolveChosenChoice('s1', undefined, undefined, 'I stab the wraith again')
+    if (typeof choice === 'symbol') throw new Error('expected a resolved choice')
+
+    const result = resolveChoice({
+      attributes: ATTRIBUTES,
+      survival: survival({ hp: 0, isDying: true }),
+      choice,
+      activeConditions: [],
+      turnNumber: 2,
+      locale: 'en',
+      rng: fixedRoll(1),
+    })
+
+    expect(result.gameOver).toBe(true)
+  })
+
+  it('a calm scene keeps a free action free of any roll or damage', async () => {
+    sceneFindFirst.mockResolvedValue(
+      scene([{ id: 'c1', text: 'greet the innkeeper', type: 'dialog', riskLevel: 'safe' }])
+    )
+    const choice = await resolveChosenChoice('s1', undefined, undefined, 'I look around')
+    if (typeof choice === 'symbol') throw new Error('expected a resolved choice')
+
+    const result = resolveChoice({
+      attributes: ATTRIBUTES,
+      survival: survival(),
+      choice,
+      activeConditions: [],
+      turnNumber: 1,
+      locale: 'en',
+      rng: fixedRoll(1),
+    })
+
+    expect(result.diceRoll).toBeUndefined()
+    expect(result.updatedSurvival.hp).toBe(12)
+    expect(result.gameOver).toBe(false)
   })
 })

--- a/apps/backend/src/services/session.service.ts
+++ b/apps/backend/src/services/session.service.ts
@@ -5,6 +5,7 @@ import {
   type Attributes,
   type Choice,
   type ContractDepth,
+  type Difficulty,
   type InventoryActionResponse,
   type InventoryItemRef,
   type Locale,
@@ -353,12 +354,51 @@ export async function buildOpeningScene(context: SessionContext): Promise<SceneR
  */
 export const INVALID_CHOICE = Symbol('invalid-choice')
 
+/** Ascending danger, so the scene's stakes can be compared and maxed. */
+const RISK_ORDER: readonly Difficulty[] = ['safe', 'low', 'medium', 'high', 'deadly']
+
+/** The stakes a free-form action is arbitrated under, inherited from the scene. */
+type InheritedStakes = Pick<Choice, 'type' | 'riskLevel'>
+
+/** A scene with nothing at stake: a calm turn, narrated without a d20. */
+const CALM_STAKES: InheritedStakes = { type: 'action', riskLevel: 'safe' }
+
+/**
+ * The stakes a free-form action inherits: those of the most dangerous choice the
+ * scene itself puts on the table. A scene that offers a `deadly` combat option is
+ * a deadly combat situation, so describing an action in prose is arbitrated
+ * exactly like clicking — no input channel is invulnerable by construction (#238).
+ *
+ * Both fields come from the *same* choice on purpose. `riskLevel` alone decides
+ * whether a d20 is rolled, but `type` decides which attribute it tests and, above
+ * all, whether a failure draws blood: only `combat`/`flee` cost HP
+ * (`PHYSICAL_RISK_TYPES`). Inheriting a `deadly` risk while defaulting the type to
+ * `action` would roll a die that can never kill — the exact invulnerability #238
+ * exists to remove.
+ *
+ * Choices with no `riskLevel` count as `safe`; a scene with no choices at all (or
+ * unparsable ones) yields calm stakes.
+ * @see docs/public/raw/08-DICE-RESOLUTION.md §9, docs/public/raw/06-SURVIVAL.md §6
+ */
+function inheritedSceneStakes(choices: readonly InheritedStakes[]): InheritedStakes {
+  return choices.reduce<InheritedStakes>((worst, choice) => {
+    const risk = choice.riskLevel ?? 'safe'
+    return RISK_ORDER.indexOf(risk) > RISK_ORDER.indexOf(worst.riskLevel ?? 'safe')
+      ? { type: choice.type, riskLevel: risk }
+      : worst
+  }, CALM_STAKES)
+}
+
 /**
  * Resolves the `Choice` that drives a turn's mechanics from the persisted
  * world-state — never from client-supplied risk. When a `choiceId` is given it
  * is looked up in the latest scene's stored `choices`; its real `type`/`riskLevel`
  * decide the d20 and stakes. An unknown `choiceId` yields `INVALID_CHOICE`.
- * A free-form action (no `choiceId`) is a deliberate safe, no-roll turn.
+ *
+ * A free-form action (no `choiceId`) inherits the scene's own stakes — both its
+ * risk and its type — rather than falling back to a safe `action`: before #238
+ * typing prose bypassed the d20 entirely, making the text box a way to attempt
+ * lethal actions risk-free.
  */
 export async function resolveChosenChoice(
   sessionId: string,
@@ -366,15 +406,21 @@ export async function resolveChosenChoice(
   chosenActionText: string | undefined,
   freeAction: string | undefined
 ): Promise<Choice | typeof INVALID_CHOICE> {
-  if (!choiceId) {
-    return { id: 'free-action', text: freeAction ?? '', type: 'action', riskLevel: 'safe' }
-  }
-
   const lastScene = await prisma.sceneLog.findFirst({
     where: { sessionId },
     orderBy: { turnNumber: 'desc' },
   })
   const choices = persistedChoicesSchema.safeParse(lastScene?.choices)
+
+  if (!choiceId) {
+    const stakes = choices.success ? inheritedSceneStakes(choices.data) : CALM_STAKES
+    return {
+      id: 'free-action',
+      text: freeAction ?? '',
+      ...stakes,
+    }
+  }
+
   const chosen = choices.success ? choices.data.find((c) => c.id === choiceId) : undefined
   if (!chosen) {
     return INVALID_CHOICE


### PR DESCRIPTION
Closes #238

## Problème

`resolveChosenChoice` renvoyait `riskLevel: 'safe'` en dur pour toute action libre — comportement documenté comme volontaire (« a deliberate safe, no-roll turn ») et verrouillé par un test. Conséquence : aucun d20 n'était lancé en saisie libre.

Écrire « je charge le spectre » était donc mécaniquement invulnérable, alors que cliquer le même choix `deadly` pouvait tuer. La zone de texte était une échappatoire par construction.

## Correctif

L'action libre hérite des enjeux du choix **le plus dangereux** de la scène persistée : `riskLevel` **et** `type`, pris sur le même choix.

Prendre les deux champs ensemble est le cœur du correctif, pas un détail : `riskLevel` décide si un d20 est lancé, mais `type` décide s'il fait saigner — seuls `combat` et `flee` appartiennent à `PHYSICAL_RISK_TYPES`. Hériter `deadly` en gardant `type: 'action'` lançait un dé **incapable de tuer**, ce qui ne remplissait pas la Definition of Done du ticket.

- Enjeux lus exclusivement côté serveur, jamais depuis le client.
- Une scène calme reste `safe` : pas de d20 gratuit sur un tour de dialogue.
- Absence de scène (1er tour) ou choix illisibles → enjeux calmes.
- `INVALID_CHOICE` inchangé pour un `choiceId` forgé.

Le contrat de mort n'a pas eu besoin d'être modifié : `resolveChoice` s'exécute avant `generateScene` et lui transmet `updatedSurvival` / `updatedConditions`. La réprieve `isDying` en deux temps (06-SURVIVAL §7) s'applique donc à l'identique en saisie libre, et l'IA ne décide toujours rien.

## Vérification

523/523 tests verts, `tsc --noEmit` et ESLint propres.

Le correctif a été validé **par mutation** plutôt que sur la seule foi de tests verts : en remettant temporairement `type: 'action'` en dur, deux tests tombent —

```
× expected 'action' to be 'combat'
× expected 12 to be +0
```

Le second est le verdict qui compte : sans l'héritage du type, le personnage **conserve ses 12 PV** malgré un jet `deadly` raté. La mortalité en saisie libre était bien absente.

Réserve honnête sur la couverture : le test « seconde action perdante = mort définitive » passe *aussi* sur le code muté, car à 0 PV la mort survient via le tick de conditions avant le jet. Il ne démontre donc pas l'héritage — c'est le test « draws blood » qui le porte. Il est conservé parce qu'il verrouille la réprieve en deux temps.

## Compromis assumé

L'héritage prend le **maximum** de la scène : dans un combat mortel, « je recule lentement » est arbitré en `combat`/`deadly`. C'est la conséquence directe de la règle du max. Distinguer l'intention réelle (frapper vs persuader, canon 08-DICE §9) demande un analyseur d'intention côté serveur — ticket d'affinage à part, qui ne masque plus un bug de mortalité.

## Canon

- `docs/public/raw/08-DICE-RESOLUTION.md` §9 (flux libre), §3 (catégories de pivot)
- `docs/public/raw/06-SURVIVAL.md` §6 (sauvegarde), §7 (contrat isDying)
