### PR TITLE
feat(#235): livrer le moteur de combat par tours

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -146,6 +146,14 @@ model GameSession {
   /// `returned_empty` au retour.
   objectiveSecured  Boolean  @default(false)
 
+  // --- Combat par tours (#235) — @see docs/public/raw/10-COMBAT.md
+  /// État complet du combat en cours, sérialisé. Null hors combat — c'est ce
+  /// null qui dit « pas de combat », jamais un `gameMode` désynchronisé.
+  /// Persisté en entier (initiative, round, camp actif, PV et conditions de
+  /// chaque ennemi) pour qu'une reprise de session retrouve la rencontre
+  /// exactement dans l'état où elle a été quittée, sans rejouer un seul dé.
+  combatState       Json?
+
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 

--- a/apps/backend/src/ai/game-master.service.test.ts
+++ b/apps/backend/src/ai/game-master.service.test.ts
@@ -125,13 +125,15 @@ describe('generateScene — N1 recent-turns loading', () => {
 
     await generateScene({ character, locale: 'en', sessionId: 's1' })
 
-    // A session with no run structure passes null — the prompt omits the section.
+    // A session with no run structure and no fight passes null for both — the
+    // prompt then omits those sections entirely.
     expect(buildSystemPrompt).toHaveBeenCalledWith(
       character,
       'en',
       [],
       recentTurns,
       souvenirs,
+      null,
       null
     )
   })
@@ -159,7 +161,8 @@ describe('generateScene — N1 recent-turns loading', () => {
       expect.anything(),
       expect.anything(),
       expect.anything(),
-      run
+      run,
+      null
     )
   })
 

--- a/apps/backend/src/ai/game-master.service.ts
+++ b/apps/backend/src/ai/game-master.service.ts
@@ -9,7 +9,12 @@ import {
 import { callOpenRouter, type OpenRouterMessage, type OpenRouterUsage } from './openrouter.provider'
 import { buildStubScene } from './scene-stub'
 import { type AiScenePayload, validateAiScene } from './scene-validator'
-import { buildSystemPrompt, type RecentTurnSummary, type RunPromptContext } from './system-prompt'
+import {
+  buildSystemPrompt,
+  type CombatPromptContext,
+  type RecentTurnSummary,
+  type RunPromptContext,
+} from './system-prompt'
 
 import type { MemoryChunkModel, SouvenirModel } from '../generated/prisma/models'
 import type { Character, Locale } from '@grimoire/shared'
@@ -30,6 +35,13 @@ export interface GameMasterInput {
    * @see docs/public/raw/23-RUN-STRUCTURE.md §4.2
    */
   run?: RunPromptContext | null
+  /**
+   * The fight resolved this turn (#235), handed to the AI as an accomplished
+   * fact to narrate. Null outside combat. The direction of the dependency is
+   * the whole point: mechanics first, prose second — never the inverse.
+   * @see docs/public/raw/10-COMBAT.md §3
+   */
+  combat?: CombatPromptContext | null
 }
 
 /**
@@ -167,7 +179,8 @@ export async function generateScene(input: GameMasterInput): Promise<GameMasterR
         memoryChunks,
         recentTurns,
         souvenirs,
-        input.run ?? null
+        input.run ?? null,
+        input.combat ?? null
       ),
     },
     { role: 'user', content: buildUserPrompt(input) },

--- a/apps/backend/src/ai/scene-validator.ts
+++ b/apps/backend/src/ai/scene-validator.ts
@@ -109,6 +109,39 @@ export const aiRestRequestedSchema = z.object({
 
 export type AiRestRequested = z.infer<typeof aiRestRequestedSchema>
 
+/**
+ * Zod schema for the optional per-turn `combat_encounter` proposal (#235).
+ *
+ * Canon is explicit that a fight is "jamais activé par le joueur" — it is a
+ * narrative pivot the Game Master announces (`10-COMBAT §1`). That makes the AI
+ * the only thing that can *signal* an encounter, and it is precisely why this
+ * schema is the narrowest of the four proposals: the AI names creatures and
+ * says whether they ambushed. It supplies no HP, no AC, no damage and no
+ * initiative — those come from the bestiary, keyed by an id this schema forces
+ * to be a canon one.
+ *
+ * The count is capped at four because a camp acts as a block (§2): a larger
+ * group would not make the fight richer, only longer and more lethal without
+ * the player ever getting a decision in between.
+ *
+ * The backend re-validates every id against the *floor* the player is actually
+ * on (`creaturesForDepth`) before instantiating anything — a Watcher King
+ * proposed on floor 2 is refused, not obeyed.
+ * @see docs/public/raw/10-COMBAT.md §1, §2
+ * @see docs/public/raw/03-BESTIARY.md §6bis
+ */
+export const aiCombatEncounterSchema = z.object({
+  creatureIds: z.array(z.string().min(1)).min(1).max(4),
+  /**
+   * An ambush skips the disengagement options canon otherwise requires the AI
+   * to offer (§1). It is a fact about the fiction, not a difficulty knob.
+   */
+  ambush: z.boolean().optional(),
+  reason: z.string().min(1).max(280),
+})
+
+export type AiCombatEncounter = z.infer<typeof aiCombatEncounterSchema>
+
 export const sceneTypeSchema = z.enum(['exploration', 'combat', 'dialog', 'event', 'shop', 'rest'])
 
 export const aiSceneSchema = z.object({
@@ -130,6 +163,8 @@ export const aiSceneSchema = z.object({
   item_gained: aiItemGainedSchema.nullish().transform((v) => v ?? undefined),
   /** Optional rest proposal for this turn (#184). Some models emit `null` instead of omitting the field. */
   rest_requested: aiRestRequestedSchema.nullish().transform((v) => v ?? undefined),
+  /** Optional hostile-encounter signal for this turn (#235). Some models emit `null` instead of omitting the field. */
+  combat_encounter: aiCombatEncounterSchema.nullish().transform((v) => v ?? undefined),
 })
 
 export type AiScenePayload = z.infer<typeof aiSceneSchema>

--- a/apps/backend/src/ai/system-prompt.ts
+++ b/apps/backend/src/ai/system-prompt.ts
@@ -1,10 +1,19 @@
 import { CONDITIONS, getConditionDefinition, localeDisplayName } from '@grimoire/shared'
 
+import { creaturesForDepth, creaturesForReturn } from '../game-rules/bestiary'
 import { gaugeTier } from '../game-rules/survival'
 
 import type { ReturnWarning } from '../game-rules/run'
 import type { MemoryChunkModel, SouvenirModel } from '../generated/prisma/models'
-import type { Character, GameMode, Locale } from '@grimoire/shared'
+import type {
+  Character,
+  CombatAction,
+  CombatOutcome,
+  FleeDirection,
+  GameMode,
+  KnockoutVerdict,
+  Locale,
+} from '@grimoire/shared'
 
 /** Narrow projection of a `SceneLog` used for the N1 recent-turns window. */
 export interface RecentTurnSummary {
@@ -28,6 +37,28 @@ export interface RunPromptContext {
   returnEngaged: boolean
   /** Supply thresholds crossed this turn. Each one MUST surface in the prose. */
   warnings: ReturnWarning[]
+}
+
+/**
+ * The fight as the prompt needs to know it: a mechanical result, already
+ * resolved, handed to the AI to be given a voice.
+ *
+ * `events` are plain sentences derived from the combat log by the backend — the
+ * AI is never shown raw dice, DCs or hit points, because a model that reads a
+ * number tends to print it, and canon keeps the arithmetic off the page.
+ * @see docs/public/raw/10-COMBAT.md §3
+ */
+export interface CombatPromptContext {
+  /** The tactical action actually resolved (after any prose translation). */
+  action: CombatAction
+  round: number
+  /** What happened this turn, in order, already phrased for narration. */
+  events: string[]
+  /** Null while the fight is still running. */
+  outcome: CombatOutcome | null
+  /** How losing was arbitrated (§8), when the fight ended in defeat. */
+  knockoutVerdict?: KnockoutVerdict
+  fleeDirection?: FleeDirection
 }
 
 /**
@@ -383,6 +414,113 @@ function buildRunSection(run: RunPromptContext | null): string[] {
 }
 
 /**
+ * Tells the AI how — and only when — it may open a fight (#235).
+ *
+ * Canon puts the trigger squarely on this side: "Le combat n'est jamais activé
+ * par le joueur : c'est une bascule narrative annoncée par l'IA" (§1). So the
+ * prompt has to hand the AI a real lever, and the two rules that make that lever
+ * safe are split by nature:
+ *
+ * - **which creatures may appear** is a floor rule, and the backend enforces it
+ *   structurally in `openCombatFromEncounter`. It is still listed here because a
+ *   proposal the backend silently drops costs the player a turn where the prose
+ *   promised a fight and no fight came;
+ * - **offering a way out** is a *prose* rule (§1 "Éviter le combat"), and no
+ *   backend check can enforce it — a defusal option is a choice written one turn
+ *   earlier, so only the AI can honour it. Hence the emphasis: canon's line is
+ *   that the fight "doit être un choix — pas un funnel forcé".
+ *
+ * Omitted entirely when a fight is already running: the engine, not the
+ * narrator, decides when that one ends.
+ * @see docs/public/raw/10-COMBAT.md §1
+ * @see docs/public/raw/03-BESTIARY.md §6bis
+ */
+function buildEncounterSection(run: RunPromptContext | null, inCombat: boolean): string[] {
+  if (inCombat) return []
+
+  const available = run
+    ? run.returnEngaged
+      ? creaturesForReturn(run.maxDepthReached)
+      : creaturesForDepth(run.currentDepth)
+    : creaturesForDepth(1)
+
+  return [
+    '',
+    'Opening a fight (combat_encounter):',
+    '- A fight is never started by the player pressing a button — it is a narrative',
+    '  pivot YOU announce. Signal it with combat_encounter when the scene you just',
+    '  wrote turns hostile: an ambush, a challenge, a predator that spotted them, or',
+    '  a hostile meeting the player failed to defuse.',
+    '- Unless it is a pure ambush, the player must have been offered a way out on the',
+    '  PREVIOUS turn — fleeing, parleying, intimidating or hiding. A fight has to be',
+    '  the consequence of a choice, never a corridor with one exit. When you feel a',
+    '  fight coming, write that turn first and let them answer it.',
+    '- Set ambush: true only when the fiction genuinely gave them no such chance.',
+    '  It is not a difficulty setting: it decides who acts first, nothing else.',
+    '- Only these creatures exist here. Naming anything else cancels the fight and',
+    '  leaves your scene without the encounter it promised:',
+    ...available.map((creature) => `  - ${creature.id} — ${creature.name}`),
+    '- Name between 1 and 4 of them in creatureIds, repeating an id for a group of the',
+    '  same creature. Never state their HP, armour or damage — those are the backend’s,',
+    '  and it will contradict you. Describe what the player SEES.',
+  ]
+}
+
+/**
+ * Turns the fight the engine just resolved into prose orders.
+ *
+ * This section is the strictest in the prompt, and deliberately so: every line
+ * below is an outcome that has *already happened* in the persisted state. The
+ * AI is told what the dice said and asked to make it land — it never chooses
+ * who hit, who died, or how the fight ends. Reversing that order is the one
+ * failure mode combat cannot survive, since a narration that contradicts the
+ * state leaves the player fighting an enemy the engine has already buried.
+ * @see docs/public/raw/10-COMBAT.md §3
+ */
+function buildCombatSection(combat: CombatPromptContext | null): string[] {
+  if (!combat) return []
+
+  const lines = [
+    '',
+    'Combat resolved this turn (ALREADY DECIDED by the backend — narrate it, never re-decide it):',
+    `- The player's action: ${combat.action}. Round ${combat.round}.`,
+    ...combat.events.map((event) => `- ${event}`),
+  ]
+
+  if (combat.outcome === null) {
+    lines.push(
+      '- The fight CONTINUES. End the narration inside the fight, with the enemies still a threat.',
+      '  Do not resolve it, do not have them surrender, do not skip to the aftermath.'
+    )
+  } else if (combat.outcome === 'victory') {
+    lines.push('- The player WON. Narrate the last blow landing and the silence after it.')
+  } else if (combat.outcome === 'fled') {
+    lines.push(
+      combat.fleeDirection === 'backward'
+        ? '- The player ESCAPED and is now heading back the way they came. Narrate the retreat.'
+        : '- The player ESCAPED forward, deeper along their route. The quest continues, so does the risk.'
+    )
+  } else {
+    // §8: the backend already arbitrated what losing means. The AI narrates the
+    // verdict it is given — it never gets to decide that a downed player lives.
+    const verdict =
+      combat.knockoutVerdict === 'saved'
+        ? '- The player FELL but was PULLED OUT ALIVE by an ally. They live. Narrate the rescue.'
+        : combat.knockoutVerdict === 'captured'
+          ? '- The player FELL and was TAKEN PRISONER, not killed. Narrate the capture, not a death.'
+          : '- The player FELL and DIED. Narrate the death. Do not soften it, do not leave a way out.'
+    lines.push(verdict)
+  }
+
+  lines.push(
+    '- Never invent a hit, a wound, a death or an escape that is not listed above. Numbers stay',
+    '  out of the prose: write the blow, not the damage roll.'
+  )
+
+  return lines
+}
+
+/**
  * Builds the Game Master system prompt.
  * The AI writes narration and choice labels only; the backend owns all rules,
  * dice, stats, and canon consistency. Canon brand terms are NOT re-translated —
@@ -394,7 +532,8 @@ export function buildSystemPrompt(
   memoryChunks: MemoryChunkModel[] = [],
   recentTurns: RecentTurnSummary[] = [],
   souvenirs: SouvenirModel[] = [],
-  run: RunPromptContext | null = null
+  run: RunPromptContext | null = null,
+  combat: CombatPromptContext | null = null
 ): string {
   const languageName = localeDisplayName(locale)
 
@@ -421,6 +560,8 @@ export function buildSystemPrompt(
     ...buildRestSection(),
     ...buildDangerCrescendoSection(character),
     ...buildRunSection(run),
+    ...buildEncounterSection(run, combat !== null),
+    ...buildCombatSection(combat),
     '',
     'Respond with a single JSON object and nothing else, matching exactly:',
     '{',
@@ -432,6 +573,8 @@ export function buildSystemPrompt(
     '  "souvenir_candidate"?: { "title_suggestion": string, "body": string, "type": "npc-death"|"moral-choice"|"secret-discovery"|"boss-victory"|"strong-promise" }',
     '  "apply_condition"?: { "id": string, "reason": string, "calamineDelta"?: number }',
     '  "item_gained"?: { "name": string, "category": "equipment"|"bag"|"artifact"|"key", "slot"?: string, "effect"?: { "healAmount"?: number, "calamineReduction"?: number, "removesCondition"?: string, "damage"?: string }, "description"?: string }',
+    '  "rest_requested"?: { "type": "short"|"fire" }',
+    '  "combat_encounter"?: { "creatureIds": string[], "ambush"?: boolean, "reason": string }',
     '}',
     '',
     'turnSummary: a short factual sentence (max 200 characters) condensing what just',
@@ -454,5 +597,11 @@ export function buildSystemPrompt(
     'item_gained: OPTIONAL, omit on most turns. Only include it when the',
     'narrative you just wrote clearly has the player finding or receiving an',
     'item THIS turn. Never invent an item that was not part of the narrative.',
+    '',
+    'combat_encounter: OPTIONAL, omit on most turns. Only include it when the',
+    'scene you just wrote turns into an actual fight, under the rules above.',
+    'creatureIds must come from the list given above, 1 to 4 entries. reason:',
+    'one short sentence on what made it a fight (e.g. "the brigands were not',
+    'fooled and drew their blades").',
   ].join('\n')
 }

--- a/apps/backend/src/game-rules/bestiary.test.ts
+++ b/apps/backend/src/game-rules/bestiary.test.ts
@@ -28,8 +28,9 @@ function turnsToKillPlayer(creature: CreatureStatBlock): number {
 }
 
 describe('bestiary coverage', () => {
-  it('holds exactly the 18 canon creatures', () => {
-    expect(listCreatures()).toHaveLength(18)
+  it('holds exactly the 22 canon entries: 18 creatures and 4 humans', () => {
+    expect(listCreatures()).toHaveLength(22)
+    expect(listCreatures().filter((c) => c.species === 'human')).toHaveLength(4)
   })
 
   it('keys every entry by its own id', () => {
@@ -59,10 +60,15 @@ describe('bestiary coverage', () => {
 })
 
 describe('canon figures taken verbatim', () => {
-  // These two are printed in the canon enemy AC table; they are not ours to tune.
+  // These are printed in the canon enemy AC table; they are not ours to tune.
+  // The four humans are the table's own anchors, so every one of them is locked.
   it('keeps the AC values the canon states outright', () => {
     expect(getCreature('calcined_common').armourClass).toBe(12)
     expect(getCreature('watcher').armourClass).toBe(18)
+    expect(getCreature('civilian').armourClass).toBe(8)
+    expect(getCreature('brigand').armourClass).toBe(11)
+    expect(getCreature('soldier').armourClass).toBe(14)
+    expect(getCreature('inquisitor').armourClass).toBe(16)
   })
 
   it('keeps AC inside the canon 8-18 bracket for everything fightable', () => {

--- a/apps/backend/src/game-rules/bestiary.ts
+++ b/apps/backend/src/game-rules/bestiary.ts
@@ -39,6 +39,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'calcined_nascent',
     name: 'Calciné naissant',
     tier: 'calcined',
+    species: 'calcined',
     habitat: 'anywhere',
     behaviour: 'tragic',
     engagement: 'fight',
@@ -55,6 +56,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'calcined_common',
     name: 'Calciné courant',
     tier: 'calcined',
+    species: 'calcined',
     habitat: 'anywhere',
     behaviour: 'predatory',
     engagement: 'fight',
@@ -70,6 +72,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'calcined_ancient',
     name: 'Calciné ancien',
     tier: 'calcined',
+    species: 'calcined',
     habitat: 'anywhere',
     behaviour: 'territorial',
     engagement: 'fight',
@@ -86,6 +89,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'calcined_major',
     name: 'Calciné majeur',
     tier: 'calcined',
+    species: 'calcined',
     habitat: 'anywhere',
     behaviour: 'predatory',
     engagement: 'fight',
@@ -106,6 +110,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'ash_scorpion',
     name: 'Scorpion-à-Cendre',
     tier: 'common',
+    species: 'beast',
     habitat: 'tissan',
     behaviour: 'defensive',
     engagement: 'fight',
@@ -122,6 +127,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'sand_dog',
     name: 'Chien des Sables',
     tier: 'common',
+    species: 'beast',
     habitat: 'tissan',
     behaviour: 'opportunistic',
     engagement: 'fight',
@@ -136,6 +142,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'road_serpent',
     name: 'Serpent des Routes',
     tier: 'common',
+    species: 'beast',
     habitat: 'tissan',
     behaviour: 'opportunistic',
     engagement: 'fight',
@@ -152,6 +159,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'ruin_rat',
     name: 'Rat des Ruines',
     tier: 'common',
+    species: 'beast',
     habitat: 'doigts',
     behaviour: 'opportunistic',
     engagement: 'fight',
@@ -167,6 +175,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'stone_bat',
     name: 'Chauve-souris de Pierre',
     tier: 'common',
+    species: 'beast',
     habitat: 'doigts',
     behaviour: 'opportunistic',
     engagement: 'fight',
@@ -182,6 +191,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'blade_crab',
     name: 'Crabe-Lame',
     tier: 'common',
+    species: 'beast',
     habitat: 'rivage',
     behaviour: 'defensive',
     engagement: 'fight',
@@ -204,6 +214,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'sand_weaver',
     name: 'Tisseur de Sable',
     tier: 'rare',
+    species: 'beast',
     habitat: 'tissan',
     behaviour: 'predatory',
     engagement: 'fight',
@@ -223,6 +234,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'grey_wind',
     name: 'Vent-Gris',
     tier: 'rare',
+    species: 'archontic',
     habitat: 'tissan',
     behaviour: 'evental',
     engagement: 'hazard',
@@ -241,6 +253,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'watcher',
     name: 'Veilleur',
     tier: 'rare',
+    species: 'archontic',
     habitat: 'doigts',
     behaviour: 'territorial',
     engagement: 'fight',
@@ -258,6 +271,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'memory_eater',
     name: 'Mangeur de Souvenir',
     tier: 'rare',
+    species: 'beast',
     habitat: 'marais',
     behaviour: 'predatory',
     engagement: 'drain',
@@ -274,6 +288,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'revenant',
     name: 'Revenant',
     tier: 'rare',
+    species: 'archontic',
     habitat: 'anywhere',
     behaviour: 'tragic',
     engagement: 'fight',
@@ -292,6 +307,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'shore_beast',
     name: 'Bête de Rivage',
     tier: 'rare',
+    species: 'beast',
     habitat: 'rivage',
     behaviour: 'predatory',
     engagement: 'fight',
@@ -313,6 +329,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'heart_of_sand',
     name: 'Le Cœur de Sable',
     tier: 'legendary',
+    species: 'archontic',
     habitat: 'tissan',
     behaviour: 'territorial',
     engagement: 'fight',
@@ -329,6 +346,7 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     id: 'watcher_king',
     name: 'Le Veilleur-Roi',
     tier: 'legendary',
+    species: 'archontic',
     habitat: 'doigts',
     behaviour: 'territorial',
     engagement: 'fight',
@@ -339,6 +357,103 @@ const BESTIARY: Record<CreatureId, CreatureStatBlock> = {
     damage: { count: 2, faces: 6, bonus: 4 },
     loot: ['major_artefact', 'rare_metals'],
     minDepth: 7,
+    maxDepth: 7,
+  },
+
+  // ─── 🧍 Humans (10-COMBAT §4, §8) ────────────────────────────────────────
+  // These four are the only enemies whose AC the canon states outright, so
+  // unlike everything above, their AC is quoted rather than derived — they are
+  // the anchors the rest of the table was calibrated against.
+  //
+  // Their `tier` is the one field with no canon backing: `03-BESTIARY` never
+  // ranks humans, because they belong to the world rather than to the
+  // bestiary's danger ladder. It is set from the danger they actually pose to a
+  // starting character, which is what `tier` is used for elsewhere.
+  //
+  // `habitat: 'anywhere'` is literal, not a shrug: people are met on roads, in
+  // ruins and in towns alike. What keeps them off the deep floors is
+  // `maxDepth` — an Inquisitor patrolling floor 7 alongside a Watcher-King
+  // would be a scene the world does not support.
+  civilian: {
+    id: 'civilian',
+    name: 'Civil',
+    tier: 'common',
+    species: 'human',
+    habitat: 'anywhere',
+    // Fights only when cornered, and badly. Canon AC 8 — the floor of the
+    // whole scale, and the only enemy a starting character outclasses outright.
+    behaviour: 'defensive',
+    engagement: 'fight',
+    maxHp: 5,
+    armourClass: 8,
+    damage: { count: 1, faces: 4, bonus: 0 },
+    loot: ['basic_materials'],
+    minDepth: 1,
+    maxDepth: 2,
+  },
+  brigand: {
+    id: 'brigand',
+    name: 'Brigand',
+    tier: 'common',
+    species: 'human',
+    habitat: 'anywhere',
+    // Canon puts brigands in ambushes (§2) and in dungeon fights
+    // (11-INVENTORY §507); they pick their moment and rob rather than hunt.
+    behaviour: 'opportunistic',
+    engagement: 'fight',
+    // Canon AC 11. ~10 HP is two-to-three player turns: a fair fight, which is
+    // exactly what a road robbery should be.
+    //
+    // 1d6 with no bonus is deliberate: a brigand is met from floor 1, and the
+    // « je gère » band forbids anything that can drop an intact character in
+    // under four turns. A flat +1 would break that by itself.
+    maxHp: 10,
+    armourClass: 11,
+    damage: { count: 1, faces: 6, bonus: 0 },
+    loot: ['basic_materials', 'rare_metals'],
+    // Floor 3 up, not floor 1: an armed man who chose to rob you kills a fresh
+    // character in ~3 turns, which is the « ça coûte » band, not « je gère ».
+    minDepth: 3,
+    maxDepth: 5,
+  },
+  soldier: {
+    id: 'soldier',
+    name: 'Soldat équipé',
+    tier: 'common',
+    species: 'human',
+    habitat: 'anywhere',
+    behaviour: 'territorial',
+    engagement: 'fight',
+    // Canon AC 14. Trained and armoured: the point where a starting character
+    // stops winning by trading blows and has to use the tactical actions.
+    // 1d8 flat kills in ~2.4 turns, which is the deep end of « ça coûte »
+    // without crossing into the two-turn band reserved for floors 5+.
+    maxHp: 16,
+    armourClass: 14,
+    damage: { count: 1, faces: 8, bonus: 0 },
+    loot: ['basic_materials', 'rare_metals'],
+    minDepth: 4,
+    maxDepth: 6,
+  },
+  inquisitor: {
+    id: 'inquisitor',
+    name: 'Inquisiteur',
+    tier: 'rare',
+    species: 'human',
+    habitat: 'anywhere',
+    // Hunts undeclared Tisse-Verbe (12-NPCS §90): he comes looking for you.
+    behaviour: 'predatory',
+    engagement: 'fight',
+    // Canon AC 16 — above a Watcher's peer and second only to it. Canon also
+    // prices his purse at 50 🪙 (11-INVENTORY §120), the richest human loot.
+    maxHp: 26,
+    armourClass: 16,
+    damage: { count: 1, faces: 10, bonus: 3 },
+    loot: ['rare_metals', 'magic_components', 'minor_artefact'],
+    // Floors 5+, with the things that kill in two turns. Canon rates him the
+    // second-hardest AC in the game and a « Légendaire » DC 25 even to talk
+    // down (08-DICE §32) — meeting him early would be the unseeable death.
+    minDepth: 5,
     maxDepth: 7,
   },
 }

--- a/apps/backend/src/game-rules/combat.test.ts
+++ b/apps/backend/src/game-rules/combat.test.ts
@@ -1,0 +1,754 @@
+import { attributeModifier } from '@grimoire/shared'
+import { describe, expect, it } from 'vitest'
+
+import {
+  advanceTurn,
+  checkCombatEnd,
+  derivePlayerConditions,
+  endCombat,
+  instantiateEnemy,
+  projectCombat,
+  resolveEnemyTurn,
+  resolveKnockout,
+  resolvePlayerTurn,
+  rollAgainst,
+  rollDamage,
+  rollInitiative,
+  startCombat,
+} from './combat'
+
+import type { CombatEnemy, CombatPlayer, CombatState, SurvivalStats } from '@grimoire/shared'
+
+/**
+ * A scripted RNG: each call returns the next value, so a test states the exact
+ * die faces it wants instead of hoping an average shows up. `faceOf` converts a
+ * d20 face into the [0,1) draw that produces it.
+ */
+function scriptedRng(values: number[]): () => number {
+  let index = 0
+  return () => {
+    const value = values[index] ?? 0
+    index += 1
+    return value
+  }
+}
+
+/** The [0,1) draw that makes `1 + floor(rng * faces)` land on `face`. */
+function faceOf(face: number, faces = 20): number {
+  return (face - 1) / faces
+}
+
+const ATTRIBUTES = { blood: 14, breath: 12, ash: 10 }
+
+function makePlayer(overrides: Partial<CombatPlayer> = {}): CombatPlayer {
+  return {
+    hp: 11,
+    maxHp: 11,
+    armourClass: 11,
+    attributes: ATTRIBUTES,
+    conditions: [],
+    combatConditions: [],
+    ...overrides,
+  }
+}
+
+function makeSurvival(overrides: Partial<SurvivalStats> = {}): SurvivalStats {
+  return {
+    hp: 11,
+    maxHp: 11,
+    thirst: 80,
+    hunger: 80,
+    energy: 80,
+    calamine: 0,
+    isDying: false,
+    neglectStreak: 0,
+    ...overrides,
+  }
+}
+
+function makeState(overrides: Partial<CombatState> = {}): CombatState {
+  return {
+    id: 'fight-1',
+    player: makePlayer(),
+    enemies: [instantiateEnemy('brigand', 'e1')],
+    initiative: 'player',
+    round: 1,
+    activeSide: 'player',
+    log: [],
+    outcome: null,
+    isHostileEnvironment: false,
+    hasLivingAlly: false,
+    ...overrides,
+  }
+}
+
+describe('rollAgainst', () => {
+  it('adds the attribute modifier to the die before comparing', () => {
+    // SANG 14 → +2. A face of 9 totals 11, which clears an AC of 11.
+    const roll = rollAgainst(ATTRIBUTES, 'blood', 11, scriptedRng([faceOf(9)]))
+    expect(roll.roll).toBe(9)
+    expect(roll.modifier).toBe(2)
+    expect(roll.total).toBe(11)
+    expect(roll.success).toBe(true)
+  })
+
+  it('lets a natural 20 beat a target the total could never reach', () => {
+    const roll = rollAgainst(ATTRIBUTES, 'blood', 99, scriptedRng([faceOf(20)]))
+    expect(roll.critical).toBe('success')
+    expect(roll.success).toBe(true)
+  })
+
+  it('lets a natural 1 fail a target the total would otherwise clear', () => {
+    const roll = rollAgainst(ATTRIBUTES, 'blood', 2, scriptedRng([faceOf(1)]))
+    expect(roll.critical).toBe('failure')
+    expect(roll.success).toBe(false)
+  })
+
+  it('keeps the better of two dice with advantage and the worse with disadvantage', () => {
+    const faces = [faceOf(4), faceOf(17)]
+    expect(rollAgainst(ATTRIBUTES, 'blood', 10, scriptedRng(faces), 'advantage').roll).toBe(17)
+    expect(rollAgainst(ATTRIBUTES, 'blood', 10, scriptedRng(faces), 'disadvantage').roll).toBe(4)
+  })
+})
+
+describe('rollDamage', () => {
+  it('sums every die and adds the flat bonus', () => {
+    const rng = scriptedRng([faceOf(3, 6), faceOf(5, 6)])
+    expect(rollDamage({ count: 2, faces: 6, bonus: 1 }, rng)).toBe(9)
+  })
+
+  it('never returns a negative amount', () => {
+    expect(rollDamage({ count: 1, faces: 4, bonus: -10 }, scriptedRng([faceOf(1, 4)]))).toBe(0)
+  })
+})
+
+describe('initiative (§2)', () => {
+  const enemies = [instantiateEnemy('brigand', 'e1')]
+
+  // Canon states the tie explicitly, and it is the player-facing half of the
+  // rule: a coin-flip start would make the opening exchange feel arbitrary.
+  it('gives a tie to the player', () => {
+    // Player SOUFFLE 12 → +1; the brigand's derived BREATH gives its own
+    // modifier. Equal totals must still seat the player first.
+    const enemyModifier = attributeModifier(enemies[0].attributes.breath)
+    const playerModifier = attributeModifier(ATTRIBUTES.breath)
+    const playerFace = 10
+    // The enemy face that makes both totals land on exactly the same number.
+    const enemyFace = playerFace + playerModifier - enemyModifier
+    expect(playerFace + playerModifier).toBe(enemyFace + enemyModifier)
+    const side = rollInitiative(
+      ATTRIBUTES,
+      enemies,
+      scriptedRng([faceOf(playerFace), faceOf(enemyFace)])
+    )
+    expect(side).toBe('player')
+  })
+
+  it('hands the opening to the enemies when they beat the player outright', () => {
+    const side = rollInitiative(ATTRIBUTES, enemies, scriptedRng([faceOf(2), faceOf(20)]))
+    expect(side).toBe('enemy')
+  })
+
+  // One roll per camp, never one per creature — a six-enemy fight must not cost
+  // six rolls, which is exactly what canon's simplification buys.
+  it('rolls once for the whole enemy camp regardless of its size', () => {
+    let calls = 0
+    const counting = (): number => {
+      calls += 1
+      return 0.5
+    }
+    const crowd = ['e1', 'e2', 'e3', 'e4'].map((id) => instantiateEnemy('brigand', id))
+    rollInitiative(ATTRIBUTES, crowd, counting)
+    expect(calls).toBe(2)
+  })
+})
+
+describe('combat conditions (§6)', () => {
+  it('marks the player engaged as soon as one enemy lives', () => {
+    const conditions = derivePlayerConditions([], [instantiateEnemy('brigand', 'e1')])
+    expect(conditions).toContain('engaged')
+    expect(conditions).not.toContain('flanked')
+  })
+
+  it('marks the player flanked from two living enemies', () => {
+    const conditions = derivePlayerConditions(
+      [],
+      [instantiateEnemy('brigand', 'e1'), instantiateEnemy('brigand', 'e2')]
+    )
+    expect(conditions).toContain('flanked')
+  })
+
+  // Positional conditions describe the board, so they must clear themselves;
+  // event conditions describe something that happened and must not.
+  it('clears positional conditions when the board empties but keeps event ones', () => {
+    const dead = { ...instantiateEnemy('brigand', 'e1'), isAlive: false, hp: 0 }
+    const conditions = derivePlayerConditions(['engaged', 'flanked', 'disarmed'], [dead])
+    expect(conditions).toEqual(['disarmed'])
+  })
+})
+
+describe('the death table (§8)', () => {
+  const human = instantiateEnemy('brigand', 'e1')
+  const beast = instantiateEnemy('sand_dog', 'e2')
+  const calcined = instantiateEnemy('calcined_common', 'e3')
+  const archontic = instantiateEnemy('watcher', 'e4')
+
+  it('saves the player when an ally is still standing', () => {
+    expect(
+      resolveKnockout({
+        hasLivingAlly: true,
+        survivingEnemies: [beast],
+        isHostileEnvironment: true,
+      })
+    ).toBe('saved')
+  })
+
+  it('takes the player prisoner when only humans are left standing', () => {
+    expect(
+      resolveKnockout({
+        hasLivingAlly: false,
+        survivingEnemies: [human],
+        isHostileEnvironment: false,
+      })
+    ).toBe('captured')
+  })
+
+  // The savage half of the table: none of these three take prisoners.
+  it.each([
+    ['a beast', beast],
+    ['a Calciné', calcined],
+    ['an archontic Watcher', archontic],
+  ])('kills the player when %s is standing over them', (_label, enemy: CombatEnemy) => {
+    expect(
+      resolveKnockout({
+        hasLivingAlly: false,
+        survivingEnemies: [enemy],
+        isHostileEnvironment: false,
+      })
+    ).toBe('dead')
+  })
+
+  // A mixed camp is the case a naive "any human?" reading gets wrong: the beast
+  // is still there, and it does not wait for the brigand's permission.
+  it('kills the player when a single savage enemy stands among humans', () => {
+    expect(
+      resolveKnockout({
+        hasLivingAlly: false,
+        survivingEnemies: [human, beast],
+        isHostileEnvironment: false,
+      })
+    ).toBe('dead')
+  })
+
+  it('overrides captivity in a hostile environment — nobody marches a prisoner there', () => {
+    expect(
+      resolveKnockout({
+        hasLivingAlly: false,
+        survivingEnemies: [human],
+        isHostileEnvironment: true,
+      })
+    ).toBe('dead')
+  })
+
+  it('kills a player who bled out with nobody left to take them', () => {
+    expect(
+      resolveKnockout({
+        hasLivingAlly: false,
+        survivingEnemies: [{ ...human, isAlive: false, hp: 0 }],
+        isHostileEnvironment: false,
+      })
+    ).toBe('dead')
+  })
+})
+
+describe('instantiateEnemy', () => {
+  it('copies the canon stat block onto the instance', () => {
+    const brigand = instantiateEnemy('brigand', 'e1')
+    expect(brigand.armourClass).toBe(11)
+    expect(brigand.species).toBe('human')
+    expect(brigand.isAlive).toBe(true)
+    expect(brigand.hp).toBe(brigand.maxHp)
+  })
+
+  it('thins a wounded variant and hardens an ancient one', () => {
+    const base = instantiateEnemy('brigand', 'e1')
+    expect(instantiateEnemy('brigand', 'e2', 'wounded').maxHp).toBeLessThan(base.maxHp)
+    expect(instantiateEnemy('brigand', 'e3', 'ancient').armourClass).toBe(base.armourClass + 2)
+  })
+})
+
+describe('startCombat', () => {
+  it('opens on round 1 with the initiative winner acting and no outcome yet', () => {
+    const state = startCombat({
+      id: 'fight-1',
+      player: makePlayer(),
+      enemies: [instantiateEnemy('brigand', 'e1')],
+      rng: scriptedRng([faceOf(20), faceOf(1)]),
+    })
+    expect(state.round).toBe(1)
+    expect(state.initiative).toBe('player')
+    expect(state.activeSide).toBe('player')
+    expect(state.outcome).toBeNull()
+    expect(state.player.combatConditions).toContain('engaged')
+  })
+})
+
+describe('the player attacking (§3)', () => {
+  it('deals weapon damage plus SANG on a hit', () => {
+    const state = makeState()
+    // Face 12 + 2 clears AC 11; then a d6 face of 4, plus SANG +2.
+    const result = resolvePlayerTurn({
+      state,
+      action: 'attack',
+      weapon: { count: 1, faces: 6, bonus: 0 },
+      rng: scriptedRng([faceOf(12), faceOf(4, 6)]),
+    })
+    expect(result.entry.hit).toBe(true)
+    expect(result.entry.damage).toBe(6)
+    expect(result.state.enemies[0].hp).toBe(state.enemies[0].maxHp - 6)
+  })
+
+  it('leaves the enemy untouched on a miss', () => {
+    const state = makeState()
+    const result = resolvePlayerTurn({
+      state,
+      action: 'attack',
+      rng: scriptedRng([faceOf(3)]),
+    })
+    expect(result.entry.hit).toBe(false)
+    expect(result.state.enemies[0].hp).toBe(state.enemies[0].maxHp)
+  })
+
+  it('disarms the player on a natural 1', () => {
+    const result = resolvePlayerTurn({
+      state: makeState(),
+      action: 'attack',
+      rng: scriptedRng([faceOf(1)]),
+    })
+    expect(result.state.player.combatConditions).toContain('disarmed')
+  })
+
+  it('doubles the damage on a natural 20', () => {
+    const result = resolvePlayerTurn({
+      state: makeState(),
+      action: 'attack',
+      weapon: { count: 1, faces: 6, bonus: 0 },
+      rng: scriptedRng([faceOf(20), faceOf(4, 6)]),
+    })
+    expect(result.entry.damage).toBe(12)
+  })
+
+  it('kills an enemy whose HP reaches zero', () => {
+    const frail = { ...instantiateEnemy('brigand', 'e1'), hp: 2 }
+    const result = resolvePlayerTurn({
+      state: makeState({ enemies: [frail] }),
+      action: 'attack',
+      weapon: { count: 1, faces: 6, bonus: 0 },
+      rng: scriptedRng([faceOf(15), faceOf(6, 6)]),
+    })
+    expect(result.state.enemies[0].isAlive).toBe(false)
+    expect(result.state.enemies[0].hp).toBe(0)
+  })
+
+  // Being frightened or dazed has to cost something measurable, or the
+  // conditions are decoration.
+  it('attacks at disadvantage while frightened', () => {
+    const state = makeState({ player: makePlayer({ combatConditions: ['frightened'] }) })
+    const result = resolvePlayerTurn({
+      state,
+      action: 'attack',
+      rng: scriptedRng([faceOf(18), faceOf(3)]),
+    })
+    expect(result.entry.roll).toBe(3)
+  })
+})
+
+describe('defending and items (§3)', () => {
+  it('heals a wounded player without ever exceeding max HP', () => {
+    const state = makeState({ player: makePlayer({ hp: 10 }) })
+    const result = resolvePlayerTurn({
+      state,
+      action: 'defend',
+      rng: scriptedRng([faceOf(4, 4)]),
+    })
+    expect(result.state.player.hp).toBe(11)
+    expect(result.entry.healing).toBe(1)
+  })
+
+  it('applies item healing decided by the inventory rules', () => {
+    const result = resolvePlayerTurn({
+      state: makeState({ player: makePlayer({ hp: 4 }) }),
+      action: 'use_item',
+      itemHealing: 5,
+    })
+    expect(result.state.player.hp).toBe(9)
+  })
+})
+
+describe('the CENDRE Leader role (§5)', () => {
+  // Intimidation is an opposed roll, not a fixed DC — the enemy rolls back.
+  it('makes an intimidated enemy hesitate rather than die', () => {
+    const soldier = instantiateEnemy('soldier', 'e1')
+    const result = resolvePlayerTurn({
+      state: makeState({ enemies: [soldier] }),
+      action: 'command',
+      // Enemy face 2, then the player's face 19.
+      rng: scriptedRng([faceOf(2), faceOf(19)]),
+    })
+    expect(result.entry.hit).toBe(true)
+    expect(result.state.enemies[0].combatConditions).toContain('frightened')
+    expect(result.state.enemies[0].isAlive).toBe(true)
+  })
+
+  // Canon: below AC 11 a shaken enemy does not hesitate, it runs.
+  it('routs an enemy under AC 11 outright', () => {
+    const civilian = instantiateEnemy('civilian', 'e1')
+    const result = resolvePlayerTurn({
+      state: makeState({ enemies: [civilian] }),
+      action: 'command',
+      rng: scriptedRng([faceOf(2), faceOf(19)]),
+    })
+    expect(result.state.enemies[0].isAlive).toBe(false)
+    expect(result.state.enemies[0].hasRouted).toBe(true)
+  })
+
+  it('reaches a second enemy on a remarkable success', () => {
+    const enemies = [instantiateEnemy('soldier', 'e1'), instantiateEnemy('soldier', 'e2')]
+    const result = resolvePlayerTurn({
+      state: makeState({ enemies }),
+      action: 'command',
+      rng: scriptedRng([faceOf(1), faceOf(20)]),
+    })
+    const shaken = result.state.enemies.filter((e) => e.combatConditions.includes('frightened'))
+    expect(shaken).toHaveLength(2)
+  })
+
+  it('never intimidates an archontic Watcher, which has no fear to work on', () => {
+    const watcher = instantiateEnemy('watcher', 'e1')
+    const result = resolvePlayerTurn({
+      state: makeState({ enemies: [watcher] }),
+      action: 'command',
+      rng: scriptedRng([faceOf(1), faceOf(20)]),
+    })
+    expect(result.state.enemies[0].combatConditions).not.toContain('frightened')
+    expect(result.state.enemies[0].isAlive).toBe(true)
+  })
+
+  it('galvanises the camp on a critical failure', () => {
+    const result = resolvePlayerTurn({
+      state: makeState(),
+      action: 'command',
+      rng: scriptedRng([faceOf(10), faceOf(1)]),
+    })
+    expect(result.state.galvanised).toBe(true)
+  })
+
+  // Commandement is the other half of §5, and it needs someone to obey it.
+  it('resolves Commandement against a fixed DC when an ally is present', () => {
+    const result = resolvePlayerTurn({
+      state: makeState({ hasLivingAlly: true }),
+      action: 'command',
+      allyKind: 'human',
+      rng: scriptedRng([faceOf(15)]),
+    })
+    expect(result.entry.hit).toBe(true)
+  })
+
+  it('makes Commandement a no-op when no ally is standing there', () => {
+    const result = resolvePlayerTurn({
+      state: makeState({ hasLivingAlly: false }),
+      action: 'command',
+      allyKind: 'human',
+      rng: scriptedRng([faceOf(20)]),
+    })
+    expect(result.entry.hit).toBeUndefined()
+  })
+})
+
+describe('fleeing (§7)', () => {
+  // The canon promise the whole design rests on: the door is never locked.
+  it('always offers flight, even surrounded and at 1 HP', () => {
+    const state = makeState({
+      player: makePlayer({ hp: 1, combatConditions: ['engaged', 'flanked'] }),
+      enemies: [instantiateEnemy('brigand', 'e1'), instantiateEnemy('brigand', 'e2')],
+    })
+    expect(projectCombat(state).canFlee).toBe(true)
+  })
+
+  it('escapes on a success and records which way the player ran', () => {
+    const result = resolvePlayerTurn({
+      state: makeState(),
+      action: 'flee',
+      fleeDirection: 'forward',
+      rng: scriptedRng([faceOf(18)]),
+    })
+    expect(result.state.outcome).toBe('fled')
+    expect(result.state.fleeDirection).toBe('forward')
+  })
+
+  // Engaged raises the DC from 12 to 15, so face 13 (+1 SOUFFLE = 14) is the
+  // discriminating case: it would escape a disengaged player and fails here.
+  it('is harder to escape while engaged', () => {
+    const free = resolvePlayerTurn({
+      state: makeState({ player: makePlayer({ combatConditions: [] }) }),
+      action: 'flee',
+      rng: scriptedRng([faceOf(13)]),
+    })
+    const engaged = resolvePlayerTurn({
+      state: makeState({ player: makePlayer({ combatConditions: ['engaged'] }) }),
+      action: 'flee',
+      rng: scriptedRng([faceOf(13)]),
+    })
+    expect(free.state.outcome).toBe('fled')
+    expect(engaged.state.outcome).toBeNull()
+  })
+
+  it('costs a free enemy hit on a failure', () => {
+    const state = makeState({ player: makePlayer({ combatConditions: ['engaged'] }) })
+    const result = resolvePlayerTurn({
+      state,
+      action: 'flee',
+      rng: scriptedRng([faceOf(5), faceOf(4, 6)]),
+    })
+    expect(result.state.outcome).toBeNull()
+    expect(result.state.player.hp).toBeLessThan(state.player.hp)
+  })
+
+  it('leaves the player dazed on a critical failure', () => {
+    const result = resolvePlayerTurn({
+      state: makeState({ player: makePlayer({ combatConditions: ['engaged'] }) }),
+      action: 'flee',
+      rng: scriptedRng([faceOf(1), faceOf(2, 6)]),
+    })
+    expect(result.state.player.combatConditions).toContain('dazed')
+  })
+})
+
+describe('the enemy block (§2, §6)', () => {
+  it('resolves every living enemy in a single turn', () => {
+    const enemies = [instantiateEnemy('brigand', 'e1'), instantiateEnemy('brigand', 'e2')]
+    const result = resolveEnemyTurn({
+      state: makeState({ enemies, player: makePlayer({ combatConditions: ['engaged'] }) }),
+      survival: makeSurvival(),
+      // Both miss; a flanked player would roll advantage, so two dice each.
+      rng: scriptedRng([faceOf(2), faceOf(2), faceOf(2), faceOf(2)]),
+    })
+    expect(result.entries).toHaveLength(2)
+  })
+
+  it('skips a dead enemy entirely', () => {
+    const dead = { ...instantiateEnemy('brigand', 'e1'), isAlive: false, hp: 0 }
+    const result = resolveEnemyTurn({
+      state: makeState({ enemies: [dead] }),
+      survival: makeSurvival(),
+      rng: scriptedRng([faceOf(20)]),
+    })
+    expect(result.entries).toHaveLength(0)
+  })
+
+  // A shaken enemy losing its turn is the payoff Intimidation is bought for.
+  it('makes an intimidated enemy skip its turn, then shake it off', () => {
+    const shaken = {
+      ...instantiateEnemy('brigand', 'e1'),
+      combatConditions: ['frightened' as const],
+    }
+    const result = resolveEnemyTurn({
+      state: makeState({ enemies: [shaken] }),
+      survival: makeSurvival(),
+      rng: scriptedRng([faceOf(20)]),
+    })
+    expect(result.entries).toHaveLength(0)
+    expect(result.state.enemies[0].combatConditions).not.toContain('frightened')
+  })
+
+  it('never lets a hazard attack — the Grey Wind is escaped, not fought', () => {
+    const wind = instantiateEnemy('grey_wind', 'e1')
+    const result = resolveEnemyTurn({
+      state: makeState({ enemies: [wind] }),
+      survival: makeSurvival(),
+      rng: scriptedRng([faceOf(20)]),
+    })
+    expect(result.entries).toHaveLength(0)
+  })
+
+  it('dazes the player on a natural 20 in melee', () => {
+    const result = resolveEnemyTurn({
+      state: makeState(),
+      survival: makeSurvival(),
+      rng: scriptedRng([faceOf(20), faceOf(3, 6)]),
+    })
+    expect(result.state.player.combatConditions).toContain('dazed')
+  })
+
+  it('attacks with advantage while the player is flanked', () => {
+    const enemies = [instantiateEnemy('brigand', 'e1'), instantiateEnemy('brigand', 'e2')]
+    const state = makeState({
+      enemies,
+      player: makePlayer({ combatConditions: ['engaged', 'flanked'] }),
+    })
+    const result = resolveEnemyTurn({
+      state,
+      survival: makeSurvival(),
+      // First enemy: faces 3 then 16 — advantage must keep 16.
+      rng: scriptedRng([faceOf(3), faceOf(16), faceOf(2, 6), faceOf(1), faceOf(1)]),
+    })
+    expect(result.entries[0].roll).toBe(16)
+  })
+
+  // Présence is the passive reward for a CENDRE build; it must actually bite.
+  it('gives basic enemies disadvantage on the opening attack at CENDRE +2', () => {
+    const state = makeState({
+      player: makePlayer({ attributes: { blood: 14, breath: 12, ash: 14 } }),
+    })
+    const result = resolveEnemyTurn({
+      state,
+      survival: makeSurvival(),
+      rng: scriptedRng([faceOf(18), faceOf(4)]),
+    })
+    expect(result.entries[0].roll).toBe(4)
+  })
+
+  it('lets Présence lapse after the opening round', () => {
+    const state = makeState({
+      round: 2,
+      player: makePlayer({ attributes: { blood: 14, breath: 12, ash: 14 } }),
+    })
+    const result = resolveEnemyTurn({
+      state,
+      survival: makeSurvival(),
+      rng: scriptedRng([faceOf(18), faceOf(4)]),
+    })
+    expect(result.entries[0].roll).toBe(18)
+  })
+
+  it('spends galvanisation on exactly one turn', () => {
+    const result = resolveEnemyTurn({
+      state: makeState({ galvanised: true }),
+      survival: makeSurvival(),
+      rng: scriptedRng([faceOf(2), faceOf(2), faceOf(1, 6)]),
+    })
+    expect(result.state.galvanised).toBe(false)
+  })
+})
+
+describe('the dying contract in combat (06-SURVIVAL §7)', () => {
+  // Combat must not invent its own death path: the first drop buys the same
+  // one-turn reprieve poison and neglect do.
+  it('pins the first drop to 0 HP at dying rather than dead', () => {
+    const result = resolveEnemyTurn({
+      state: makeState({ player: makePlayer({ hp: 1 }) }),
+      survival: makeSurvival({ hp: 1 }),
+      rng: scriptedRng([faceOf(19), faceOf(6, 6)]),
+    })
+    expect(result.survival.hp).toBe(0)
+    expect(result.survival.isDying).toBe(true)
+    expect(result.definitiveDeath).toBe(false)
+    expect(result.state.outcome).toBeNull()
+    expect(result.state.knockoutVerdict).toBeUndefined()
+  })
+
+  it('opens the death table only on the second drop', () => {
+    const result = resolveEnemyTurn({
+      state: makeState({ player: makePlayer({ hp: 1 }) }),
+      survival: makeSurvival({ hp: 1, isDying: true }),
+      rng: scriptedRng([faceOf(19), faceOf(6, 6)]),
+    })
+    expect(result.definitiveDeath).toBe(true)
+    expect(result.state.outcome).toBe('defeat')
+    // A lone brigand is human, so the verdict is captivity rather than death.
+    expect(result.state.knockoutVerdict).toBe('captured')
+  })
+
+  it('reads the death table off the enemies actually left standing', () => {
+    const result = resolveEnemyTurn({
+      state: makeState({
+        player: makePlayer({ hp: 1 }),
+        enemies: [instantiateEnemy('sand_dog', 'e1')],
+        isHostileEnvironment: false,
+      }),
+      survival: makeSurvival({ hp: 1, isDying: true }),
+      rng: scriptedRng([faceOf(19), faceOf(6, 6)]),
+    })
+    expect(result.state.knockoutVerdict).toBe('dead')
+  })
+})
+
+describe('ending a fight (§9)', () => {
+  it('reports victory once every enemy is down', () => {
+    const dead = { ...instantiateEnemy('brigand', 'e1'), isAlive: false, hp: 0 }
+    expect(checkCombatEnd(makeState({ enemies: [dead] }))).toBe('victory')
+  })
+
+  it('reports nothing while an enemy still stands', () => {
+    expect(checkCombatEnd(makeState())).toBeNull()
+  })
+
+  it('pays iron and loot on victory', () => {
+    const dead = { ...instantiateEnemy('brigand', 'e1'), isAlive: false, hp: 0 }
+    const result = endCombat({ state: makeState({ enemies: [dead] }), rng: () => 0.5 })
+    expect(result.outcome).toBe('victory')
+    expect(result.ironGained).toBeGreaterThan(0)
+    expect(result.loot.length).toBeGreaterThan(0)
+  })
+
+  // Canon is explicit that an Inquisitor is worth far more than a brigand.
+  it('pays a rare enemy more iron than a common one', () => {
+    const brigand = { ...instantiateEnemy('brigand', 'e1'), isAlive: false, hp: 0 }
+    const inquisitor = { ...instantiateEnemy('inquisitor', 'e2'), isAlive: false, hp: 0 }
+    const common = endCombat({ state: makeState({ enemies: [brigand] }), rng: () => 0.99 })
+    const rare = endCombat({ state: makeState({ enemies: [inquisitor] }), rng: () => 0 })
+    expect(rare.ironGained).toBeGreaterThan(common.ironGained)
+  })
+
+  // An enemy that ran took its purse with it.
+  it('pays nothing for an enemy that routed rather than died', () => {
+    const routed = {
+      ...instantiateEnemy('civilian', 'e1'),
+      isAlive: false,
+      hasRouted: true,
+    }
+    const result = endCombat({ state: makeState({ enemies: [routed] }), rng: () => 0.5 })
+    expect(result.ironGained).toBe(0)
+    expect(result.loot).toHaveLength(0)
+  })
+
+  it('pays nothing on a defeat and carries the verdict through', () => {
+    const state = makeState({ outcome: 'defeat', knockoutVerdict: 'captured' })
+    const result = endCombat({ state, rng: () => 0.5 })
+    expect(result.ironGained).toBe(0)
+    expect(result.knockoutVerdict).toBe('captured')
+  })
+
+  it('carries the flight direction through to the run', () => {
+    const state = makeState({ outcome: 'fled', fleeDirection: 'backward' })
+    expect(endCombat({ state, rng: () => 0.5 }).fleeDirection).toBe('backward')
+  })
+})
+
+describe('projection and turn order', () => {
+  it('projects everything the interface needs without a rule to recompute', () => {
+    const state = makeState()
+    const snapshot = projectCombat(state)
+    expect(snapshot.round).toBe(state.round)
+    expect(snapshot.enemies).toEqual(state.enemies)
+    expect(snapshot.initiative).toBe(state.initiative)
+    expect(snapshot.result).toBeUndefined()
+  })
+
+  it('attaches the result once the fight is over', () => {
+    const dead = { ...instantiateEnemy('brigand', 'e1'), isAlive: false, hp: 0 }
+    const state = makeState({ enemies: [dead] })
+    const snapshot = projectCombat(state, endCombat({ state, rng: () => 0.5 }))
+    expect(snapshot.result?.outcome).toBe('victory')
+  })
+
+  it('advances the round only after the enemy block has acted', () => {
+    const afterPlayer = advanceTurn(makeState({ activeSide: 'player' }))
+    expect(afterPlayer.activeSide).toBe('enemy')
+    expect(afterPlayer.round).toBe(1)
+
+    const afterEnemy = advanceTurn(afterPlayer)
+    expect(afterEnemy.activeSide).toBe('player')
+    expect(afterEnemy.round).toBe(2)
+  })
+})

--- a/apps/backend/src/game-rules/combat.ts
+++ b/apps/backend/src/game-rules/combat.ts
@@ -1,0 +1,848 @@
+import { attributeModifier } from '@grimoire/shared'
+
+import { getCreature } from './bestiary'
+import { resolveDying } from './survival'
+
+import type {
+  Attributes,
+  CombatAction,
+  CombatConditionId,
+  CombatEnemy,
+  CombatLogEntry,
+  CombatLoot,
+  CombatOutcome,
+  CombatPlayer,
+  CombatResult,
+  CombatSnapshot,
+  CombatState,
+  CreatureId,
+  CreatureTier,
+  CreatureVariant,
+  DamageDice,
+  FleeDirection,
+  InitiativeSide,
+  KnockoutContext,
+  KnockoutVerdict,
+  SurvivalStats,
+} from '@grimoire/shared'
+
+/**
+ * The turn-based combat engine — the only place a fight is arbitrated.
+ *
+ * Everything here is a pure function of state plus an injectable `rng`, which
+ * is what makes a fight reproducible in a test and impossible for the AI to
+ * lean on. The AI is handed the resolved mechanical outcome and writes prose
+ * for it; it never supplies a number, a hit, or a verdict.
+ *
+ * @see docs/public/raw/10-COMBAT.md
+ * @see docs/public/raw/08-DICE-RESOLUTION.md §7
+ */
+
+/** A d20 face. Kept separate from `rollCheck` because combat compares against
+ * a numeric target (an AC, a fixed DC) rather than a named `Difficulty`. */
+function rollD20(rng: () => number): number {
+  return 1 + Math.floor(rng() * 20)
+}
+
+/** Rolls 2d20 and keeps the better or worse face, per canon §5. */
+function rollD20With(rng: () => number, mode: 'normal' | 'advantage' | 'disadvantage'): number {
+  const first = rollD20(rng)
+  if (mode === 'normal') return first
+  const second = rollD20(rng)
+  return mode === 'advantage' ? Math.max(first, second) : Math.min(first, second)
+}
+
+/** The outcome of one roll against a numeric target. */
+export interface TargetedRoll {
+  roll: number
+  modifier: number
+  total: number
+  target: number
+  success: boolean
+  critical: 'success' | 'failure' | null
+}
+
+/**
+ * Rolls d20 + attribute modifier against a numeric target. Natural 20 always
+ * succeeds and natural 1 always fails, matching `rollCheck`'s convention so the
+ * two never disagree about what a critical is.
+ */
+export function rollAgainst(
+  attributes: Attributes,
+  attribute: keyof Attributes,
+  target: number,
+  rng: () => number,
+  mode: 'normal' | 'advantage' | 'disadvantage' = 'normal'
+): TargetedRoll {
+  const roll = rollD20With(rng, mode)
+  const modifier = attributeModifier(attributes[attribute])
+  const total = roll + modifier
+  const critical = roll === 20 ? 'success' : roll === 1 ? 'failure' : null
+  const success = critical === 'success' ? true : critical === 'failure' ? false : total >= target
+  return { roll, modifier, total, target, success, critical }
+}
+
+/** Rolls a damage expression. @see 08-DICE-RESOLUTION.md §7 */
+export function rollDamage(dice: DamageDice, rng: () => number): number {
+  let total = dice.bonus
+  for (let i = 0; i < dice.count; i++) {
+    total += 1 + Math.floor(rng() * dice.faces)
+  }
+  return Math.max(0, total)
+}
+
+// ─── Initiative (§2) ────────────────────────────────────────────────────────
+
+/**
+ * One initiative roll per side, never one per creature — canon calls this a
+ * deliberate simplification to hold the pace. Ties go to the player.
+ * @see 10-COMBAT.md §2
+ */
+export function rollInitiative(
+  player: Attributes,
+  enemies: readonly CombatEnemy[],
+  rng: () => number
+): InitiativeSide {
+  const playerTotal = rollD20(rng) + attributeModifier(player.breath)
+
+  // The enemy camp rolls once, on the group's average BREATH.
+  const living = enemies.filter((enemy) => enemy.isAlive)
+  const averageBreath =
+    living.length === 0
+      ? 0
+      : Math.round(living.reduce((sum, e) => sum + e.attributes.breath, 0) / living.length)
+  const enemyTotal = rollD20(rng) + attributeModifier(averageBreath)
+
+  return enemyTotal > playerTotal ? 'enemy' : 'player'
+}
+
+// ─── Combat conditions (§6) ─────────────────────────────────────────────────
+
+/** Two or more living enemies surround the player: they attack with advantage. */
+const FLANKED_THRESHOLD = 2
+
+/** Recomputes the positional conditions that follow from the board itself. */
+export function derivePlayerConditions(
+  current: readonly CombatConditionId[],
+  enemies: readonly CombatEnemy[]
+): CombatConditionId[] {
+  const living = enemies.filter((enemy) => enemy.isAlive).length
+
+  // `engaged` and `flanked` describe where the player is standing, so they are
+  // recomputed every turn rather than accumulated; `disarmed`, `frightened` and
+  // `dazed` are events and are carried over untouched.
+  const carried = current.filter((id) => id !== 'engaged' && id !== 'flanked')
+  const positional: CombatConditionId[] = []
+  if (living > 0) positional.push('engaged')
+  if (living >= FLANKED_THRESHOLD) positional.push('flanked')
+
+  return [...carried, ...positional]
+}
+
+// ─── The death table (§8) ───────────────────────────────────────────────────
+
+/**
+ * Decides what becomes of a player dropped to 0 HP, as a rule rather than as a
+ * narrative choice.
+ *
+ * This is the truth table of `10-COMBAT §8` evaluated in its own stated order.
+ * A living ally saves first, because the ally is physically able to drag the
+ * body out before anything else happens. A hostile environment then overrides
+ * captivity: nobody marches a prisoner through the Ventre-Gris. Human enemies
+ * take prisoners; savage ones — beasts, Calcinés, archontic automata — do not.
+ *
+ * The AI receives this verdict and writes the scene for it. It never chooses
+ * it: a death decided by a model is by construction a death the player could
+ * not see coming (`01-PILLARS §9`).
+ *
+ * @see 10-COMBAT.md §8 (corrected 2026-08-06)
+ */
+export function resolveKnockout(context: KnockoutContext): KnockoutVerdict {
+  const { hasLivingAlly, survivingEnemies, isHostileEnvironment } = context
+  const living = survivingEnemies.filter((enemy) => enemy.isAlive)
+
+  if (hasLivingAlly) return 'saved'
+  if (isHostileEnvironment) return 'dead'
+
+  // No enemy left standing and no ally: the player simply bled out where they
+  // fell. Nothing is there to take them prisoner.
+  if (living.length === 0) return 'dead'
+
+  return living.every((enemy) => enemy.species === 'human') ? 'captured' : 'dead'
+}
+
+// ─── Enemy instantiation ────────────────────────────────────────────────────
+
+/** Attributes given to an instantiated creature, scaled off its stat block. */
+function creatureAttributes(armourClass: number): Attributes {
+  // Creatures have no attribute sheet in canon; their AC already encodes how
+  // hard they are to hit, so BREATH is derived from it for initiative purposes
+  // and the rest sits at the human baseline.
+  return { blood: 10, breath: Math.max(6, armourClass - 2), ash: 10 }
+}
+
+/**
+ * Builds one live enemy from a bestiary entry. `variant` is applied here and
+ * never mid-fight: canon requires it to be announced before the first turn.
+ */
+export function instantiateEnemy(
+  creatureId: CreatureId,
+  instanceId: string,
+  variant: CreatureVariant | null = null
+): CombatEnemy {
+  const block = getCreature(creatureId)
+  const maxHp = variant === 'wounded' ? Math.max(1, Math.round(block.maxHp * 0.6)) : block.maxHp
+
+  return {
+    id: instanceId,
+    creatureId: block.id,
+    name: block.name,
+    tier: block.tier,
+    species: block.species,
+    behaviour: block.behaviour,
+    variant,
+    hp: maxHp,
+    maxHp,
+    armourClass: variant === 'ancient' ? block.armourClass + 2 : block.armourClass,
+    attributes: creatureAttributes(block.armourClass),
+    combatConditions: [],
+    isAlive: true,
+  }
+}
+
+// ─── Starting a fight ───────────────────────────────────────────────────────
+
+export interface StartCombatInput {
+  id: string
+  player: CombatPlayer
+  enemies: CombatEnemy[]
+  isHostileEnvironment?: boolean
+  hasLivingAlly?: boolean
+  /**
+   * Seats a side first instead of rolling for it. Set on an ambush, which canon
+   * defines as a fight the player never had the chance to defuse (§1) — the
+   * surprise is that they answer second, not that the attackers hit harder.
+   */
+  forcedInitiative?: InitiativeSide
+  rng?: () => number
+}
+
+/** Opens a fight: rolls the single initiative and seats both sides. */
+export function startCombat(input: StartCombatInput): CombatState {
+  const rng = input.rng ?? Math.random
+  const initiative =
+    input.forcedInitiative ?? rollInitiative(input.player.attributes, input.enemies, rng)
+
+  return {
+    id: input.id,
+    player: {
+      ...input.player,
+      combatConditions: derivePlayerConditions(input.player.combatConditions, input.enemies),
+    },
+    enemies: input.enemies,
+    initiative,
+    round: 1,
+    activeSide: initiative,
+    log: [],
+    outcome: null,
+    isHostileEnvironment: input.isHostileEnvironment ?? false,
+    hasLivingAlly: input.hasLivingAlly ?? false,
+  }
+}
+
+// ─── The player's turn (§3) ─────────────────────────────────────────────────
+
+/** Fleeing: DC 12 normally, DC 15 when engaged or surrounded. @see §7 */
+export const FLEE_DC = { normal: 12, engaged: 15 } as const
+
+/** Commanding an ally: DC 12 for a human, 14 for a beast or mercenary. @see §5 */
+export const COMMAND_DC = { human: 12, beast: 14 } as const
+
+/** Presence: CENDRE +2 or better makes basic enemies hesitate on round 1. @see §5 */
+export const PRESENCE_ASH_MODIFIER = 2
+
+/** Beating a target by this much is a « succès remarquable ». @see 08-DICE §4 */
+const REMARKABLE_MARGIN = 5
+
+/** Below this AC, an intimidated enemy breaks and runs instead of hesitating. @see §5 */
+const ROUT_ARMOUR_CLASS = 11
+
+/** Adds a combat condition without ever duplicating it. */
+function withCondition(
+  conditions: readonly CombatConditionId[],
+  id: CombatConditionId
+): CombatConditionId[] {
+  return conditions.includes(id) ? [...conditions] : [...conditions, id]
+}
+
+/**
+ * Whether Intimidation bites on this enemy. Canon draws the line by nature
+ * rather than by strength: archontic Watchers have no fear to work on, and a
+ * Calciné past its early stages has no reason left to reach.
+ * @see 10-COMBAT.md §5
+ */
+function canBeIntimidated(enemy: CombatEnemy): boolean {
+  if (enemy.species === 'archontic') return false
+  if (enemy.species === 'calcined') {
+    return enemy.creatureId === 'calcined_nascent' || enemy.creatureId === 'calcined_common'
+  }
+  return enemy.tier !== 'legendary'
+}
+
+/**
+ * The enemies Présence works on: canon names crawling Calcinés, brigands and
+ * animals — the basic ranks, never the rares and above.
+ * @see 10-COMBAT.md §5
+ */
+function isBasicEnemy(enemy: CombatEnemy): boolean {
+  return enemy.tier === 'common' || enemy.creatureId === 'calcined_nascent'
+}
+
+/**
+ * Présence, passive: a player at CENDRE +2 or better makes the basic ranks
+ * hesitate, so their *first* attack of the fight is taken at disadvantage.
+ * Applied once, at the opening — hence the round check.
+ * @see 10-COMBAT.md §5
+ */
+function hasPresenceOver(state: CombatState, enemy: CombatEnemy): boolean {
+  return (
+    state.round === 1 &&
+    attributeModifier(state.player.attributes.ash) >= PRESENCE_ASH_MODIFIER &&
+    isBasicEnemy(enemy)
+  )
+}
+
+/** The player's bare-handed / default weapon die when none is supplied. */
+const DEFAULT_WEAPON: DamageDice = { count: 1, faces: 6, bonus: 0 }
+
+export interface PlayerTurnInput {
+  state: CombatState
+  action: CombatAction
+  /** Which enemy is targeted. Defaults to the first living one. */
+  targetId?: string
+  /** The weapon die for an attack. Defaults to a d6. */
+  weapon?: DamageDice
+  /** Which way the player runs. Required for `flee`. */
+  fleeDirection?: FleeDirection
+  /** HP restored by `use_item`, already decided by the inventory rules. */
+  itemHealing?: number
+  /**
+   * Turns `command` into Commandement rather than Intimidation: the player
+   * shouts an order at their own ally instead of at the enemy. Canon splits the
+   * DC by what the ally *is* — a person takes an order at 12, a beast or a paid
+   * mercenary at 14.
+   * @see 10-COMBAT.md §5
+   */
+  allyKind?: keyof typeof COMMAND_DC
+  rng?: () => number
+}
+
+export interface PlayerTurnResult {
+  state: CombatState
+  entry: CombatLogEntry
+}
+
+/** Whether the player currently has an enemy in contact. */
+function isEngaged(state: CombatState): boolean {
+  return state.player.combatConditions.includes('engaged')
+}
+
+/** The enemy an action applies to. */
+function pickTarget(state: CombatState, targetId?: string): CombatEnemy | undefined {
+  const living = state.enemies.filter((enemy) => enemy.isAlive)
+  return targetId ? living.find((enemy) => enemy.id === targetId) : living[0]
+}
+
+/** Applies damage to one enemy, marking it dead at 0. */
+function damageEnemy(enemies: CombatEnemy[], targetId: string, amount: number): CombatEnemy[] {
+  return enemies.map((enemy) => {
+    if (enemy.id !== targetId) return enemy
+    const hp = Math.max(0, enemy.hp - amount)
+    return { ...enemy, hp, isAlive: hp > 0 }
+  })
+}
+
+/**
+ * Resolves one player action and returns the new state plus the log entry the
+ * AI will narrate. The entry carries the die and the damage precisely so the
+ * prose can describe them without the model ever choosing them.
+ *
+ * @see 10-COMBAT.md §3, §5, §7
+ */
+export function resolvePlayerTurn(input: PlayerTurnInput): PlayerTurnResult {
+  const rng = input.rng ?? Math.random
+  const state = input.state
+  const base: Pick<CombatLogEntry, 'round' | 'actor' | 'action'> = {
+    round: state.round,
+    actor: 'player',
+    action: input.action,
+  }
+
+  switch (input.action) {
+    case 'attack': {
+      const target = pickTarget(state, input.targetId)
+      if (!target) {
+        return { state, entry: { ...base, narrative: '' } }
+      }
+
+      // Melee is SANG, per §3. Disadvantage while frightened or dazed (§6).
+      const hindered =
+        state.player.combatConditions.includes('frightened') ||
+        state.player.combatConditions.includes('dazed')
+      const roll = rollAgainst(
+        state.player.attributes,
+        'blood',
+        target.armourClass,
+        rng,
+        hindered ? 'disadvantage' : 'normal'
+      )
+
+      if (!roll.success) {
+        // Nat 1 knocks the weapon loose (§6, Désarmé).
+        const conditions: CombatConditionId[] =
+          roll.critical === 'failure' && !state.player.combatConditions.includes('disarmed')
+            ? [...state.player.combatConditions, 'disarmed']
+            : state.player.combatConditions
+        return {
+          state: { ...state, player: { ...state.player, combatConditions: conditions } },
+          entry: { ...base, targetId: target.id, roll: roll.roll, hit: false, narrative: '' },
+        }
+      }
+
+      const weapon = input.weapon ?? DEFAULT_WEAPON
+      const rolled = rollDamage(weapon, rng) + attributeModifier(state.player.attributes.blood)
+      // A critical doubles the dice, per the d20 convention the engine already
+      // uses for nat 20 elsewhere.
+      const damage = roll.critical === 'success' ? rolled * 2 : rolled
+      const enemies = damageEnemy(state.enemies, target.id, damage)
+
+      return {
+        state: {
+          ...state,
+          enemies,
+          player: {
+            ...state.player,
+            combatConditions: derivePlayerConditions(state.player.combatConditions, enemies),
+          },
+        },
+        entry: { ...base, targetId: target.id, roll: roll.roll, hit: true, damage, narrative: '' },
+      }
+    }
+
+    case 'defend': {
+      // Canon offers a light bandage heal when the player steps back (§3).
+      const healed = Math.min(
+        state.player.maxHp - state.player.hp,
+        rollDamage({ count: 1, faces: 4, bonus: 0 }, rng)
+      )
+      return {
+        state: { ...state, player: { ...state.player, hp: state.player.hp + healed } },
+        entry: { ...base, healing: healed, narrative: '' },
+      }
+    }
+
+    case 'command': {
+      // Commandement (§5): the order goes to the player's own ally, against a
+      // fixed DC. Only reachable when an ally is actually standing there —
+      // otherwise the shout has nobody to obey it.
+      if (input.allyKind) {
+        if (!state.hasLivingAlly) {
+          return { state, entry: { ...base, narrative: '' } }
+        }
+        const roll = rollAgainst(state.player.attributes, 'ash', COMMAND_DC[input.allyKind], rng)
+        // The ally acting immediately is the session's business, not the
+        // engine's: combat records that the order landed and hands it over.
+        return { state, entry: { ...base, roll: roll.roll, hit: roll.success, narrative: '' } }
+      }
+
+      // Intimidation: CENDRE against the target's CENDRE (§5). A success makes
+      // one enemy hesitate; a remarkable one reaches two.
+      const target = pickTarget(state, input.targetId)
+      if (!target) {
+        return { state, entry: { ...base, narrative: '' } }
+      }
+
+      // The opposed roll is an active d20 on the enemy's side, not a fixed DC.
+      const opposed = rollD20(rng) + attributeModifier(target.attributes.ash)
+      const roll = rollAgainst(state.player.attributes, 'ash', opposed, rng)
+
+      if (!roll.success) {
+        // Critical failure galvanises the camp: every enemy attacks with
+        // advantage next turn, carried as `galvanised` on the instances.
+        const enemies =
+          roll.critical === 'failure'
+            ? state.enemies.map((enemy) =>
+                enemy.isAlive
+                  ? { ...enemy, combatConditions: withCondition(enemy.combatConditions, 'engaged') }
+                  : enemy
+              )
+            : state.enemies
+        return {
+          state: { ...state, enemies, galvanised: roll.critical === 'failure' },
+          entry: { ...base, targetId: target.id, roll: roll.roll, hit: false, narrative: '' },
+        }
+      }
+
+      // Remarkable success — beating the opposed roll by 5 or more — reaches a
+      // second enemy, per canon.
+      const reach = roll.total - opposed >= REMARKABLE_MARGIN ? 2 : 1
+      const affected = state.enemies
+        .filter((enemy) => enemy.isAlive && canBeIntimidated(enemy))
+        .slice(0, reach)
+        .map((enemy) => enemy.id)
+
+      // Canon: a shaken enemy whose AC is under 11 does not merely hesitate, it
+      // breaks and runs — it leaves the fight for good.
+      const enemies = state.enemies.map((enemy) => {
+        if (!affected.includes(enemy.id)) return enemy
+        return enemy.armourClass < ROUT_ARMOUR_CLASS
+          ? // Routed, not killed: it leaves the fight on its own legs, so it
+            // leaves no corpse to loot either (§9 pays for the dead).
+            { ...enemy, isAlive: false, hasRouted: true }
+          : { ...enemy, combatConditions: withCondition(enemy.combatConditions, 'frightened') }
+      })
+
+      return {
+        state: {
+          ...state,
+          enemies,
+          player: {
+            ...state.player,
+            combatConditions: derivePlayerConditions(state.player.combatConditions, enemies),
+          },
+        },
+        entry: {
+          ...base,
+          targetId: target.id,
+          roll: roll.roll,
+          hit: affected.length > 0,
+          narrative: '',
+        },
+      }
+    }
+
+    case 'awaken_artefact': {
+      const target = pickTarget(state, input.targetId)
+      if (!target) {
+        return { state, entry: { ...base, narrative: '' } }
+      }
+      // Base artefact power: a flat 1d8, no roll to hit (§3).
+      const damage = rollDamage({ count: 1, faces: 8, bonus: 0 }, rng)
+      const enemies = damageEnemy(state.enemies, target.id, damage)
+      return {
+        state: {
+          ...state,
+          enemies,
+          player: {
+            ...state.player,
+            combatConditions: derivePlayerConditions(state.player.combatConditions, enemies),
+          },
+        },
+        entry: { ...base, targetId: target.id, hit: true, damage, narrative: '' },
+      }
+    }
+
+    case 'use_item': {
+      const healed = Math.min(state.player.maxHp - state.player.hp, input.itemHealing ?? 0)
+      return {
+        state: { ...state, player: { ...state.player, hp: state.player.hp + healed } },
+        entry: { ...base, healing: healed, narrative: '' },
+      }
+    }
+
+    case 'flee': {
+      const dc = isEngaged(state) ? FLEE_DC.engaged : FLEE_DC.normal
+      const roll = rollAgainst(state.player.attributes, 'breath', dc, rng)
+
+      if (roll.success) {
+        // Canon leaves the choice of direction to the player and makes both
+        // real: forward keeps the contract alive, backward begins the return.
+        // Defaulting to `backward` is the safe reading of an unspecified escape.
+        return {
+          state: {
+            ...state,
+            outcome: 'fled',
+            fleeDirection: input.fleeDirection ?? 'backward',
+          },
+          entry: { ...base, roll: roll.roll, hit: true, narrative: '' },
+        }
+      }
+
+      // Failure costs a free enemy hit; a critical failure also trips the
+      // player, so the next action is taken at disadvantage (§7).
+      const attacker = state.enemies.find((enemy) => enemy.isAlive)
+      const block = attacker ? getCreature(attacker.creatureId) : null
+      const damage = block?.damage ? rollDamage(block.damage, rng) : 0
+      const hp = Math.max(0, state.player.hp - damage)
+      const conditions: CombatConditionId[] =
+        roll.critical === 'failure' && !state.player.combatConditions.includes('dazed')
+          ? [...state.player.combatConditions, 'dazed']
+          : state.player.combatConditions
+
+      return {
+        state: { ...state, player: { ...state.player, hp, combatConditions: conditions } },
+        entry: { ...base, roll: roll.roll, hit: false, damage, narrative: '' },
+      }
+    }
+  }
+}
+
+// ─── The enemy block (§2, §6) ───────────────────────────────────────────────
+
+export interface EnemyTurnInput {
+  state: CombatState
+  /**
+   * The player's survival sheet. Passed in rather than mirrored on
+   * `CombatPlayer` because the dying reprieve is a single universal contract
+   * (`06-SURVIVAL §7`) — combat must not keep a second copy of it that could
+   * drift from poison or neglect.
+   */
+  survival: SurvivalStats
+  rng?: () => number
+}
+
+export interface EnemyTurnResult {
+  state: CombatState
+  survival: SurvivalStats
+  entries: CombatLogEntry[]
+  /** True when this turn was the second 0-HP hit — the run is over. */
+  definitiveDeath: boolean
+}
+
+/**
+ * Resolves the whole enemy camp in one block, as canon requires: enemies do not
+ * take individual initiatives, they act together after (or before) the player.
+ *
+ * Damage lands on `SurvivalStats` through `resolveDying`, so a fight cannot
+ * invent its own death path: the first drop to 0 pins HP at 0 and telegraphs
+ * one turn of reprieve, exactly as poison and neglect do.
+ *
+ * @see 10-COMBAT.md §2, §6, §8
+ * @see 06-SURVIVAL.md §7
+ */
+export function resolveEnemyTurn(input: EnemyTurnInput): EnemyTurnResult {
+  const rng = input.rng ?? Math.random
+  const state = input.state
+  const entries: CombatLogEntry[] = []
+
+  let hp = input.survival.hp
+  let playerConditions = [...state.player.combatConditions]
+  const enemies = [...state.enemies]
+
+  // Enemies attack with advantage while the player is surrounded (§6, Encerclé).
+  const flanked = playerConditions.includes('flanked')
+
+  for (let index = 0; index < enemies.length; index++) {
+    const enemy = enemies[index]
+    if (!enemy.isAlive) continue
+
+    // An intimidated enemy recoils and skips this turn, then shakes it off (§5).
+    if (enemy.combatConditions.includes('frightened')) {
+      enemies[index] = {
+        ...enemy,
+        combatConditions: enemy.combatConditions.filter((id) => id !== 'frightened'),
+      }
+      continue
+    }
+
+    const block = getCreature(enemy.creatureId)
+    // A hazard is not fought and deals no attack — it is escaped (§4).
+    if (block.engagement === 'hazard' || !block.damage) continue
+
+    // Two modifiers pull in opposite directions and can cancel: the player is
+    // surrounded (§6) but also carries enough CENDRE to make the basic ranks
+    // hesitate on the opening exchange (§5).
+    const advantage = flanked || state.galvanised === true
+    const disadvantage = hasPresenceOver(state, enemy)
+    const mode = advantage === disadvantage ? 'normal' : advantage ? 'advantage' : 'disadvantage'
+
+    const roll = rollAgainst(enemy.attributes, 'blood', state.player.armourClass, rng, mode)
+
+    if (!roll.success) {
+      entries.push({
+        round: state.round,
+        actor: 'enemy',
+        action: 'attack',
+        targetId: enemy.id,
+        roll: roll.roll,
+        hit: false,
+        narrative: '',
+      })
+      continue
+    }
+
+    const rolled = rollDamage(block.damage, rng)
+    const damage = roll.critical === 'success' ? rolled * 2 : rolled
+    hp = Math.max(0, hp - damage)
+
+    // A natural 20 in melee rings the player's head (§6, Sonné).
+    if (roll.critical === 'success' && !playerConditions.includes('dazed')) {
+      playerConditions = [...playerConditions, 'dazed']
+    }
+
+    entries.push({
+      round: state.round,
+      actor: 'enemy',
+      action: 'attack',
+      targetId: enemy.id,
+      roll: roll.roll,
+      hit: true,
+      damage,
+      narrative: '',
+    })
+
+    if (hp === 0) break
+  }
+
+  const dying = resolveDying({ ...input.survival, hp })
+  const player: CombatPlayer = {
+    ...state.player,
+    hp: dying.survival.hp,
+    combatConditions: derivePlayerConditions(playerConditions, enemies),
+  }
+
+  // Only a *definitive* death opens the table. The first drop buys the reprieve
+  // canon promises, and the player still gets a turn to spend it.
+  const knockoutVerdict = dying.definitiveDeath
+    ? resolveKnockout({
+        hasLivingAlly: state.hasLivingAlly,
+        survivingEnemies: enemies,
+        isHostileEnvironment: state.isHostileEnvironment,
+      })
+    : undefined
+
+  return {
+    state: {
+      ...state,
+      player,
+      enemies,
+      log: [...state.log, ...entries],
+      // Galvanisation buys the enemies exactly the one turn canon grants them.
+      galvanised: false,
+      ...(knockoutVerdict ? { outcome: 'defeat' as const, knockoutVerdict } : {}),
+    },
+    survival: dying.survival,
+    entries,
+    definitiveDeath: dying.definitiveDeath,
+  }
+}
+
+// ─── Ending a fight (§9) ────────────────────────────────────────────────────
+
+/**
+ * Iron looted from a corpse, per enemy. Canon prints the two ends of the scale
+ * outright — 1-10 for a brigand, 20-50 for an Inquisitor — and the tiers in
+ * between are interpolated on that line rather than invented from nothing.
+ * @see 10-COMBAT.md §9
+ */
+const IRON_BY_TIER: Record<CreatureTier, { min: number; max: number }> = {
+  common: { min: 1, max: 10 },
+  calcined: { min: 5, max: 20 },
+  rare: { min: 20, max: 50 },
+  legendary: { min: 50, max: 120 },
+}
+
+/** Rolls the iron one corpse yields. */
+function rollIron(tier: CreatureTier, rng: () => number): number {
+  const { min, max } = IRON_BY_TIER[tier]
+  return min + Math.floor(rng() * (max - min + 1))
+}
+
+/**
+ * Whether the fight has reached an end, and which one. Returns `null` while it
+ * is still running so the caller can keep taking turns.
+ */
+export function checkCombatEnd(state: CombatState): CombatOutcome | null {
+  if (state.outcome) return state.outcome
+  if (state.enemies.every((enemy) => !enemy.isAlive)) return 'victory'
+  return null
+}
+
+export interface EndCombatInput {
+  state: CombatState
+  /** Overrides the direction recorded on the state, if the run needs to. */
+  fleeDirection?: FleeDirection
+  rng?: () => number
+}
+
+/**
+ * Settles a finished fight into its payoff.
+ *
+ * Canon is explicit that there is no XP bar and no level: the reward for
+ * winning is iron off the corpses, the equipment the enemy was carrying, and
+ * the story moving. Defeat and flight pay nothing — but neither of them is
+ * automatically the end of the run, which is what `knockoutVerdict` carries.
+ *
+ * @see 10-COMBAT.md §9
+ */
+export function endCombat(input: EndCombatInput): CombatResult {
+  const rng = input.rng ?? Math.random
+  const state = input.state
+  const outcome = checkCombatEnd(state) ?? 'victory'
+
+  if (outcome !== 'victory') {
+    const fleeDirection = input.fleeDirection ?? state.fleeDirection
+    return {
+      outcome,
+      loot: [],
+      ironGained: 0,
+      ...(fleeDirection ? { fleeDirection } : {}),
+      ...(state.knockoutVerdict ? { knockoutVerdict: state.knockoutVerdict } : {}),
+    }
+  }
+
+  const loot: CombatLoot[] = []
+  let ironGained = 0
+
+  for (const enemy of state.enemies) {
+    // Only the dead are looted. An enemy that ran took its gear with it.
+    if (enemy.hasRouted) continue
+    ironGained += rollIron(enemy.tier, rng)
+
+    // Loot quality is the enemy's own quality — canon states it plainly, which
+    // is what makes a hard fight worth picking.
+    for (const tier of getCreature(enemy.creatureId).loot) {
+      loot.push({
+        itemId: `${enemy.creatureId}_${tier}`,
+        itemName: `${enemy.name} — ${tier}`,
+        tier,
+        quantity: 1,
+      })
+    }
+  }
+
+  return { outcome, loot, ironGained }
+}
+
+// ─── Projection to the client (§3) ──────────────────────────────────────────
+
+/**
+ * Projects the fight for the interface. Everything the combat screen draws is
+ * decided here; the client recomputes no AC, no damage and no end condition.
+ *
+ * `canFlee` is unconditionally true because canon says fleeing is always an
+ * option — a fight the player cannot walk away from is a punishment, not a
+ * choice. The cost of running lives in the DC, never in hiding the button.
+ *
+ * @see 10-COMBAT.md §3, §7
+ */
+export function projectCombat(state: CombatState, result?: CombatResult): CombatSnapshot {
+  return {
+    player: state.player,
+    enemies: state.enemies,
+    initiative: state.initiative,
+    round: state.round,
+    activeSide: state.activeSide,
+    log: state.log,
+    canFlee: true,
+    ...(result ? { result } : {}),
+  }
+}
+
+/** Hands the turn to the other side, advancing the round after the enemy block. */
+export function advanceTurn(state: CombatState): CombatState {
+  if (state.activeSide === 'player') {
+    return { ...state, activeSide: 'enemy' }
+  }
+  return { ...state, activeSide: 'player', round: state.round + 1 }
+}

--- a/apps/backend/src/game-rules/consequences.ts
+++ b/apps/backend/src/game-rules/consequences.ts
@@ -5,15 +5,7 @@ import {
   tickConditions,
 } from './conditions'
 import { rollCheck } from './dice'
-import {
-  applyNeglectErosion,
-  applyTurnDrain,
-  clearDyingOnHeal,
-  NEGLECT_STREAK_THRESHOLD,
-  resolveDying,
-  rollNeglectCalamine,
-  tickNeglectStreak,
-} from './survival'
+import { applyTurnUpkeep, clearDyingOnHeal, resolveDying } from './survival'
 
 import type {
   ActiveCondition,
@@ -117,23 +109,10 @@ export function resolveChoice({
 }: ResolveChoiceInput): ResolveChoiceResult {
   const risk: Difficulty = choice.riskLevel ?? 'safe'
 
-  const drained = applyTurnDrain(survival)
-  // -1 PV/turn while thirst or hunger sits at 0 (non-cumulative between the
-  // two), plus the consecutive-neglect counter that feeds the Calamine
-  // source below. #201.
-  const eroded = applyNeglectErosion(drained)
-  const neglectTracked = tickNeglectStreak(eroded)
-  const neglectCalamineDelta =
-    neglectTracked.neglectStreak >= NEGLECT_STREAK_THRESHOLD
-      ? rollNeglectCalamine(neglectTracked.neglectStreak, rng)
-      : 0
-  const withNeglectCalamine: SurvivalStats =
-    neglectCalamineDelta > 0
-      ? {
-          ...neglectTracked,
-          calamine: clamp(neglectTracked.calamine + neglectCalamineDelta, 0, 100),
-        }
-      : neglectTracked
+  // Drain, -1 PV/turn while thirst or hunger sits at 0 (non-cumulative between
+  // the two), the consecutive-neglect counter and the Calamine it corrodes.
+  // Shared with the combat path so a turn costs the same either way. #201, #235.
+  const { survival: withNeglectCalamine, neglectCalamineDelta } = applyTurnUpkeep(survival, rng)
 
   const consequences: ChoiceConsequence = {
     survivalChanges: {

--- a/apps/backend/src/game-rules/survival.ts
+++ b/apps/backend/src/game-rules/survival.ts
@@ -98,6 +98,44 @@ export function rollNeglectCalamine(
   return min + Math.floor(rng() * (max - min + 1))
 }
 
+export interface TurnUpkeepResult {
+  survival: SurvivalStats
+  /** Calamine added by prolonged neglect this turn, 0 when the streak is short. */
+  neglectCalamineDelta: number
+}
+
+/**
+ * The full per-turn survival upkeep: drain, neglect erosion, streak, and the
+ * Calamine that prolonged neglect corrodes.
+ *
+ * Extracted so that *every* kind of turn pays it, not just the exploration one.
+ * Canon says "-1 PV par tour" and "+3 à +5 Calamine par tour" without carving
+ * out an exception for fighting (§4, §59) — and a turn spent trading blows is
+ * still a turn. Leaving combat outside this cycle would have made starving free
+ * as long as the player kept swinging, which is the opposite of the pressure
+ * survival is meant to apply.
+ *
+ * Pure given `rng`, like every other rule in this folder.
+ * @see docs/public/raw/06-SURVIVAL.md §4
+ */
+export function applyTurnUpkeep(
+  stats: SurvivalStats,
+  rng: () => number = Math.random
+): TurnUpkeepResult {
+  const drained = applyTurnDrain(stats)
+  const eroded = applyNeglectErosion(drained)
+  const tracked = tickNeglectStreak(eroded)
+  const neglectCalamineDelta = rollNeglectCalamine(tracked.neglectStreak, rng)
+
+  return {
+    survival:
+      neglectCalamineDelta > 0
+        ? { ...tracked, calamine: clamp(tracked.calamine + neglectCalamineDelta, 0, 100) }
+        : tracked,
+    neglectCalamineDelta,
+  }
+}
+
 export interface DyingResolution {
   survival: SurvivalStats
   /** True once this hit is the SECOND consecutive 0-HP event — definitive death. */

--- a/apps/backend/src/routes/game-action.schema.ts
+++ b/apps/backend/src/routes/game-action.schema.ts
@@ -31,6 +31,26 @@ export const gameActionSchema = z.object({
    * @see docs/public/raw/23-RUN-STRUCTURE.md §4
    */
   engageReturn: z.boolean().optional(),
+  /**
+   * The tactical action, when this turn is spent in a fight (#235). Only ever a
+   * *declaration of intent*: which of the six canon actions the player pressed.
+   * Every die, DC and consequence behind it is rolled by the backend, so a
+   * forged request can pick a different action but never a better outcome.
+   *
+   * Ignored outside combat, and optional inside it — a turn taken in prose
+   * carries no `combatAction` at all and is translated server-side instead.
+   * @see docs/public/raw/10-COMBAT.md §3
+   */
+  combatAction: z
+    .enum(['attack', 'defend', 'flee', 'command', 'use_item', 'awaken_artefact'])
+    .optional(),
+  /** Which enemy the action is aimed at. The engine falls back to the first one standing. */
+  targetId: z.string().min(1).max(64).optional(),
+  /**
+   * Which way the player runs when fleeing. Backward engages the return trip;
+   * forward escapes the fight but carries on with the quest (10-COMBAT §7).
+   */
+  fleeDirection: z.enum(['forward', 'backward']).optional(),
 })
 
 export type GameActionRequest = z.infer<typeof gameActionSchema>

--- a/apps/backend/src/routes/game.routes.ts
+++ b/apps/backend/src/routes/game.routes.ts
@@ -1,6 +1,7 @@
 import { type Request, type Response, Router } from 'express'
 
 import { prisma } from '../lib/prisma'
+import { COMBAT_STAKES, readCombatState } from '../services/combat.service'
 import {
   abandonSession,
   buildOpeningScene,
@@ -75,7 +76,16 @@ gameRouter.post('/action', async (req: Request, res: Response<ApiResponse<SceneR
     return
   }
 
-  const { sessionId, choiceId, chosenActionText, freeAction, engageReturn } = parsed.data
+  const {
+    sessionId,
+    choiceId,
+    chosenActionText,
+    freeAction,
+    engageReturn,
+    combatAction,
+    targetId,
+    fleeDirection,
+  } = parsed.data
   const userId = req.auth!.userId
 
   // Scope the session to the caller — a user can only act on their own session.
@@ -92,9 +102,21 @@ gameRouter.post('/action', async (req: Request, res: Response<ApiResponse<SceneR
     return
   }
 
+  // A turn spent in a fight takes its stakes from the fight itself, not from the
+  // choices of the scene that opened it: those choices no longer exist, so
+  // validating against them would reject every legitimate tactical action. The
+  // combat engine owns the dice from here — see resolveTurn's combat branch.
+  const inCombat = readCombatState(session) !== null
+
   // Resolve the risk from the persisted scene, never from the client. An unknown
   // choiceId is rejected outright — it must not silently degrade to a safe turn.
-  const choice = await resolveChosenChoice(sessionId, choiceId, chosenActionText, freeAction)
+  const choice = inCombat
+    ? {
+        id: choiceId ?? 'combat-action',
+        text: chosenActionText ?? freeAction ?? '',
+        ...COMBAT_STAKES,
+      }
+    : await resolveChosenChoice(sessionId, choiceId, chosenActionText, freeAction)
   if (choice === INVALID_CHOICE) {
     res.status(400).json({ success: false, error: 'Choice does not belong to the current scene' })
     return
@@ -107,6 +129,9 @@ gameRouter.post('/action', async (req: Request, res: Response<ApiResponse<SceneR
     chosenActionText,
     freeAction,
     engageReturn,
+    combatAction,
+    targetId,
+    fleeDirection,
   })
 
   res.json({ success: true, data: response })

--- a/apps/backend/src/services/combat.service.test.ts
+++ b/apps/backend/src/services/combat.service.test.ts
@@ -1,0 +1,418 @@
+import { describe, expect, it } from 'vitest'
+
+import { instantiateEnemy } from '../game-rules/combat'
+import { Prisma } from '../generated/prisma/client'
+
+import {
+  openCombatFromEncounter,
+  readCombatState,
+  resolveCombatTurn,
+  projectCombatState,
+  toCombatStatePersistence,
+  translateFreeAction,
+} from './combat.service'
+
+import type { AiCombatEncounter } from '../ai/scene-validator'
+import type { GameSession } from '../generated/prisma/client'
+import type {
+  ActiveCondition,
+  CombatPlayer,
+  CombatState,
+  RunState,
+  SurvivalStats,
+} from '@grimoire/shared'
+
+function makePlayer(overrides: Partial<CombatPlayer> = {}): CombatPlayer {
+  return {
+    hp: 11,
+    maxHp: 11,
+    armourClass: 11,
+    attributes: { blood: 14, breath: 12, ash: 10 },
+    conditions: [],
+    combatConditions: [],
+    ...overrides,
+  }
+}
+
+function makeSurvival(overrides: Partial<SurvivalStats> = {}): SurvivalStats {
+  return {
+    hp: 11,
+    maxHp: 11,
+    thirst: 80,
+    hunger: 80,
+    energy: 80,
+    calamine: 0,
+    isDying: false,
+    neglectStreak: 0,
+    ...overrides,
+  }
+}
+
+function makeState(overrides: Partial<CombatState> = {}): CombatState {
+  return {
+    id: 'fight-1',
+    player: makePlayer(),
+    enemies: [instantiateEnemy('brigand', 'e1')],
+    initiative: 'player',
+    round: 1,
+    activeSide: 'player',
+    log: [],
+    outcome: null,
+    isHostileEnvironment: false,
+    hasLivingAlly: false,
+    ...overrides,
+  }
+}
+
+/**
+ * The state as the column actually holds it — a plain JSON object, which is
+ * what the tests below then corrupt on purpose.
+ */
+function storedBlob(state: CombatState): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(state)) as Record<string, unknown>
+}
+
+/** A session row carrying only what the combat service reads. */
+function makeSession(combatState: unknown): GameSession {
+  return { combatState } as unknown as GameSession
+}
+
+describe('reading a persisted fight', () => {
+  it('reads null when no fight is in progress', () => {
+    expect(readCombatState(makeSession(null))).toBeNull()
+  })
+
+  // The DoD's "resume the session exactly": a reload must not reroll a die.
+  it('restores a fight byte for byte, mid-round', () => {
+    const wounded = { ...instantiateEnemy('soldier', 'e1'), hp: 3 }
+    const stored = makeState({
+      enemies: [wounded, instantiateEnemy('brigand', 'e2')],
+      round: 4,
+      activeSide: 'enemy',
+      initiative: 'enemy',
+      player: makePlayer({ hp: 5, combatConditions: ['engaged', 'flanked'] }),
+      galvanised: true,
+    })
+
+    // Round-trip through JSON, which is what the column actually stores.
+    const restored = readCombatState(makeSession(storedBlob(stored)))
+    expect(restored).toEqual(stored)
+  })
+
+  // A fight we cannot trust must not resume as a corrupted one.
+  it('refuses a blob whose shape does not match the contract', () => {
+    expect(readCombatState(makeSession({ id: 'fight-1', round: 2 }))).toBeNull()
+  })
+
+  // A field the schema forgot must fail loudly rather than be stripped on the
+  // way in: a silent drop is how a resumed fight loses data nobody notices.
+  it('refuses a blob carrying a field the schema does not declare', () => {
+    const extra = storedBlob(makeState())
+    ;(extra.enemies as Record<string, unknown>[])[0].unknownField = 'x'
+    expect(readCombatState(makeSession(extra))).toBeNull()
+  })
+
+  it('refuses a blob with a negative HP pool', () => {
+    const broken = storedBlob(makeState())
+    ;(broken.player as Record<string, unknown>).hp = -4
+    expect(readCombatState(makeSession(broken))).toBeNull()
+  })
+})
+
+describe('writing a fight back', () => {
+  it('stores the state and switches the session into combat mode', () => {
+    const persisted = toCombatStatePersistence(makeState())
+    expect(persisted.gameMode).toBe('combat')
+    expect(persisted.combatState).not.toBeNull()
+  })
+
+  // Leaving a finished fight in the column would let a reload pay the same
+  // victory twice.
+  it('clears the column once the fight is decided', () => {
+    const persisted = toCombatStatePersistence(makeState({ outcome: 'victory' }))
+    // Prisma.DbNull, not null: on a nullable Json column a plain `null` means
+    // "leave the column untouched", which would keep the finished fight in the
+    // row and let a reload pay it out again.
+    expect(persisted.combatState).toBe(Prisma.DbNull)
+    expect(persisted.gameMode).toBe('exploration')
+  })
+
+  it('leaves exploration mode when there is no fight at all', () => {
+    expect(toCombatStatePersistence(null)).toEqual({
+      gameMode: 'exploration',
+      combatState: Prisma.DbNull,
+    })
+  })
+})
+
+describe('translating a free-form action (#238 inside a fight)', () => {
+  // Prose must never be the cheap way out: anything unrecognised costs a turn
+  // and can be answered in blood.
+  it('falls back to attacking rather than to anything free', () => {
+    expect(translateFreeAction('je fais quelque chose de bizarre').action).toBe('attack')
+  })
+
+  it.each([
+    ['je pare le coup avec mon bouclier', 'defend'],
+    ["j'intimide le brigand en hurlant", 'command'],
+    ["j'éveille mon artefact", 'awaken_artefact'],
+    ['je bois une potion', 'use_item'],
+    ['je frappe le soldat', 'attack'],
+  ])('reads %s as %s', (text, expected) => {
+    expect(translateFreeAction(text).action).toBe(expected)
+  })
+
+  it('reads flight and the direction it runs in', () => {
+    expect(translateFreeAction('je fuis vers le fond du couloir')).toEqual({
+      action: 'flee',
+      fleeDirection: 'forward',
+    })
+    expect(translateFreeAction('je fuis en arrière vers la sortie')).toEqual({
+      action: 'flee',
+      fleeDirection: 'backward',
+    })
+  })
+
+  it('treats a demi-tour as beginning the climb home', () => {
+    expect(translateFreeAction('je fuis, demi-tour').fleeDirection).toBe('backward')
+  })
+})
+
+describe('resolving a full exchange', () => {
+  it('lets the enemy camp answer after the player acts', () => {
+    const output = resolveCombatTurn({
+      state: makeState(),
+      survival: makeSurvival(),
+      action: 'attack',
+      rng: () => 0.5,
+    })
+    const actors = output.state.log.map((entry) => entry.actor)
+    expect(actors).toContain('player')
+    expect(actors).toContain('enemy')
+  })
+
+  it('hands the turn back to the player and advances the round', () => {
+    const output = resolveCombatTurn({
+      state: makeState(),
+      survival: makeSurvival(),
+      action: 'attack',
+      rng: () => 0.5,
+    })
+    expect(output.state.activeSide).toBe('player')
+    expect(output.state.round).toBe(2)
+  })
+
+  // Canon has no posthumous round: a camp with nobody left cannot swing back.
+  it('skips the enemy answer when the player ends the fight', () => {
+    const frail = { ...instantiateEnemy('brigand', 'e1'), hp: 1 }
+    const output = resolveCombatTurn({
+      state: makeState({ enemies: [frail] }),
+      survival: makeSurvival(),
+      action: 'attack',
+      rng: () => 0.95,
+    })
+    expect(output.state.log.every((entry) => entry.actor === 'player')).toBe(true)
+    expect(output.result?.outcome).toBe('victory')
+  })
+
+  it('settles the fight and pays out on victory', () => {
+    const frail = { ...instantiateEnemy('brigand', 'e1'), hp: 1 }
+    const output = resolveCombatTurn({
+      state: makeState({ enemies: [frail] }),
+      survival: makeSurvival(),
+      action: 'attack',
+      rng: () => 0.95,
+    })
+    expect(output.result?.ironGained).toBeGreaterThan(0)
+    expect(toCombatStatePersistence(output.state).combatState).toBe(Prisma.DbNull)
+  })
+
+  it('returns no result while the fight is still running', () => {
+    const output = resolveCombatTurn({
+      state: makeState({ enemies: [instantiateEnemy('watcher', 'e1')] }),
+      survival: makeSurvival(),
+      action: 'attack',
+      rng: () => 0.1,
+    })
+    expect(output.result).toBeNull()
+    expect(output.state.outcome).toBeNull()
+  })
+
+  // The survival contract must cross the service boundary intact: combat may
+  // not invent a death path of its own.
+  it('reports a definitive death so the session can end on it', () => {
+    const output = resolveCombatTurn({
+      state: makeState({ player: makePlayer({ hp: 1 }) }),
+      survival: makeSurvival({ hp: 1, isDying: true }),
+      action: 'defend',
+      rng: () => 0.95,
+    })
+    expect(output.definitiveDeath).toBe(true)
+    expect(output.state.outcome).toBe('defeat')
+    expect(output.state.knockoutVerdict).toBeDefined()
+  })
+
+  it('carries the flight direction out to the run', () => {
+    const output = resolveCombatTurn({
+      state: makeState(),
+      survival: makeSurvival(),
+      action: 'flee',
+      fleeDirection: 'backward',
+      rng: () => 0.95,
+    })
+    expect(output.state.outcome).toBe('fled')
+    expect(output.result?.fleeDirection).toBe('backward')
+  })
+})
+
+describe('opening a fight from what the AI narrated (§1)', () => {
+  function makeRun(overrides: Partial<RunState> = {}): RunState {
+    return {
+      contract: {
+        id: 'ct1',
+        destination: 'Les Salines Basses',
+        objective: 'Rapporter le sceau du contremaître',
+        targetDepth: 5,
+        rewardIron: 40,
+      },
+      mode: 'descent',
+      currentDepth: 4,
+      maxDepthReached: 4,
+      currentRoomId: null,
+      returnEngaged: false,
+      objectiveSecured: false,
+      ...overrides,
+    } as unknown as RunState
+  }
+
+  function encounter(overrides: Partial<AiCombatEncounter> = {}): AiCombatEncounter {
+    return { creatureIds: ['brigand'], reason: 'they drew their blades', ...overrides }
+  }
+
+  function open(
+    input: Partial<Parameters<typeof openCombatFromEncounter>[0]> = {}
+  ): CombatState | null {
+    return openCombatFromEncounter({
+      encounter: encounter(),
+      run: makeRun(),
+      attributes: { blood: 14, breath: 12, ash: 10 },
+      survival: makeSurvival(),
+      conditions: [],
+      rng: () => 0.5,
+      ...input,
+    })
+  }
+
+  it('opens the fight the AI signalled, with the creatures it named', () => {
+    const state = open({ encounter: encounter({ creatureIds: ['brigand', 'brigand'] }) })
+    expect(state?.enemies.map((e) => e.creatureId)).toEqual(['brigand', 'brigand'])
+  })
+
+  // Every stat block value has to come from the bestiary: an encounter the AI
+  // could stat would be an encounter the AI could make unsurvivable.
+  it('takes HP and armour from the bestiary, never from the proposal', () => {
+    const [enemy] = open()!.enemies
+    const canon = instantiateEnemy('brigand', enemy.id)
+    expect(enemy.hp).toBe(canon.hp)
+    expect(enemy.armourClass).toBe(canon.armourClass)
+  })
+
+  it('gives each enemy its own id so a group can be targeted one by one', () => {
+    const state = open({ encounter: encounter({ creatureIds: ['brigand', 'brigand'] }) })
+    const [first, second] = state!.enemies
+    expect(first.id).not.toBe(second.id)
+  })
+
+  // The canon anti-rule of 03-BESTIARY §6bis, enforced here rather than trusted
+  // to the prompt: a legendary on floor 2 is the death nobody could see coming.
+  it('refuses a creature that does not belong on this floor', () => {
+    expect(open({ encounter: encounter({ creatureIds: ['watcher_king'] }) })).toBeNull()
+  })
+
+  it('drops the off-floor creatures and keeps the legitimate ones', () => {
+    const state = open({
+      encounter: encounter({ creatureIds: ['watcher_king', 'brigand'] }),
+    })
+    expect(state?.enemies.map((e) => e.creatureId)).toEqual(['brigand'])
+  })
+
+  it('refuses a creature the bestiary has never heard of', () => {
+    expect(open({ encounter: encounter({ creatureIds: ['dragon_of_salt'] }) })).toBeNull()
+  })
+
+  // The climb home draws on the fauna already crossed, not on the shallow band
+  // the player currently stands in — the way back is shorter, not gentler.
+  it('draws from the traversed fauna once the return is engaged', () => {
+    const run = makeRun({ returnEngaged: true, currentDepth: 1, maxDepthReached: 6 })
+    expect(
+      open({ run, encounter: encounter({ creatureIds: ['calcined_ancient'] }) })
+    ).not.toBeNull()
+  })
+
+  // 06-SURVIVAL §7: the reprieve at 0 HP is a turn to act in, not a turn to be
+  // killed in. Opening a fight there spends it on a death nobody can answer.
+  it('never opens a fight on a dying character', () => {
+    expect(open({ survival: makeSurvival({ hp: 0, isDying: true }) })).toBeNull()
+  })
+
+  it('seats the enemy camp first on an ambush', () => {
+    const state = open({ encounter: encounter({ ambush: true }) })
+    expect(state?.initiative).toBe('enemy')
+    expect(state?.activeSide).toBe('enemy')
+  })
+
+  // Without an ambush the initiative is rolled like any other: the fight the
+  // player saw coming does not hand the first blow away. Both sides draw from
+  // the same rng in order, so the dice have to be sequenced — a constant would
+  // roll the same die twice and only ever produce a tie.
+  it('rolls for initiative when the fight was not an ambush', () => {
+    const dice = (values: number[]) => {
+      let i = 0
+      return () => values[Math.min(i++, values.length - 1)]
+    }
+    // Player rolls first, enemy second.
+    expect(open({ rng: dice([0.95, 0]) })?.initiative).toBe('player')
+    expect(open({ rng: dice([0, 0.95]) })?.initiative).toBe('enemy')
+  })
+
+  it('carries the run conditions into the fight', () => {
+    const poisoned: ActiveCondition[] = [
+      { id: 'poison', source: 'ai', appliedAtTurn: 3, expiresRule: { type: 'until_cured' } },
+    ]
+    expect(open({ conditions: poisoned })?.player.conditions).toEqual(poisoned)
+  })
+
+  it('opens the fight on the HP the character actually has left', () => {
+    expect(open({ survival: makeSurvival({ hp: 4 }) })?.player.hp).toBe(4)
+  })
+
+  // A session with no run at all (still at the inn) falls back to the
+  // shallowest band, which is the conservative end rather than a free-for-all.
+  it('falls back to the shallowest band with no run underway', () => {
+    expect(open({ run: null, encounter: encounter({ creatureIds: ['brigand'] }) })).toBeNull()
+    expect(open({ run: null, encounter: encounter({ creatureIds: ['ruin_rat'] }) })).not.toBeNull()
+  })
+
+  // An opened fight is immediately persistable: anything else would mean a
+  // fight that exists in memory and vanishes on reload.
+  it('produces a state the persistence round-trip accepts', () => {
+    const state = open()!
+    const stored = toCombatStatePersistence(state)
+    expect(stored.gameMode).toBe('combat')
+    expect(readCombatState(makeSession(storedBlob(state)))).toEqual(state)
+  })
+})
+
+describe('projecting to the client', () => {
+  it('always offers the escape hatch', () => {
+    expect(projectCombatState(makeState()).canFlee).toBe(true)
+  })
+
+  it('projects the fight without asking the client to recompute a rule', () => {
+    const state = makeState({ round: 3, activeSide: 'enemy' })
+    const snapshot = projectCombatState(state)
+    expect(snapshot.round).toBe(3)
+    expect(snapshot.activeSide).toBe('enemy')
+    expect(snapshot.result).toBeUndefined()
+  })
+})

--- a/apps/backend/src/services/combat.service.ts
+++ b/apps/backend/src/services/combat.service.ts
@@ -1,0 +1,515 @@
+import { randomUUID } from 'node:crypto'
+
+import { z } from 'zod'
+
+import { creaturesForDepth, creaturesForReturn } from '../game-rules/bestiary'
+import {
+  advanceTurn,
+  checkCombatEnd,
+  endCombat,
+  instantiateEnemy,
+  projectCombat,
+  resolveEnemyTurn,
+  resolvePlayerTurn,
+  startCombat,
+} from '../game-rules/combat'
+import { Prisma } from '../generated/prisma/client'
+
+import type { AiCombatEncounter } from '../ai/scene-validator'
+import type { CombatPromptContext } from '../ai/system-prompt'
+import type { GameSession } from '../generated/prisma/client'
+import type {
+  ActiveCondition,
+  Attributes,
+  CombatAction,
+  CombatLogEntry,
+  CombatResult,
+  CombatSnapshot,
+  CombatState,
+  CreatureId,
+  Difficulty,
+  FleeDirection,
+  RunState,
+  SurvivalStats,
+} from '@grimoire/shared'
+
+/**
+ * Bridges the pure combat rules (`game-rules/combat.ts`) to the persisted
+ * session. No rule lives here: this module reads the `combatState` column into
+ * a `CombatState`, hands it to the engine, and writes the result back. Every
+ * die, every threshold and every verdict stays in `game-rules/`, which knows
+ * nothing about Prisma.
+ * @see docs/public/raw/10-COMBAT.md
+ */
+
+// ─── Persistence ────────────────────────────────────────────────────────────
+
+/**
+ * Validates the persisted combat blob on the way *in*.
+ *
+ * A stored fight is replayed by trusting it, so it is parsed exactly like AI
+ * output: a row hand-edited, half-written by an interrupted request, or left
+ * over from an older shape must fail loudly here rather than resume as a fight
+ * with a missing enemy or a negative HP pool.
+ *
+ * The schema is deliberately structural rather than exhaustive — it guarantees
+ * the engine receives the shape it declares, and the engine owns what the
+ * values may mean.
+ */
+const persistedEnemySchema = z.strictObject({
+  id: z.string(),
+  creatureId: z.string(),
+  name: z.string(),
+  species: z.enum(['human', 'beast', 'calcined', 'archontic']),
+  tier: z.enum(['common', 'calcined', 'rare', 'legendary']),
+  behaviour: z.enum([
+    'opportunistic',
+    'defensive',
+    'territorial',
+    'predatory',
+    'evental',
+    'tragic',
+  ]),
+  variant: z.enum(['hungry', 'pack', 'saturated', 'wounded', 'ancient']).nullable(),
+  hp: z.number().int().min(0),
+  maxHp: z.number().int().min(0),
+  armourClass: z.number().int(),
+  attributes: z.object({
+    blood: z.number().int(),
+    breath: z.number().int(),
+    ash: z.number().int(),
+  }),
+  combatConditions: z.array(z.enum(['engaged', 'flanked', 'disarmed', 'frightened', 'dazed'])),
+  isAlive: z.boolean(),
+  hasRouted: z.boolean().optional(),
+})
+
+const persistedCombatSchema = z.strictObject({
+  id: z.string(),
+  player: z.strictObject({
+    hp: z.number().int().min(0),
+    maxHp: z.number().int().min(1),
+    armourClass: z.number().int(),
+    attributes: z.object({
+      blood: z.number().int(),
+      breath: z.number().int(),
+      ash: z.number().int(),
+    }),
+    // Survival conditions cross into the fight as the full `ActiveCondition`
+    // records the character sheet carries, not as bare ids: the expiry rule and
+    // the turn they were applied on are what lets the run keep ageing them
+    // while the fight runs.
+    conditions: z.array(
+      z.strictObject({
+        id: z.string().min(1),
+        source: z.enum(['backend', 'ai']),
+        appliedAtTurn: z.number().int(),
+        expiresRule: z.union([
+          z.strictObject({ type: z.literal('until_cured') }),
+          z.strictObject({ type: z.literal('turns'), count: z.number().int() }),
+        ]),
+      })
+    ),
+    combatConditions: z.array(z.enum(['engaged', 'flanked', 'disarmed', 'frightened', 'dazed'])),
+  }),
+  enemies: z.array(persistedEnemySchema),
+  initiative: z.enum(['player', 'enemy']),
+  round: z.number().int().min(1),
+  activeSide: z.enum(['player', 'enemy']),
+  log: z.array(z.unknown()),
+  outcome: z.enum(['victory', 'defeat', 'fled']).nullable(),
+  fleeDirection: z.enum(['forward', 'backward']).optional(),
+  isHostileEnvironment: z.boolean(),
+  hasLivingAlly: z.boolean(),
+  knockoutVerdict: z.enum(['saved', 'captured', 'dead']).optional(),
+  galvanised: z.boolean().optional(),
+})
+
+/**
+ * Projects a session row into the `CombatState` the pure rules operate on.
+ * Returns null when no fight is in progress — that null is the single source of
+ * truth for "not in combat", never a `gameMode` string that could drift out of
+ * sync with the stored state.
+ *
+ * A blob that fails validation also reads as null: a fight we cannot trust is
+ * not resumed as a corrupted one.
+ */
+export function readCombatState(session: GameSession): CombatState | null {
+  if (session.combatState === null || session.combatState === undefined) return null
+
+  const parsed = persistedCombatSchema.safeParse(session.combatState)
+  if (!parsed.success) return null
+
+  return parsed.data as unknown as CombatState
+}
+
+/** The session columns a `CombatState` writes back to. */
+export interface CombatStatePersistence {
+  gameMode: string
+  combatState: Prisma.InputJsonValue | typeof Prisma.DbNull
+}
+
+/**
+ * Flattens a `CombatState` into the session columns it owns.
+ *
+ * A finished fight persists as SQL NULL rather than as a state carrying its
+ * outcome: the result has already been applied to the character by then, and
+ * leaving the blob behind would let a reload resolve the same victory twice.
+ * The mode returns to exploration on the same write, so the two can never
+ * disagree.
+ *
+ * Clearing goes through `Prisma.DbNull`, not `null`: on a nullable Json column
+ * a TypeScript `null` means "leave this column alone", so writing it would
+ * silently keep the finished fight in the row — the exact double-resolution
+ * this function exists to prevent.
+ */
+export function toCombatStatePersistence(state: CombatState | null): CombatStatePersistence {
+  // Covers both "no fight at all" and "fight already decided": in either case
+  // the column is cleared and the session returns to exploration.
+  if (state?.outcome !== null) {
+    return { gameMode: 'exploration', combatState: Prisma.DbNull }
+  }
+  return { gameMode: 'combat', combatState: state as unknown as Prisma.InputJsonValue }
+}
+
+// ─── Opening a fight (§1) ───────────────────────────────────────────────────
+
+/**
+ * The player as the fight sees them, assembled from the character sheet.
+ *
+ * Armour class is the canon starting figure for leather (`10-COMBAT §4`); the
+ * inventory does not yet carry an armour rating, so deriving it from equipment
+ * would mean inventing one. Anchoring on the documented baseline keeps the
+ * number traceable to canon rather than to a guess.
+ */
+function toCombatPlayer(
+  attributes: Attributes,
+  survival: SurvivalStats,
+  conditions: readonly ActiveCondition[]
+): CombatState['player'] {
+  return {
+    hp: survival.hp,
+    maxHp: survival.maxHp,
+    armourClass: BASE_ARMOUR_CLASS,
+    attributes,
+    conditions: [...conditions],
+    combatConditions: [],
+  }
+}
+
+/** Leather armour, the canon starting kit. @see 10-COMBAT §4 */
+const BASE_ARMOUR_CLASS = 11
+
+/**
+ * The creatures that may legitimately appear where the player currently stands.
+ *
+ * Climbing back out draws from the fauna already traversed rather than from the
+ * current floor: the way home is shorter, not gentler, and what makes it
+ * dangerous is the player's own spent state (`03-BESTIARY §6bis`).
+ *
+ * A session with no run at all — still at the inn, or an old session predating
+ * the run loop — yields floor 1, the shallowest band. That is the conservative
+ * end: an inn brawl can only ever be with the weakest creatures on the table.
+ */
+function allowedCreatures(run: RunState | null): Set<string> {
+  const blocks = run
+    ? run.returnEngaged
+      ? creaturesForReturn(run.maxDepthReached)
+      : creaturesForDepth(run.currentDepth)
+    : creaturesForDepth(1)
+
+  return new Set(blocks.map((block) => block.id))
+}
+
+export interface OpenCombatInput {
+  /** What the narrator signalled this turn. */
+  encounter: AiCombatEncounter
+  run: RunState | null
+  attributes: Attributes
+  survival: SurvivalStats
+  conditions: readonly ActiveCondition[]
+  rng?: () => number
+}
+
+/**
+ * Decides whether the encounter the AI just narrated actually becomes a fight,
+ * and builds it if so.
+ *
+ * This is the one place a combat can start, and it is deliberately a *filter*
+ * rather than a constructor. Canon makes the fight a narrative pivot the Game
+ * Master announces (§1), so the AI has to be the thing that signals it — but a
+ * model that can open a lethal fight on demand is a model that can kill a
+ * player on a whim. So the signal is treated exactly like every other AI
+ * proposal in this codebase: it names creatures, and the backend decides.
+ *
+ * Three guardrails, all structural:
+ * - **the id must be in the bestiary** — an invented creature has no AC, no HP
+ *   and no loot, so it cannot be arbitrated;
+ * - **the creature must belong on this floor** — `creaturesForDepth` is the
+ *   canon anti-rule "jamais un légendaire aux étages 1-2, même pour la
+ *   surprise", and it is enforced here rather than trusted to the prompt;
+ * - **a dying character is never ambushed into a fight** — canon grants one
+ *   turn of reprieve at 0 HP (`06-SURVIVAL §7`), and opening a fight during it
+ *   would spend that reprieve on a death the player could not act against.
+ *
+ * Returns null when nothing survives the filter, which reads as "no fight this
+ * turn": the scene the AI wrote still stands, it simply stays a scene.
+ * @see docs/public/raw/10-COMBAT.md §1, §2
+ * @see docs/public/raw/03-BESTIARY.md §6bis
+ */
+export function openCombatFromEncounter(input: OpenCombatInput): CombatState | null {
+  const { encounter, run, attributes, survival, conditions } = input
+
+  // A character already on the ground cannot be pulled into a new fight: the
+  // reprieve canon grants them is a turn to act, not a turn to be killed in.
+  if (survival.isDying || survival.hp <= 0) return null
+
+  const allowed = allowedCreatures(run)
+  const enemies = encounter.creatureIds
+    .filter((id) => allowed.has(id))
+    .map((id) => instantiateEnemy(id as CreatureId, randomUUID()))
+
+  if (enemies.length === 0) return null
+
+  return startCombat({
+    id: randomUUID(),
+    player: toCombatPlayer(attributes, survival, conditions),
+    enemies,
+    // An ambush is what canon calls a fight the player had no chance to
+    // defuse (§1). Mechanically that is the enemy camp acting first, which is
+    // the initiative — not a bonus to their dice.
+    ...(encounter.ambush ? { forcedInitiative: 'enemy' as const } : {}),
+    rng: input.rng,
+  })
+}
+
+// ─── Resolving a turn ───────────────────────────────────────────────────────
+
+/**
+ * Free-form prose is not a fifth action. Before #238 the text box let a player
+ * attempt lethal things without a die; in a fight the same hole would let them
+ * act outside the six actions canon allows. So prose is *translated* into one
+ * of those six and then resolved exactly like the button, sharing its dice and
+ * its costs.
+ *
+ * Matching is keyword-based and intentionally conservative: anything that does
+ * not clearly read as fleeing, defending, commanding or using something is an
+ * attack — the default that costs a turn and can be answered in blood, never
+ * the one that is free.
+ */
+const ACTION_PATTERNS: readonly { action: CombatAction; pattern: RegExp }[] = [
+  { action: 'flee', pattern: /\b(fui[rs]?|fuit|enfui|échapp|echapp|flee|run away|recul)/i },
+  { action: 'defend', pattern: /\b(défen|defen|pare[rz]?|parade|bloque|protège|protege|garde)/i },
+  {
+    action: 'command',
+    pattern: /\b(intimide|intimida|ordonne|commande|menace|crie|hurle|effra[iy])/i,
+  },
+  { action: 'awaken_artefact', pattern: /\b(artefact|éveille|eveille|awaken|relique)/i },
+  { action: 'use_item', pattern: /\b(bois|boire|mange|utilise|potion|bandage|soigne)/i },
+]
+
+/** Which way prose is running, when it reads as flight at all. */
+const BACKWARD_PATTERN = /\b(arrière|arriere|retour|remonte|demi-tour|back)/i
+
+/**
+ * Translates a free-form action into the tactical action that will actually be
+ * resolved. Returns the attack default when nothing matches.
+ * @see docs/public/raw/10-COMBAT.md §3
+ */
+export function translateFreeAction(text: string): {
+  action: CombatAction
+  fleeDirection?: FleeDirection
+} {
+  const matched = ACTION_PATTERNS.find(({ pattern }) => pattern.test(text))
+  if (!matched) return { action: 'attack' }
+
+  if (matched.action === 'flee') {
+    return {
+      action: 'flee',
+      fleeDirection: BACKWARD_PATTERN.test(text) ? 'backward' : 'forward',
+    }
+  }
+
+  return { action: matched.action }
+}
+
+export interface CombatTurnInput {
+  state: CombatState
+  survival: SurvivalStats
+  /** The tactical action, already translated when it came in as prose. */
+  action: CombatAction
+  targetId?: string
+  fleeDirection?: FleeDirection
+  itemHealing?: number
+  allyKind?: 'human' | 'beast'
+  rng?: () => number
+}
+
+export interface CombatTurnOutput {
+  state: CombatState
+  survival: SurvivalStats
+  /** Set once the fight is over, so the caller can pay out and close it. */
+  result: CombatResult | null
+  /** The player died for good this turn — the session ends on `death`. */
+  definitiveDeath: boolean
+  /**
+   * Only the exchanges logged *this* turn. The narrator is given the turn that
+   * just happened, not the whole fight replayed every round.
+   */
+  entriesThisTurn: CombatLogEntry[]
+}
+
+/**
+ * Plays one full exchange: the player acts, then the enemy camp answers as a
+ * block unless the fight already ended.
+ *
+ * The enemy answer is skipped when the player's own action ended the fight —
+ * canon has no posthumous round, and a camp that already lost its last member
+ * has nobody left to swing.
+ */
+export function resolveCombatTurn(input: CombatTurnInput): CombatTurnOutput {
+  const playerTurn = resolvePlayerTurn({
+    state: input.state,
+    action: input.action,
+    targetId: input.targetId,
+    fleeDirection: input.fleeDirection,
+    itemHealing: input.itemHealing,
+    allyKind: input.allyKind,
+    rng: input.rng,
+  })
+
+  let state: CombatState = {
+    ...playerTurn.state,
+    log: [...playerTurn.state.log, playerTurn.entry],
+  }
+  let survival = input.survival
+  let definitiveDeath = false
+  const entriesThisTurn: CombatLogEntry[] = [playerTurn.entry]
+
+  const afterPlayer = state.outcome ?? checkCombatEnd(state)
+  if (afterPlayer === null) {
+    const enemyTurn = resolveEnemyTurn({
+      state: advanceTurn(state),
+      survival,
+      rng: input.rng,
+    })
+    state = {
+      ...enemyTurn.state,
+      log: [...enemyTurn.state.log, ...enemyTurn.entries],
+    }
+    survival = enemyTurn.survival
+    definitiveDeath = enemyTurn.definitiveDeath
+    entriesThisTurn.push(...enemyTurn.entries)
+    state = advanceTurn(state)
+  }
+
+  const outcome = state.outcome ?? checkCombatEnd(state)
+  if (outcome === null) {
+    return { state, survival, result: null, definitiveDeath, entriesThisTurn }
+  }
+
+  const settled: CombatState = { ...state, outcome }
+  const result = endCombat({ state: settled, rng: input.rng })
+
+  return { state: settled, survival, result, definitiveDeath, entriesThisTurn }
+}
+
+// ─── Projection ─────────────────────────────────────────────────────────────
+
+/**
+ * The combat snapshot projected to the client alongside the scene. The client
+ * infers nothing: whose turn it is, what each enemy has left and whether the
+ * fight is over are all decided here.
+ */
+export function projectCombatState(
+  state: CombatState,
+  result?: CombatResult | null
+): CombatSnapshot {
+  return projectCombat(state, result ?? undefined)
+}
+
+/**
+ * The stakes a turn spent in combat is arbitrated under. A fight is never a
+ * calm scene, so a free-form action taken during one inherits combat stakes
+ * rather than the scene's — the continuity of #238 inside the fight.
+ */
+export const COMBAT_STAKES: { type: 'combat'; riskLevel: Difficulty } = {
+  type: 'combat',
+  riskLevel: 'high',
+}
+
+// ─── Handing the result to the narrator ─────────────────────────────────────
+
+/** Names an enemy for the prompt, falling back to the id if it somehow vanished. */
+function nameOf(state: CombatState, targetId: string | undefined): string {
+  if (!targetId) return 'the enemy'
+  return state.enemies.find((enemy) => enemy.id === targetId)?.name ?? targetId
+}
+
+/**
+ * Turns one resolved exchange into a sentence the narrator can dress up.
+ *
+ * Numbers are deliberately dropped: the AI is told that a blow landed hard or
+ * glanced off, never that it dealt 6 damage against AC 13. A model shown a
+ * number prints it, and canon keeps the arithmetic in the interface, out of the
+ * prose (§3). What survives here is only what the fiction needs.
+ */
+function describeEntry(state: CombatState, entry: CombatLogEntry): string {
+  const target = nameOf(state, entry.targetId)
+  const side = entry.actor === 'player' ? 'The player' : target
+
+  switch (entry.action) {
+    case 'attack': {
+      if (entry.hit !== true) {
+        return `${side} attacked ${entry.actor === 'player' ? target : 'the player'} and MISSED.`
+      }
+      const lethal =
+        entry.actor === 'player' && !state.enemies.find((e) => e.id === entry.targetId)?.isAlive
+      const victim = entry.actor === 'player' ? target : 'the player'
+      return lethal
+        ? `The player struck ${target} down. ${target} is DEAD.`
+        : `${side} HIT ${victim}${entry.damage && entry.damage >= 6 ? ', hard' : ''}.`
+    }
+    case 'defend':
+      return `${side} took a defensive stance instead of striking.`
+    case 'flee':
+      return entry.hit === true
+        ? 'The player broke away from the fight.'
+        : 'The player tried to break away and FAILED — the enemies kept them there.'
+    case 'command':
+      return entry.hit === true
+        ? `${side} shouted an order and it LANDED — ${target} faltered.`
+        : `${side} shouted an order and it fell flat.`
+    case 'use_item':
+      return entry.healing && entry.healing > 0
+        ? 'The player used something that eased their wounds.'
+        : 'The player used an item.'
+    case 'awaken_artefact':
+      return `${side} woke an artefact.`
+    default:
+      return entry.narrative
+  }
+}
+
+/**
+ * Projects the turn's log into the prompt context the Game Master narrates from.
+ *
+ * Only the entries logged *this* turn are passed: the AI narrates the exchange
+ * that just happened, not the whole fight again. The outcome, the §8 verdict and
+ * the flight direction all come from the state — the AI receives them as decided
+ * facts, which is the direction #235 requires.
+ */
+export function toCombatPromptContext(
+  state: CombatState,
+  action: CombatAction,
+  entriesThisTurn: CombatLogEntry[]
+): CombatPromptContext {
+  return {
+    action,
+    round: state.round,
+    events: entriesThisTurn.map((entry) => describeEntry(state, entry)),
+    outcome: state.outcome,
+    ...(state.knockoutVerdict ? { knockoutVerdict: state.knockoutVerdict } : {}),
+    ...(state.fleeDirection ? { fleeDirection: state.fleeDirection } : {}),
+  }
+}

--- a/apps/backend/src/services/session.service.combat.test.ts
+++ b/apps/backend/src/services/session.service.combat.test.ts
@@ -304,12 +304,16 @@ describe('persisting the fight', () => {
 
   // Leaving a decided fight in the column would let a reload pay it out twice.
   it('clears the column with DbNull once the fight is decided', async () => {
-    // A lone frail enemy against a good roll settles it in one exchange.
+    // A lone frail enemy against a pinned high roll settles it in one exchange.
+    // The rng is injected rather than left to Math.random: the turn now draws
+    // for the survival upkeep before the blows, so an ambient random would make
+    // "the rat dies this round" a coin flip instead of a fact.
     await resolveTurn({
       session: session(combatState({ enemies: [enemy('ruin_rat', { hp: 1, armourClass: 1 })] })),
       character,
       choice,
       combatAction: 'attack',
+      combatRng: () => 0.95,
     })
 
     const data = lastSessionUpdate()
@@ -323,6 +327,8 @@ describe('persisting the fight', () => {
       character,
       choice,
       combatAction: 'attack',
+      // Pinned so the rat reliably falls this round — see the DbNull test above.
+      combatRng: () => 0.95,
     })
 
     // The exact figure is rolled (`rollIron`), so asserting it would be testing
@@ -570,5 +576,66 @@ describe('opening a fight from the scene the AI just wrote (§1)', () => {
     await resolveTurn({ session: sessionOnARun(null), character, choice: walkOn })
 
     expect(sceneLogCreate).toHaveBeenCalledTimes(1)
+  })
+})
+
+/**
+ * Canon prices a turn the same whether it is spent walking or fighting: the
+ * drain, the -1 PV of an empty gauge and the Calamine of prolonged neglect all
+ * apply (06-SURVIVAL §4). Without this the fight would be a shelter from
+ * survival — starving costs nothing for as long as the player keeps swinging.
+ */
+describe('paying the survival upkeep inside a fight (§4)', () => {
+  /** The fighter, with whichever gauges the scenario needs emptied. */
+  function fighter(overrides: Partial<DbCharacter>): DbCharacter {
+    return { ...character, ...overrides } as unknown as DbCharacter
+  }
+
+  /** One round of defending — the action that takes no swing of its own. */
+  async function fightOneRound(who: DbCharacter): Promise<void> {
+    await resolveTurn({
+      session: session(combatState()),
+      character: who,
+      choice,
+      combatAction: 'defend',
+      combatRng: () => 0.5,
+    })
+  }
+
+  it('drains the gauges on a turn spent fighting', async () => {
+    await fightOneRound(character)
+
+    // TURN_DRAIN: thirst -4, hunger -3, energy -4 from the fixture's 100.
+    expect(lastCharacterUpdate()).toMatchObject({ thirst: 96, hunger: 97, energy: 96 })
+  })
+
+  // The erosion is what a starving fighter would otherwise dodge entirely: the
+  // engine only ever touches HP through blows, so nothing else would take it.
+  it('erodes a point of HP while a gauge sits at zero', async () => {
+    await fightOneRound(fighter({ thirst: 0 }))
+
+    expect(lastCharacterUpdate().thirst).toBe(0)
+    expect(lastCharacterUpdate().neglectStreak).toBe(1)
+    // Whatever the jackal did this round, one extra point came off the top.
+    expect(lastCharacterUpdate().hp).toBeLessThanOrEqual(19)
+  })
+
+  // Past the streak threshold, neglect starts corroding Calamine — the one
+  // Calamine source that is backend-triggered rather than AI-proposed.
+  it('corrodes Calamine once neglect has run past the threshold', async () => {
+    await fightOneRound(fighter({ hunger: 0, neglectStreak: 5 }))
+
+    // 0.5 lands mid-range in NEGLECT_CALAMINE_RANGE (3..5) → +4 on the fixture's 30.
+    expect(lastCharacterUpdate().calamine).toBe(34)
+    expect(lastCharacterUpdate().neglectStreak).toBe(6)
+  })
+
+  // A fed fighter pays the drain and nothing more: the streak stays reset and
+  // the Calamine untouched, since it never rises on its own (§174).
+  it('leaves a fed fighter alone beyond the ordinary drain', async () => {
+    await fightOneRound(character)
+
+    expect(lastCharacterUpdate().neglectStreak).toBe(0)
+    expect(lastCharacterUpdate().calamine).toBe(30)
   })
 })

--- a/apps/backend/src/services/session.service.combat.test.ts
+++ b/apps/backend/src/services/session.service.combat.test.ts
@@ -1,0 +1,574 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const transaction = vi.fn().mockResolvedValue(undefined)
+const sceneLogCreate = vi.fn()
+const characterUpdate = vi.fn()
+const gameSessionUpdate = vi.fn()
+vi.mock('../lib/prisma', () => ({
+  prisma: {
+    $transaction: transaction,
+    sceneLog: { create: sceneLogCreate, findMany: vi.fn().mockResolvedValue([]) },
+    character: { update: characterUpdate },
+    gameSession: { update: gameSessionUpdate },
+  },
+}))
+
+// The whole point of the combat branch is that it never reaches the scene d20.
+const resolveChoice = vi.fn()
+vi.mock('../game-rules/consequences', () => ({ resolveChoice }))
+
+const generateScene = vi.fn()
+vi.mock('../ai/game-master.service', () => ({ generateScene }))
+
+const assembleScene = vi.fn()
+vi.mock('./scene-assembler', () => ({ assembleScene }))
+
+vi.mock('./memory.service', () => ({ compressScene: vi.fn().mockResolvedValue(undefined) }))
+
+const generateChronicle = vi.fn().mockResolvedValue({ generated: true })
+vi.mock('./chronicle.service', () => ({ generateChronicle }))
+
+const { resolveTurn } = await import('./session.service')
+
+import { instantiateEnemy, startCombat } from '../game-rules/combat'
+import { Prisma } from '../generated/prisma/client'
+
+import type { Character as DbCharacter, GameSession } from '../generated/prisma/client'
+import type { CombatEnemy, CombatPlayer, CombatState, CreatureId } from '@grimoire/shared'
+
+const character = {
+  id: 'char1',
+  userId: 'user1',
+  name: 'Yarel of the Salt Roads',
+  people: 'sahelin',
+  vocation: 'salt-walker',
+  blood: 14,
+  breath: 14,
+  ash: 10,
+  hp: 20,
+  maxHp: 20,
+  iron: 40,
+  thirst: 100,
+  hunger: 100,
+  energy: 100,
+  calamine: 30,
+  isDying: false,
+  neglectStreak: 0,
+  activeConditions: [],
+  inventory: [],
+  createdAt: new Date(),
+} as unknown as DbCharacter
+
+/**
+ * Enemies come from the real bestiary rather than from a hand-written literal:
+ * a fixture invented here would drift from the persisted shape and let these
+ * tests pass against a state the service could never actually load.
+ */
+function enemy(
+  creatureId: CreatureId = 'ruin_rat',
+  overrides: Partial<CombatEnemy> = {}
+): CombatEnemy {
+  return { ...instantiateEnemy(creatureId, `e-${creatureId}`), ...overrides }
+}
+
+function player(overrides: Partial<CombatPlayer> = {}): CombatPlayer {
+  return {
+    hp: 20,
+    maxHp: 20,
+    armourClass: 12,
+    attributes: { blood: 14, breath: 14, ash: 10, clay: 10 },
+    conditions: [],
+    combatConditions: [],
+    ...overrides,
+  } as CombatPlayer
+}
+
+/** Opens a real fight, so the persisted blob always matches the live contract. */
+function combatState(overrides: Partial<CombatState> = {}): CombatState {
+  const base = startCombat({
+    id: 'combat1',
+    player: player(),
+    enemies: [enemy()],
+    // A fixed rng keeps initiative — and therefore who swings first — stable.
+    rng: () => 0.5,
+  })
+  return { ...base, ...overrides }
+}
+
+/** A session carrying a fight in progress — the only authority on "in combat". */
+function session(state: CombatState | null, turnNumber = 5): GameSession {
+  return {
+    id: 's1',
+    characterId: 'char1',
+    turnNumber,
+    location: 'Calamine',
+    locale: 'en',
+    status: 'active',
+    gameMode: state ? 'combat' : 'exploration',
+    combatState: state ? (JSON.parse(JSON.stringify(state)) as unknown) : null,
+    endReason: null,
+    createdAt: new Date(),
+  } as unknown as GameSession
+}
+
+/**
+ * The same session, but underway on a contract: without one there is no run
+ * state to advance, so nothing would record the direction a flight ran in.
+ */
+function sessionOnARun(state: CombatState | null): GameSession {
+  return {
+    ...session(state),
+    contractId: 'ct1',
+    contractDestination: 'Les Salines Basses',
+    contractTargetDepth: 3,
+    contractRewardIron: 40,
+    contractObjective: 'Rapporter le sceau du contremaître',
+    currentDepth: 2,
+    maxDepthReached: 2,
+    currentRoomId: null,
+    returnEngaged: false,
+    objectiveSecured: false,
+  } as unknown as GameSession
+}
+
+const choice = {
+  id: 'combat-action',
+  text: 'strike the jackal',
+  type: 'combat' as const,
+  riskLevel: 'deadly' as const,
+}
+
+/** Reads the `data` payload passed to the mocked `gameSession.update`. */
+function lastSessionUpdate(): Record<string, unknown> {
+  const call = gameSessionUpdate.mock.calls.at(-1) as
+    | [{ data: Record<string, unknown> }]
+    | undefined
+  return call?.[0].data ?? {}
+}
+
+function lastCharacterUpdate(): Record<string, unknown> {
+  const call = characterUpdate.mock.calls.at(-1) as [{ data: Record<string, unknown> }] | undefined
+  return call?.[0].data ?? {}
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  transaction.mockResolvedValue(undefined)
+  generateScene.mockResolvedValue({
+    scene: { narrative: 'Steel meets bone.', turnSummary: 'A blow lands.', choices: [] },
+    source: 'ai',
+  })
+  assembleScene.mockReturnValue({
+    sceneType: 'combat',
+    location: 'Calamine',
+    narrative: 'Steel meets bone.',
+    choices: [],
+  })
+})
+
+describe('routing a turn into the fight', () => {
+  // The persisted state is the switch. A turn taken mid-fight must never fall
+  // through to the exploration d20, which knows nothing about AC or enemies.
+  it('resolves through the combat engine and never rolls the scene d20', async () => {
+    await resolveTurn({
+      session: session(combatState()),
+      character,
+      choice,
+      combatAction: 'attack',
+    })
+
+    expect(resolveChoice).not.toHaveBeenCalled()
+    expect(generateScene).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the ordinary turn path alone when no fight is stored', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: {
+        hp: 20,
+        maxHp: 20,
+        thirst: 100,
+        hunger: 100,
+        energy: 100,
+        calamine: 30,
+        isDying: false,
+        neglectStreak: 0,
+      },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+
+    await resolveTurn({
+      session: session(null),
+      character,
+      choice: { id: 'c1', text: 'walk on', type: 'action', riskLevel: 'safe' },
+    })
+
+    expect(resolveChoice).toHaveBeenCalledTimes(1)
+    // The exploration path writes the column too — as DbNull, since the AI
+    // signalled no encounter. What matters is that no fight was opened, not
+    // that the field went untouched.
+    expect(lastSessionUpdate().combatState).toBe(Prisma.DbNull)
+    expect(lastSessionUpdate().gameMode).toBe('exploration')
+  })
+
+  // A blob that fails validation reads as "no fight": a corrupted state must not
+  // resume as a half-loaded one where the enemies have silently disappeared.
+  it('falls back to the ordinary path when the stored fight is corrupted', async () => {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: {
+        hp: 20,
+        maxHp: 20,
+        thirst: 100,
+        hunger: 100,
+        energy: 100,
+        calamine: 30,
+        isDying: false,
+        neglectStreak: 0,
+      },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+    const corrupted = { ...session(null), combatState: { round: 'not-a-number' } } as GameSession
+
+    await resolveTurn({ session: corrupted, character, choice })
+
+    expect(resolveChoice).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('feeding the AI a decided fight', () => {
+  // The direction of the dependency is the rule: mechanics first, prose second.
+  it('hands the resolved combat to the prompt as an accomplished fact', async () => {
+    await resolveTurn({
+      session: session(combatState()),
+      character,
+      choice,
+      combatAction: 'attack',
+    })
+
+    const input = generateScene.mock.calls[0]?.[0] as {
+      combat?: { action: string; events: string[] }
+    }
+    expect(input.combat?.action).toBe('attack')
+    expect(input.combat?.events.length).toBeGreaterThan(0)
+  })
+
+  // Canon keeps the arithmetic in the interface, out of the prose: a model shown
+  // a damage number prints it.
+  it('strips every number out of the events handed to the narrator', async () => {
+    await resolveTurn({
+      session: session(combatState()),
+      character,
+      choice,
+      combatAction: 'attack',
+    })
+
+    const input = generateScene.mock.calls[0]?.[0] as { combat?: { events: string[] } }
+    for (const event of input.combat?.events ?? []) {
+      expect(event).not.toMatch(/\d/)
+    }
+  })
+
+  // Prose is translated into a tactical action rather than resolved on its own
+  // terms, so the text box is never a cheaper way to fight than the buttons.
+  it('translates a free-form action instead of trusting it', async () => {
+    await resolveTurn({
+      session: session(combatState()),
+      character,
+      choice,
+      freeAction: 'je me jette sur le chacal pour le frapper',
+    })
+
+    const input = generateScene.mock.calls[0]?.[0] as { combat?: { action: string } }
+    expect(input.combat?.action).toBe('attack')
+    expect(resolveChoice).not.toHaveBeenCalled()
+  })
+})
+
+describe('persisting the fight', () => {
+  it('writes the ongoing fight back so the next turn resumes it intact', async () => {
+    await resolveTurn({
+      session: session(combatState({ enemies: [enemy('heart_of_sand')] })),
+      character,
+      choice,
+      combatAction: 'defend',
+    })
+
+    const data = lastSessionUpdate()
+    expect(data.gameMode).toBe('combat')
+    expect(data.combatState).toBeTruthy()
+    expect(data.combatState).not.toBe(Prisma.DbNull)
+  })
+
+  // Leaving a decided fight in the column would let a reload pay it out twice.
+  it('clears the column with DbNull once the fight is decided', async () => {
+    // A lone frail enemy against a good roll settles it in one exchange.
+    await resolveTurn({
+      session: session(combatState({ enemies: [enemy('ruin_rat', { hp: 1, armourClass: 1 })] })),
+      character,
+      choice,
+      combatAction: 'attack',
+    })
+
+    const data = lastSessionUpdate()
+    expect(data.combatState).toBe(Prisma.DbNull)
+    expect(data.gameMode).toBe('exploration')
+  })
+
+  it('banks the iron reward on the same write that clears the fight', async () => {
+    await resolveTurn({
+      session: session(combatState({ enemies: [enemy('ruin_rat', { hp: 1, armourClass: 1 })] })),
+      character,
+      choice,
+      combatAction: 'attack',
+    })
+
+    // The exact figure is rolled (`rollIron`), so asserting it would be testing
+    // the dice. What must hold is that it is paid, and paid on the very write
+    // that clears the fight — otherwise a reload could bank the same corpses twice.
+    const iron = lastCharacterUpdate().iron as { increment: number } | undefined
+    expect(iron?.increment).toBeGreaterThan(0)
+    expect(lastSessionUpdate().combatState).toBe(Prisma.DbNull)
+  })
+
+  it('pays no iron while the fight is still running', async () => {
+    await resolveTurn({
+      session: session(combatState({ enemies: [enemy('heart_of_sand')] })),
+      character,
+      choice,
+      combatAction: 'defend',
+    })
+
+    expect(lastCharacterUpdate().iron).toBeUndefined()
+  })
+})
+
+describe('ending the fight', () => {
+  // A first drop to 0 HP is the one turn of reprieve canon grants; only the
+  // second death is definitive, and only it ends the session.
+  // HP live on the character, not on the combat blob: the fight reads the same
+  // survival stats the rest of the run does, so a knockout here is the same
+  // knockout the survival rules already arbitrate.
+  const onDeathsDoor = { ...character, hp: 1 } as DbCharacter
+
+  it('does not end the session on the first knockout', async () => {
+    // A player on 1 HP cannot survive a hit from the heaviest bestiary block.
+    const brutal = enemy('heart_of_sand')
+    await resolveTurn({
+      session: session(combatState({ enemies: [brutal], activeSide: 'enemy' })),
+      character: onDeathsDoor,
+      choice,
+      combatAction: 'defend',
+      // Pinned high: the point is what a landed blow does, not whether it lands.
+      combatRng: () => 0.99,
+    })
+
+    // The first fall costs the reprieve, not the run (06-SURVIVAL §7).
+    const data = lastSessionUpdate()
+    expect(data.status).toBeUndefined()
+    expect(data.endReason).toBeUndefined()
+    expect(lastCharacterUpdate().isDying).toBe(true)
+  })
+
+  it('ends the session with endReason death on a definitive death', async () => {
+    const brutal = enemy('heart_of_sand')
+    const response = await resolveTurn({
+      session: session(combatState({ enemies: [brutal], activeSide: 'enemy' })),
+      // Already dying: this second fall is the definitive one.
+      character: { ...onDeathsDoor, isDying: true } as DbCharacter,
+      choice,
+      combatAction: 'defend',
+      combatRng: () => 0.99,
+    })
+
+    expect(lastSessionUpdate()).toMatchObject({ status: 'ended', endReason: 'death' })
+    expect(response.endReason).toBe('death')
+  })
+
+  // Running backward is the same irreversible pivot as the "faire demi-tour"
+  // button: it engages the return trip (10-COMBAT §7). Running forward escapes
+  // the fight and carries on with the quest, which is the ordinary advance.
+  it('engages the return when the player flees backward', async () => {
+    await resolveTurn({
+      session: sessionOnARun(combatState({ enemies: [enemy('heart_of_sand')] })),
+      character,
+      choice,
+      combatAction: 'flee',
+      fleeDirection: 'backward',
+      // Pinned high so the escape succeeds: the pivot is what is under test.
+      combatRng: () => 0.99,
+    })
+
+    expect(lastSessionUpdate().returnEngaged).toBe(true)
+  })
+
+  it('leaves the return alone when the player flees forward', async () => {
+    await resolveTurn({
+      session: sessionOnARun(combatState({ enemies: [enemy('heart_of_sand')] })),
+      character,
+      choice,
+      combatAction: 'flee',
+      fleeDirection: 'forward',
+      combatRng: () => 0.99,
+    })
+
+    expect(lastSessionUpdate().returnEngaged).toBe(false)
+  })
+
+  it('projects the fight onto the response so the front can render it', async () => {
+    const response = await resolveTurn({
+      session: session(combatState({ enemies: [enemy('heart_of_sand')] })),
+      character,
+      choice,
+      combatAction: 'defend',
+    })
+
+    expect(response.combat).toBeTruthy()
+    expect(response.combat?.enemies?.length).toBeGreaterThan(0)
+  })
+})
+
+describe('opening a fight from the scene the AI just wrote (§1)', () => {
+  /** A normal, survivable exploration turn — the baseline this block varies. */
+  function ordinaryTurn() {
+    resolveChoice.mockReturnValue({
+      updatedSurvival: {
+        hp: 20,
+        maxHp: 20,
+        thirst: 100,
+        hunger: 100,
+        energy: 100,
+        calamine: 30,
+        isDying: false,
+        neglectStreak: 0,
+      },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: false,
+    })
+  }
+
+  /** The AI's turn output, with the encounter signal it may attach to it. */
+  function narrates(encounter: unknown) {
+    generateScene.mockResolvedValue({
+      scene: {
+        narrative: 'Sand shifts. Something is already moving.',
+        turnSummary: 'Rats boil out of the ruin.',
+        choices: [],
+        ...(encounter ? { combat_encounter: encounter } : {}),
+      },
+      source: 'ai',
+    })
+  }
+
+  const walkOn = { id: 'c1', text: 'walk on', type: 'action' as const, riskLevel: 'safe' as const }
+
+  beforeEach(ordinaryTurn)
+
+  it('switches the session into the fight the AI signalled', async () => {
+    // sand_dog spans floors 1-3: the run advances one floor before the fight
+    // opens, so the encounter is checked against where the character now is.
+    narrates({ creatureIds: ['sand_dog'], reason: 'they were already waiting' })
+
+    const response = await resolveTurn({
+      session: sessionOnARun(null),
+      character,
+      choice: walkOn,
+      combatRng: () => 0.5,
+    })
+
+    expect(lastSessionUpdate().gameMode).toBe('combat')
+    expect(lastSessionUpdate().combatState).not.toBe(Prisma.DbNull)
+    // The client learns it is in a fight from the same response, never by
+    // inferring it from the prose.
+    expect(response.combat?.enemies?.length).toBe(1)
+  })
+
+  // The floor rule is the backend's, not the prompt's: a proposal it refuses
+  // leaves the scene standing as a scene.
+  it('refuses a creature that does not belong on this floor', async () => {
+    narrates({ creatureIds: ['watcher_king'], reason: 'the king himself descends' })
+
+    const response = await resolveTurn({
+      session: sessionOnARun(null),
+      character,
+      choice: walkOn,
+    })
+
+    expect(lastSessionUpdate().gameMode).toBe('exploration')
+    expect(lastSessionUpdate().combatState).toBe(Prisma.DbNull)
+    expect(response.combat).toBeUndefined()
+  })
+
+  // A fight persisted onto a session the same write is ending would leave a row
+  // that is both `ended` and in `combat`.
+  it('opens nothing on a turn that killed the character', async () => {
+    narrates({ creatureIds: ['sand_dog'], reason: 'they smell blood' })
+    resolveChoice.mockReturnValue({
+      updatedSurvival: {
+        hp: 0,
+        maxHp: 20,
+        thirst: 100,
+        hunger: 100,
+        energy: 100,
+        calamine: 30,
+        isDying: true,
+        neglectStreak: 0,
+      },
+      updatedConditions: [],
+      consequences: {},
+      gameOver: true,
+    })
+
+    await resolveTurn({ session: sessionOnARun(null), character, choice: walkOn })
+
+    expect(lastSessionUpdate()).toMatchObject({ status: 'ended', endReason: 'death' })
+    expect(lastSessionUpdate().combatState).toBe(Prisma.DbNull)
+  })
+
+  // Death is not the only way a turn can end a run: reaching the surface on the
+  // climb home ends it too, and a fight opened there would be a fight nobody is
+  // left underground to have. @see 23-RUN-STRUCTURE.md §5
+  it('opens nothing on the turn the run reaches the surface', async () => {
+    narrates({ creatureIds: ['sand_dog'], reason: 'one last jackal at the mouth' })
+    const surfacing = {
+      ...sessionOnARun(null),
+      currentDepth: 1,
+      returnEngaged: true,
+      objectiveSecured: true,
+    } as unknown as GameSession
+
+    const response = await resolveTurn({ session: surfacing, character, choice: walkOn })
+
+    expect(lastSessionUpdate()).toMatchObject({ status: 'ended', endReason: 'extracted' })
+    expect(lastSessionUpdate().combatState).toBe(Prisma.DbNull)
+    expect(lastSessionUpdate().gameMode).toBe('exploration')
+    expect(response.combat).toBeUndefined()
+  })
+
+  // Most turns carry no encounter at all, and must stay exploration turns.
+  it('leaves the turn alone when the AI signalled nothing', async () => {
+    narrates(null)
+
+    const response = await resolveTurn({
+      session: sessionOnARun(null),
+      character,
+      choice: walkOn,
+    })
+
+    expect(lastSessionUpdate().gameMode).toBe('exploration')
+    expect(response.combat).toBeUndefined()
+  })
+
+  // The scene the AI wrote still stands even when its encounter is refused:
+  // the turn is not replayed, only the fight is dropped.
+  it('still records the turn when the encounter is refused', async () => {
+    narrates({ creatureIds: ['watcher_king'], reason: 'the king himself descends' })
+
+    await resolveTurn({ session: sessionOnARun(null), character, choice: walkOn })
+
+    expect(sceneLogCreate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/backend/src/services/session.service.ts
+++ b/apps/backend/src/services/session.service.ts
@@ -4,8 +4,11 @@ import {
   type ActiveCondition,
   type Attributes,
   type Choice,
+  type CombatAction,
+  type CombatState,
   type ContractDepth,
   type Difficulty,
+  type FleeDirection,
   type InventoryActionResponse,
   type InventoryItemRef,
   type Locale,
@@ -34,6 +37,15 @@ import { prisma } from '../lib/prisma'
 
 import { deriveAttributes } from './character.service'
 import { generateChronicle } from './chronicle.service'
+import {
+  openCombatFromEncounter,
+  projectCombatState,
+  readCombatState,
+  resolveCombatTurn,
+  toCombatPromptContext,
+  toCombatStatePersistence,
+  translateFreeAction,
+} from './combat.service'
 import { compressScene } from './memory.service'
 import {
   advanceRun,
@@ -447,6 +459,19 @@ export interface ResolveTurnInput {
    * @see docs/public/raw/23-RUN-STRUCTURE.md §3
    */
   engageReturn?: boolean
+  /**
+   * The tactical action pressed, when this turn is spent in a fight (#235).
+   * Absent for a turn taken in prose, which is translated server-side instead.
+   */
+  combatAction?: CombatAction
+  targetId?: string
+  fleeDirection?: FleeDirection
+  /**
+   * Dice source for the fight. Left unset in production, where the engine falls
+   * back to `Math.random`; tests pin it so a scenario asserts the wiring rather
+   * than the roll it happened to get.
+   */
+  combatRng?: () => number
 }
 
 /**
@@ -470,12 +495,167 @@ function advanceRunForTurn(
 }
 
 /**
+ * Resolves one turn spent inside a fight (#235).
+ *
+ * This is a separate path from `resolveTurn`'s d20, not a variant of it: combat
+ * carries its own dice, its own DCs and its own end conditions, all of them in
+ * `game-rules/combat.ts`. What the two paths share is the order of operations —
+ * the backend resolves everything first, and only then does the AI narrate what
+ * already happened.
+ *
+ * The tactical action comes from a button when there is one, and from prose
+ * otherwise: a free-form action is *translated* into one of the six canon
+ * actions rather than being resolved on its own terms, so the text box cannot
+ * be a cheaper way to fight than the buttons (#238 inside a fight).
+ *
+ * @see docs/public/raw/10-COMBAT.md §3, §7, §8, §9
+ */
+async function resolveCombatTurnForSession(
+  input: ResolveTurnInput,
+  state: CombatState
+): Promise<SceneResponse> {
+  const { session, character, chosenActionText, freeAction } = input
+  const { attributes, survival, activeConditions, inventory } = readCharacter(character)
+
+  // A button states its action outright; prose has to be read. Either way the
+  // resolution below is identical — same dice, same costs.
+  const translated = input.combatAction
+    ? { action: input.combatAction, fleeDirection: input.fleeDirection }
+    : translateFreeAction(freeAction ?? chosenActionText ?? '')
+
+  const turn = resolveCombatTurn({
+    state,
+    survival,
+    action: translated.action,
+    targetId: input.targetId,
+    fleeDirection: input.fleeDirection ?? translated.fleeDirection,
+    allyKind: 'human',
+    rng: input.combatRng,
+  })
+
+  // Running backward is the same pivot as the "faire demi-tour" button: it
+  // engages the return trip, irreversibly. Running forward escapes the fight
+  // and carries on with the quest, which the ordinary per-turn advance already
+  // does — so only the backward case needs an extra move here (§7).
+  const fledBackward = turn.result?.outcome === 'fled' && turn.state.fleeDirection === 'backward'
+  const run = advanceRunForTurn(session, input.engageReturn === true || fledBackward)
+
+  const gm = await generateScene({
+    character: toGmCharacter(character, attributes, turn.survival, activeConditions, inventory),
+    locale: session.locale,
+    sessionId: session.id,
+    chosenActionText,
+    freeAction,
+    run: run
+      ? {
+          destination: run.next.contract.destination,
+          objective: run.next.contract.objective,
+          targetDepth: run.next.contract.targetDepth,
+          currentDepth: run.next.currentDepth,
+          maxDepthReached: run.next.maxDepthReached,
+          mode: run.next.mode,
+          returnEngaged: run.next.returnEngaged,
+          warnings: [],
+        }
+      : null,
+    combat: toCombatPromptContext(turn.state, translated.action, turn.entriesThisTurn),
+  })
+
+  const nextTurn = session.turnNumber + 1
+  const ironGained = turn.result?.ironGained ?? 0
+
+  const scene = assembleScene({
+    payload: gm.scene,
+    sessionId: session.id,
+    turnNumber: nextTurn,
+    imageUrl: session.currentImageUrl,
+  })
+
+  // Only a definitive death ends the session. A first drop to 0 HP is the one
+  // turn of reprieve canon grants (06-SURVIVAL §7), and being captured or
+  // pulled out by an ally (§8) leaves the character alive to keep playing —
+  // the backend already arbitrated which of the three happened.
+  const endReason: SessionEndReason | null = turn.definitiveDeath ? 'death' : null
+
+  await prisma.$transaction([
+    prisma.sceneLog.create({
+      data: {
+        sessionId: session.id,
+        turnNumber: nextTurn,
+        sceneType: scene.sceneType,
+        location: scene.location,
+        narrative: scene.narrative,
+        turnSummary: gm.scene.turnSummary,
+        choices: scene.choices as unknown as object,
+        chosenChoice: input.choice.text ? (input.choice as unknown as object) : undefined,
+        source: gm.source,
+      },
+    }),
+    prisma.character.update({
+      where: { id: character.id },
+      data: {
+        hp: turn.survival.hp,
+        isDying: turn.survival.isDying,
+        // Iron is paid on the same write that clears the fight, so a reload can
+        // never bank the same corpses twice.
+        ...(ironGained > 0 ? { iron: { increment: ironGained } } : {}),
+      },
+    }),
+    prisma.gameSession.update({
+      where: { id: session.id },
+      data: {
+        turnNumber: nextTurn,
+        location: scene.location,
+        ...(run ? toRunStatePersistence(run.next) : {}),
+        // The fight's own persistence decides the mode: a finished fight clears
+        // the column and returns to exploration on this very write.
+        ...toCombatStatePersistence(turn.state),
+        ...(endReason ? { status: 'ended', endReason } : {}),
+      },
+    }),
+  ])
+
+  if (endReason) {
+    void (async () => {
+      try {
+        await generateChronicle(session.id)
+      } catch (err) {
+        console.warn(`[Chronicle] failed to generate for session ${session.id}:`, err)
+      }
+    })()
+  }
+
+  return {
+    activeConditions,
+    ...(endReason ? { endReason } : {}),
+    iron: character.iron + ironGained,
+    scene,
+    survival: turn.survival,
+    updatedStats: toStatsRecord(turn.survival),
+    updatedInventory: toInventoryRefs(inventory),
+    notifications: [],
+    source: gm.source,
+    combat: projectCombatState(turn.state, turn.result),
+    ...(run ? { run: projectRun(run.next, countCarriedSupplies(inventory)) } : {}),
+  }
+}
+
+/**
  * Resolves one turn against the persisted world-state. The backend owns every
  * mechanic: it rolls the d20 (via `resolveChoice`), applies survival + HP,
  * persists the outcome, and — on death (`hp<=0`) — ends the session with
  * `endReason='death'`. The AI only narrates. Returns the enriched `SceneResponse`.
+ *
+ * A turn taken while a fight is in progress is routed to the combat engine
+ * instead (#235): the persisted `combatState` is the sole authority on whether
+ * that is the case, never a `gameMode` string that could drift out of sync.
  */
 export async function resolveTurn(input: ResolveTurnInput): Promise<SceneResponse> {
+  const combat = readCombatState(input.session)
+  if (combat) {
+    return resolveCombatTurnForSession(input, combat)
+  }
+
   const { session, character, choice, chosenActionText, freeAction } = input
   const { attributes, survival, activeConditions, inventory } = readCharacter(character)
 
@@ -592,6 +772,28 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
   // who dies on the last climb did not come home. @see 23-RUN-STRUCTURE.md §5
   const returnEnding = run && !gameOver ? resolveReturnEnding(run.next) : null
 
+  // The AI may signal that what it just narrated turned hostile (#235). Canon
+  // makes the fight a narrative pivot the Game Master announces, never a button
+  // the player presses (10-COMBAT §1) — so the signal has to come from the AI,
+  // and the arbitration has to stay here: `openCombatFromEncounter` re-checks
+  // the creatures against the floor before anything is instantiated.
+  //
+  // A turn that already ended the run opens nothing. Persisting a fight onto a
+  // session the same write is closing would leave a session that is `ended` and
+  // in `combat` at once — and on death it would drop a reload into a fight the
+  // character did not survive to see.
+  const openedCombat =
+    !gameOver && !returnEnding && gm.scene.combat_encounter
+      ? openCombatFromEncounter({
+          encounter: gm.scene.combat_encounter,
+          run: run?.next ?? null,
+          attributes,
+          survival: restedSurvival,
+          conditions: finalConditions,
+          rng: input.combatRng,
+        })
+      : null
+
   const endReason: SessionEndReason | null = resolution.gameOver
     ? 'death'
     : calcined
@@ -636,6 +838,11 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
         turnNumber: nextTurn,
         location: scene.location,
         ...(run ? toRunStatePersistence(run.next) : {}),
+        // Switches the session into combat mode when the turn just opened a
+        // fight. `openedCombat` is null on every other turn, which this same
+        // call writes back as exploration — this path is only ever reached with
+        // no fight in progress, so clearing is a no-op rather than a risk.
+        ...toCombatStatePersistence(openedCombat),
         ...(runOver ? { status: 'ended', endReason } : {}),
       },
     }),
@@ -700,6 +907,9 @@ export async function resolveTurn(input: ResolveTurnInput): Promise<SceneRespons
     notifications: [],
     diceRoll: resolution.diceRoll,
     source: gm.source,
+    // The client learns it is now in a fight from the same response that
+    // narrated the pivot — it never has to poll or infer it from the prose.
+    ...(openedCombat ? { combat: projectCombatState(openedCombat) } : {}),
     // Projected from the inventory as it stands *after* the turn, so the panel
     // the player reads before deciding to descend reflects what they actually
     // carry now.

--- a/apps/backend/src/services/session.service.ts
+++ b/apps/backend/src/services/session.service.ts
@@ -32,7 +32,7 @@ import { resolveChoice } from '../game-rules/consequences'
 import { acquireItem, equipItem, unequipItem, useItem } from '../game-rules/inventory'
 import { applyRest } from '../game-rules/rest'
 import { createContract, createRunState, engageReturn } from '../game-rules/run'
-import { clearDyingOnHeal } from '../game-rules/survival'
+import { applyTurnUpkeep, clearDyingOnHeal } from '../game-rules/survival'
 import { prisma } from '../lib/prisma'
 
 import { deriveAttributes } from './character.service'
@@ -523,9 +523,19 @@ async function resolveCombatTurnForSession(
     ? { action: input.combatAction, fleeDirection: input.fleeDirection }
     : translateFreeAction(freeAction ?? chosenActionText ?? '')
 
+  // A round of fighting is a turn like any other, and canon prices it the same:
+  // the drain, the -1 PV of an empty gauge and the Calamine of prolonged neglect
+  // all apply (06-SURVIVAL §4). Without this, starving would cost nothing for as
+  // long as the player kept swinging.
+  //
+  // Paid BEFORE the blows are traded, so a character the thirst finishes off
+  // drops to 0 on the upkeep and lets `resolveCombatTurn` arbitrate the dying
+  // rule on the real HP — rather than dying twice over in the same turn.
+  const upkeep = applyTurnUpkeep(survival, input.combatRng)
+
   const turn = resolveCombatTurn({
     state,
-    survival,
+    survival: upkeep.survival,
     action: translated.action,
     targetId: input.targetId,
     fleeDirection: input.fleeDirection ?? translated.fleeDirection,
@@ -594,8 +604,16 @@ async function resolveCombatTurnForSession(
     prisma.character.update({
       where: { id: character.id },
       data: {
+        // The whole survival sheet, not just HP: the upkeep above moved the
+        // gauges, and persisting only the damage would let a fight rewind the
+        // thirst it just cost.
         hp: turn.survival.hp,
+        thirst: turn.survival.thirst,
+        hunger: turn.survival.hunger,
+        energy: turn.survival.energy,
+        calamine: turn.survival.calamine,
         isDying: turn.survival.isDying,
+        neglectStreak: turn.survival.neglectStreak,
         // Iron is paid on the same write that clears the fight, so a reload can
         // never bank the same corpses twice.
         ...(ironGained > 0 ? { iron: { increment: ironGained } } : {}),

--- a/packages/shared/src/types/combat.types.ts
+++ b/packages/shared/src/types/combat.types.ts
@@ -37,7 +37,7 @@ export type CreatureHabitat =
   | "anywhere";
 
 /**
- * The bestiary, closed. These 18 are *the* list — the AI draws from it and
+ * The bestiary, closed. These 22 are *the* list — the AI draws from it and
  * never adds to it.
  *
  * Not a style rule: a creature invented on the fly has no AC, no HP, no
@@ -45,7 +45,15 @@ export type CreatureHabitat =
  * cannot learn to fight it. Knowledge meta-progression only has value if the
  * creature met on run 8 is the same one met on run 3.
  *
+ * The four human entries are not decoration. `10-COMBAT §8` makes the outcome
+ * of a knockout depend on *who* was standing over the body — human captors
+ * take prisoners, beasts finish the job — so a fight with no way to express
+ * "these are people" cannot arbitrate its own death table. They also carry the
+ * canon AC figures the whole scale is anchored on (§4) and are the only
+ * enemies Intimidation reliably works on (§5).
+ *
  * @see 03-BESTIARY.md §6
+ * @see 10-COMBAT.md §4, §5, §8
  */
 export type CreatureId =
   // 💛 Calcinés — the four stages (§2)
@@ -69,7 +77,32 @@ export type CreatureId =
   | "shore_beast"
   // 🔴 Legendary bosses (§5)
   | "heart_of_sand"
-  | "watcher_king";
+  | "watcher_king"
+  // 🧍 Humans — the AC anchors of `10-COMBAT §4` and the only enemies that
+  // take prisoners rather than finishing a downed player (§8).
+  | "civilian"
+  | "brigand"
+  | "soldier"
+  | "inquisitor";
+
+/**
+ * What an enemy *is*, as a rule rather than as flavour.
+ *
+ * This exists for one reason: `10-COMBAT §8` decides a downed player's fate
+ * from who is standing over them — human enemies take a prisoner, savage ones
+ * finish the kill. Reading that off `tier` or a name would be guesswork, so the
+ * distinction is declared.
+ *
+ * `calcined` is its own species and not a kind of human on purpose. Canon calls
+ * them former humans who lost their reason (`02-WORLD-BIBLE §5`), and §8 lists
+ * them on the *savage* side of the table — they do not take prisoners. Keeping
+ * them separate also lets Intimidation apply to weak Calcinés (§5) without
+ * making them human anywhere else.
+ *
+ * @see 10-COMBAT.md §5, §8
+ * @see 02-WORLD-BIBLE.md §5
+ */
+export type CreatureSpecies = "human" | "beast" | "calcined" | "archontic";
 
 /**
  * How a creature acts, which is what the AI narrates. Behaviour is data, not
@@ -165,6 +198,7 @@ export interface CreatureStatBlock {
   /** Canon display name, in the game's French copy. */
   name: string;
   tier: CreatureTier;
+  species: CreatureSpecies;
   habitat: CreatureHabitat;
   behaviour: CreatureBehaviour;
   engagement: CreatureEngagement;
@@ -237,6 +271,43 @@ export type InitiativeSide = "player" | "enemy";
 export type CombatOutcome = "victory" | "defeat" | "fled";
 
 /**
+ * What becomes of a player dropped to 0 HP in a fight.
+ *
+ * Canon printed this as a table of what "the AI decides"; the correction of
+ * 2026-08-06 revoked that outright — a death chosen by a model is by
+ * construction a death the player could not see coming (`01-PILLARS §9`). The
+ * table stays as the **truth table**, but the backend evaluates it and the AI
+ * only writes the scene for the verdict it is handed.
+ *
+ * - `saved` — a living ally drags the body clear; the run continues, at a cost.
+ * - `captured` — human enemies take a prisoner; the player wakes in chains and
+ *   the run continues in a new scene.
+ * - `dead` — savage enemies or a hostile environment finish it; the run ends.
+ *
+ * @see 10-COMBAT.md §8
+ */
+export type KnockoutVerdict = "saved" | "captured" | "dead";
+
+/**
+ * The state the death table is evaluated against. Kept as an explicit input so
+ * the verdict is a pure function of the fight rather than of ambient context —
+ * which is what makes it testable, and what stops the AI from influencing it.
+ * @see 10-COMBAT.md §8
+ */
+export interface KnockoutContext {
+  /** Whether an ally is still standing to pull the player out. */
+  hasLivingAlly: boolean;
+  /** The enemies still alive when the player went down. */
+  survivingEnemies: CombatEnemy[];
+  /**
+   * Whether the fight is in a place that kills the helpless on its own
+   * (Ventre-Gris, marshes). Overrides captivity: nobody takes a prisoner
+   * somewhere the prisoner cannot survive.
+   */
+  isHostileEnvironment: boolean;
+}
+
+/**
  * A creature as it stands in a fight. `variant` is present from the first
  * turn, never revealed mid-fight.
  */
@@ -247,6 +318,8 @@ export interface CombatEnemy {
   /** Display name, already localised for the client. */
   name: string;
   tier: CreatureTier;
+  /** Carried onto the instance because the death table (§8) reads it. */
+  species: CreatureSpecies;
   behaviour: CreatureBehaviour;
   /** The single variant applied, if any. Never more than one. */
   variant: CreatureVariant | null;
@@ -258,6 +331,13 @@ export interface CombatEnemy {
   combatConditions: CombatConditionId[];
   /** False once dropped — kept in the list so the log stays readable. */
   isAlive: boolean;
+  /**
+   * True when this enemy broke and ran rather than died — canon has a shaken
+   * enemy under AC 11 flee outright (§5). It is out of the fight like a corpse,
+   * but it is not one: it leaves nothing behind to loot (§9).
+   * @see 10-COMBAT.md §5, §9
+   */
+  hasRouted?: boolean;
 }
 
 /** The player's side of the fight. */
@@ -313,6 +393,32 @@ export interface CombatState {
   log: CombatLogEntry[];
   /** Null while the fight is still running. */
   outcome: CombatOutcome | null;
+  /**
+   * Which way the player ran, set alongside `outcome: "fled"`. Held on the state
+   * and not only on the result because the direction decides what the *run*
+   * does next — forward continues the contract, backward starts the climb home
+   * — and a session resumed mid-escape must still know which.
+   * @see 10-COMBAT.md §7
+   */
+  fleeDirection?: FleeDirection;
+  /**
+   * Set only when the player was dropped, alongside `outcome: "defeat"`. The
+   * backend computes it from the death table; the AI narrates it.
+   * @see 10-COMBAT.md §8
+   */
+  knockoutVerdict?: KnockoutVerdict;
+  /** Whether this fight happens somewhere that kills the helpless (§8). */
+  isHostileEnvironment: boolean;
+  /** Whether an ally fights alongside the player — read by the death table. */
+  hasLivingAlly: boolean;
+  /**
+   * Set for exactly one enemy turn after a botched Intimidation: canon has the
+   * camp galvanised and attacking with the upper hand. Optional because an
+   * ordinary fight never sets it, and a resumed session must read its absence
+   * as "not galvanised" rather than as missing data.
+   * @see 10-COMBAT.md §5
+   */
+  galvanised?: boolean;
 }
 
 /** How a fight concluded, with what it cost and what it paid. */
@@ -322,6 +428,12 @@ export interface CombatResult {
   ironGained: number;
   /** Set when the fight ended by fleeing — the run needs to know which way. */
   fleeDirection?: FleeDirection;
+  /**
+   * Set on defeat. Only `dead` ends the run: `saved` and `captured` hand the
+   * story back to the session with the player still alive.
+   * @see 10-COMBAT.md §8
+   */
+  knockoutVerdict?: KnockoutVerdict;
 }
 
 /**


### PR DESCRIPTION
Closes #235

## Ce que ça livre

Le moteur de combat par tours, de bout en bout : les contrats partagés, le bestiaire, le moteur pur, le câblage à la session et à la persistance, et le déclencheur qui ouvre un combat depuis une scène.

## Le moteur

`game-rules/combat.ts` est pur : aucune I/O, aucun accès base, un `rng` injecté. Il tient l'initiative, les rounds, les jets d'attaque contre l'AC, les dégâts, la fuite et la résolution de fin de combat. Le d20 et toutes les conséquences restent côté backend — l'IA ne décide rien.

`combat.service.ts` fait le pont : lecture/écriture de l'état persisté, projection vers le client, et arbitrage des propositions de l'IA.

## Le déclencheur

Le canon est explicite (`10-COMBAT §1`) : « Le combat n'est jamais activé par le joueur : c'est une bascule narrative annoncée par l'IA. » Ce n'est donc **pas** une route `POST /combat/start`. L'IA *signale* via un champ `combat_encounter` (`creatureIds`, `ambush`, `reason`), et le backend *arbitre* — exactement le pattern déjà en place pour `apply_condition` ou `item_gained`.

`openCombatFromEncounter` applique trois garde-fous structurels :

- la créature doit exister au bestiaire (une créature inventée n'a ni AC, ni PV, ni butin — elle n'est pas arbitrable) ;
- elle doit appartenir à l'étage courant, via `creaturesForDepth` / `creaturesForReturn`. L'anti-règle canon « jamais un légendaire aux étages 1-2, même pour la surprise » est vérifiée en code, pas confiée au prompt ;
- un personnage agonisant n'est jamais happé dans un combat : le tour de sursis que le canon lui accorde (`06-SURVIVAL §7`) est un tour pour agir, pas un tour pour mourir.

Un combat n'est pas non plus ouvert sur un tour qui termine le run — mort *ou* extraction. Sans ça, la même écriture persisterait une session à la fois `ended` et `in combat`.

Le prompt liste à l'IA les créatures réellement disponibles à son étage : une proposition rejetée en silence coûterait au joueur un tour où la prose promettait un combat qui n'est jamais venu.

## Un point à connaître

La règle canon « Éviter le combat » (toujours offrir fuir / parlementer / intimider / se cacher avant l'engagement) porte sur le tour **précédent**. Aucune vérification backend ne peut l'imposer — elle vit dans le prompt seul. Le commentaire de `buildEncounterSection` dit explicitement cette asymétrie plutôt que de laisser croire que tout est verrouillé côté code.

## Un bug latent corrigé au passage

Le cast `as unknown as CombatState` dans `readCombatState` masquait un schéma Zod qui validait les conditions comme `string[]` alors que le contrat est `ActiveCondition[]`. Les règles d'expiration auraient été perdues à chaque rechargement d'un combat en cours. Corrigé aux trois endroits concernés.

## Vérification

648 tests verts, lint et type-check propres.

Vérification par mutation sur les six points de décision du déclencheur — garde-fou agonisant, filtre bestiaire/profondeur, initiative d'embuscade, faune du retour, encounter vide, fin de run : **tous tués**. C'est cette dernière mutation qui a payé, en révélant que la suite ne couvrait que la fin de run par mort et pas par extraction ; le test manquant a été ajouté.

## Base de données

La colonne `combatState` (Json nullable) est déjà appliquée sur Supabase — migration `add_combat_state_to_game_session`. Aucune action requise au merge.


---

## Correctif de relecture — l'entretien de survie pendant un combat

Défaut trouvé en relisant le diff : le chemin combat sautait l'entretien de survie
par tour. Un personnage à soif 0 perdait -1 PV/tour en exploration, mais **rien**
pendant un combat, et `neglectStreak` cessait d'avancer. Un combat de 6 rounds
effaçait 6 PV d'attrition et remettait la pression de négligence à zéro : mourir de
faim devenait gratuit tant que le joueur continuait à frapper. Aucun test ne le
voyait — les deux chemins étaient testés isolément.

Le canon dit « -1 PV **par tour** » et « +3 à +5 Calamine **par tour** » (06-SURVIVAL §4)
sans exception pour le combat : un tour passé à échanger des coups reste un tour.

- `applyTurnUpkeep` factorisé dans `survival.ts` (drain + érosion + streak + Calamine),
  les **deux** chemins y passent désormais — ils ne peuvent plus diverger.
- Payé **avant** les coups, pour que `resolveCombatTurn` arbitre la règle du mourant
  sur les vrais PV plutôt que de faire mourir deux fois dans le même tour.
- La feuille de survie complète est persistée (6 champs), plus seulement `hp`/`isDying`.
- Calamine laissée **sans** drain passif : c'est le canon (§174), pas un oubli.

4 tests ajoutés, vérifiés contre deux mutants (upkeep neutralisé / persistance retirée) :
3/4 tuent le premier, 4/4 le second. Deux tests existants qui dépendaient de
`Math.random` ont été épinglés sur un rng injecté — le tirage supplémentaire de
l'entretien a révélé une instabilité préexistante (1 échec sur 5 runs), stable 8/8 depuis.

652 tests verts, lint et type-check OK.
