### PR TITLE
feat(#260): représenter une quête qui n'est pas un donjon

### DIFF
--- a/apps/backend/prisma/migrations/20260809160000_reshape_quest_contract/migration.sql
+++ b/apps/backend/prisma/migrations/20260809160000_reshape_quest_contract/migration.sql
@@ -1,0 +1,17 @@
+-- Reshape the run contract so the board is not a list of dungeons (#260).
+-- @see docs/public/raw/23-RUN-STRUCTURE.md §1, §2
+--
+-- Every column is added nullable: existing rows carry an accepted contract that
+-- must keep reading back, and `readContract` treats a missing family as the
+-- dungeon it was. `contractTargetDepth` was already nullable and now stays null
+-- for every family but `dungeon`.
+ALTER TABLE "GameSession" ADD COLUMN "contractFamily" TEXT;
+ALTER TABLE "GameSession" ADD COLUMN "contractCommissioner" TEXT;
+ALTER TABLE "GameSession" ADD COLUMN "contractDanger" TEXT;
+ALTER TABLE "GameSession" ADD COLUMN "contractDuration" TEXT;
+ALTER TABLE "GameSession" ADD COLUMN "contractSuccessCondition" TEXT;
+ALTER TABLE "GameSession" ADD COLUMN "contractFailureConditions" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+-- Contracts written before this migration were all dungeons. Naming that
+-- explicitly beats leaving the engine to infer it from a null forever.
+UPDATE "GameSession" SET "contractFamily" = 'dungeon' WHERE "contractId" IS NOT NULL;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -157,12 +157,29 @@ model GameSession {
   /// Contrat accepté. Null tant que le joueur n'est pas parti — et sur toutes
   /// les sessions antérieures à #228, qui restent jouables sans structure de run.
   contractId        String?
+  /// Famille de quête (dungeon | escort | investigation | hunt | recovery |
+  /// negotiation | dilemma). Seule `dungeon` descend : c'est elle qui décide si
+  /// `contractTargetDepth` a un sens (#260).
+  contractFamily      String?
   contractDestination String?
+  /// Commanditaire : qui a posé le contrat, et qui paie au retour.
+  contractCommissioner String?
+  /// Tag de danger affiché sur le tableau (easy | medium | hard). Le chiffrage
+  /// qui le produit reste interne et n'est jamais envoyé au client.
+  contractDanger      String?
+  /// Tag de durée affiché (short | long | major). Les minutes restent internes.
+  contractDuration    String?
   /// Profondeur visée (3 | 5 | 7). Plafonnée à 7 par le moteur, jamais par la DB.
+  /// Null pour toute quête non-donjon — une escorte n'a pas de paliers, et
+  /// aucune règle n'a le droit de lui en inventer.
   contractTargetDepth Int?
   /// Fer payé par le commanditaire au retour, si le joueur revient.
   contractRewardGold  Int?
   contractObjective   String?
+  /// Ce que le backend vérifie pour déclarer le contrat rempli.
+  contractSuccessCondition String?
+  /// Toutes les façons de perdre le contrat. Vide = seule la mort le fait échouer.
+  contractFailureConditions String[] @default([])
   /// Palier courant. 0 = en surface (auberge ou sorti du donjon).
   currentDepth      Int      @default(0)
   /// Palier le plus profond atteint ce run. Ne redescend jamais — c'est lui qui

--- a/apps/backend/src/ai/system-prompt.test.ts
+++ b/apps/backend/src/ai/system-prompt.test.ts
@@ -359,6 +359,20 @@ describe('run section', () => {
     expect(prompt).toContain('the backend owns every value below')
   })
 
+  it('names the target depth of a dungeon contract', () => {
+    // Kept deliberately: the narrator is trusted with the floor count so the
+    // descent can be written with a sense of how far down it goes (#260).
+    expect(promptWithRun(run())).toContain('Target depth: 5 floors')
+  })
+
+  it('omits the depth entirely for a contract that has no floors', () => {
+    // An escort has no paliers, and a narrator handed a number invents one.
+    const prompt = promptWithRun(run({ targetDepth: undefined }))
+
+    expect(prompt).not.toContain('Target depth')
+    expect(prompt).toContain('This contract has no floors')
+  })
+
   it('forbids a climactic set-piece on the way home', () => {
     // §4 — the return may kill, but never by ambush.
     const prompt = promptWithRun(run({ returnEngaged: true, mode: 'return' }))

--- a/apps/backend/src/ai/system-prompt.ts
+++ b/apps/backend/src/ai/system-prompt.ts
@@ -30,7 +30,12 @@ export interface RecentTurnSummary {
 export interface RunPromptContext {
   destination: string
   objective: string
-  targetDepth: number
+  /**
+   * Floors the contract targets. Undefined for every non-dungeon family, which
+   * has none — the section then simply omits the depth rather than naming a
+   * number the run does not have (#260).
+   */
+  targetDepth?: number
   currentDepth: number
   maxDepthReached: number
   mode: GameMode
@@ -372,7 +377,10 @@ function buildRunSection(run: RunPromptContext | null): string[] {
   const lines = [
     '',
     'Run structure (the backend owns every value below — never contradict it):',
-    `- Contract: "${run.objective}" at ${run.destination}. Target depth: ${run.targetDepth} floors.`,
+    run.targetDepth === undefined
+      ? `- Contract: "${run.objective}" at ${run.destination}. This contract has no floors —` +
+        ' never speak of descending, of paliers, or of a bottom to reach.'
+      : `- Contract: "${run.objective}" at ${run.destination}. Target depth: ${run.targetDepth} floors.`,
     `- The character stands on floor ${run.currentDepth}, deepest reached ${run.maxDepthReached}.`,
     `- Current mode: ${run.mode}.`,
   ]

--- a/apps/backend/src/game-rules/run.test.ts
+++ b/apps/backend/src/game-rules/run.test.ts
@@ -17,15 +17,36 @@ import {
   WATER_PER_RETURN_ROOM,
 } from './run'
 
-import type { ContractDepth, RunState } from '@grimoire/shared'
+import type { ContractDepth, QuestDuration, RunState } from '@grimoire/shared'
 
 function contract(targetDepth: ContractDepth = 5) {
   return createContract({
     id: 'contract-1',
+    family: 'dungeon',
     destination: 'Les Salines Basses',
+    commissioner: 'La guilde du sel',
+    danger: 'medium',
+    duration: 'long',
     targetDepth,
     rewardGold: 120,
     objective: 'Rapporter le sceau du contremaître',
+    successCondition: 'Le sceau est dans le sac au retour',
+  })
+}
+
+/** A contract with no floors — the shape every non-dungeon family takes (#260). */
+function floorlessContract(duration: QuestDuration = 'long') {
+  return createContract({
+    id: 'contract-2',
+    family: 'escort',
+    destination: 'La route haute',
+    commissioner: 'Un marchand pressé',
+    danger: 'easy',
+    duration,
+    rewardGold: 80,
+    objective: 'Escorter la caravane jusqu’au col',
+    successCondition: 'La caravane atteint le col',
+    failureConditions: ['Le marchand meurt'],
   })
 }
 
@@ -42,15 +63,57 @@ describe('createContract', () => {
     [5, 90],
     [7, 150],
   ])('derives the target duration from depth %i → %i minutes', (depth, minutes) => {
-    expect(
+    expect(contract(depth as ContractDepth).targetDurationMinutes).toBe(minutes)
+  })
+
+  it.each([
+    ['short', 45],
+    ['long', 90],
+    ['major', 150],
+  ])('derives a floorless contract duration from the tag %s → %i minutes', (tag, minutes) => {
+    const built = floorlessContract(tag as QuestDuration)
+    expect(built.targetDurationMinutes).toBe(minutes)
+    expect(built.targetDepth).toBeUndefined()
+  })
+
+  it('refuses a depth on a family that has no floors', () => {
+    // A contract that is not a dungeon must not carry floors: accepting one
+    // silently would put a descent under a quest the run loop never descends.
+    expect(() =>
       createContract({
         id: 'c',
+        family: 'negotiation',
         destination: 'd',
-        targetDepth: depth as ContractDepth,
+        commissioner: 'c',
+        danger: 'hard',
+        duration: 'short',
+        targetDepth: 5,
         rewardGold: 10,
         objective: 'o',
-      }).targetDurationMinutes
-    ).toBe(minutes)
+        successCondition: 's',
+      })
+    ).toThrow(/no floors/)
+  })
+
+  it('defaults failureConditions to empty — death is then the only way to lose', () => {
+    expect(contract().failureConditions).toEqual([])
+  })
+})
+
+describe('a contract without floors (#260)', () => {
+  it('can never descend', () => {
+    // The answer is a flat "no", not a fabricated depth: an escort must not
+    // grow a dungeon because a rule wanted a number.
+    expect(canDescend(createRunState(floorlessContract()))).toBe(false)
+  })
+
+  it('reports the contract duration as the remaining estimate', () => {
+    expect(estimateRemainingMinutes(createRunState(floorlessContract('short')))).toBe(45)
+  })
+
+  it('reports nothing left once the return is engaged', () => {
+    const state = engageReturn(createRunState(floorlessContract()))
+    expect(estimateRemainingMinutes(state)).toBe(0)
   })
 })
 

--- a/apps/backend/src/game-rules/run.ts
+++ b/apps/backend/src/game-rules/run.ts
@@ -3,6 +3,10 @@ import {
   CONTRACT_DURATION_MINUTES,
   MAX_CONTRACT_DEPTH,
   MIN_CONTRACT_DEPTH,
+  QUEST_DURATION_MINUTES,
+  type QuestDanger,
+  type QuestDuration,
+  type QuestFamily,
   type ReturnEstimate,
   type ReturnRisk,
   type RunContract,
@@ -48,21 +52,51 @@ export interface CarriedSupplies {
   food: number
 }
 
-/** Builds the run contract accepted at the inn. @see 23-RUN-STRUCTURE.md §1 */
+/**
+ * Builds the run contract accepted at the inn.
+ *
+ * A depth is accepted only for a dungeon: passing one with any other family is
+ * a caller bug, and silently keeping it would put floors on a contract the run
+ * loop never descends. The minutes are derived — from the depth when there is
+ * one, from the duration tag otherwise — so the two kinds of contract answer
+ * the duration question in the same unit without either inventing the other's.
+ * @see 23-RUN-STRUCTURE.md §1, §2
+ */
 export function createContract(params: {
   id: string
+  family: QuestFamily
   destination: string
-  targetDepth: ContractDepth
+  commissioner: string
+  danger: QuestDanger
+  duration: QuestDuration
+  targetDepth?: ContractDepth
   rewardGold: number
   objective: string
+  successCondition: string
+  failureConditions?: string[]
 }): RunContract {
+  if (params.family !== 'dungeon' && params.targetDepth !== undefined) {
+    throw new Error(`A ${params.family} contract has no floors: targetDepth is dungeon-only`)
+  }
+
+  const targetDepth = params.family === 'dungeon' ? params.targetDepth : undefined
+
   return {
     id: params.id,
+    family: params.family,
     destination: params.destination,
-    targetDepth: params.targetDepth,
-    targetDurationMinutes: CONTRACT_DURATION_MINUTES[params.targetDepth],
+    commissioner: params.commissioner,
+    danger: params.danger,
+    duration: params.duration,
+    ...(targetDepth === undefined ? {} : { targetDepth }),
+    targetDurationMinutes:
+      targetDepth === undefined
+        ? QUEST_DURATION_MINUTES[params.duration]
+        : CONTRACT_DURATION_MINUTES[targetDepth],
     rewardGold: params.rewardGold,
     objective: params.objective,
+    successCondition: params.successCondition,
+    failureConditions: params.failureConditions ?? [],
   }
 }
 
@@ -85,11 +119,17 @@ export function createRunState(contract: RunContract): RunState {
  * The 7-floor ceiling is enforced here as a rule, not only as a type: the
  * engine structurally cannot produce a run past `MAX_CONTRACT_DEPTH`, whatever
  * the contract asked for. Once the return is engaged, descending is over.
- * @see 23-RUN-STRUCTURE.md §1, §3
+ *
+ * A contract without floors can never descend — and the answer is `false`, not
+ * a fabricated depth: a quest that has no dungeon must not grow one because a
+ * rule needed a number (#260).
+ * @see 23-RUN-STRUCTURE.md §1, §2, §3
  */
 export function canDescend(state: RunState): boolean {
   if (state.returnEngaged) return false
-  return state.currentDepth < Math.min(state.contract.targetDepth, MAX_CONTRACT_DEPTH)
+  const targetDepth = state.contract.targetDepth
+  if (targetDepth === undefined) return false
+  return state.currentDepth < Math.min(targetDepth, MAX_CONTRACT_DEPTH)
 }
 
 /** Descends one floor, tracking the deepest point reached. No-op if forbidden. */
@@ -181,7 +221,16 @@ export function computeReturnEstimate(state: RunState, supplies: CarriedSupplies
  * @see 23-RUN-STRUCTURE.md §1
  */
 export function estimateRemainingMinutes(state: RunState): number {
-  const target = Math.min(state.contract.targetDepth, MAX_CONTRACT_DEPTH)
+  const targetDepth = state.contract.targetDepth
+
+  // No floors, no descent to price. The contract's own target is the only
+  // honest answer here — deriving one from rooms would mean inventing a
+  // dungeon under a quest that has none (#260).
+  if (targetDepth === undefined) {
+    return state.returnEngaged ? 0 : state.contract.targetDurationMinutes
+  }
+
+  const target = Math.min(targetDepth, MAX_CONTRACT_DEPTH)
   const floorsLeftToDescend = state.returnEngaged ? 0 : Math.max(0, target - state.currentDepth)
   const deepestPoint = state.returnEngaged ? state.currentDepth : target
 

--- a/apps/backend/src/routes/game-action.schema.ts
+++ b/apps/backend/src/routes/game-action.schema.ts
@@ -69,19 +69,42 @@ export const createSessionSchema = z.object({
 export type CreateSessionRequest = z.infer<typeof createSessionSchema>
 
 /**
- * Accepting a contract at the inn and setting out (#228). The depth is the one
- * commitment the player makes for the evening (~45 min at 3 floors, 2h30 at 7)
- * and is the only field with a rule behind it: only the canon depths are
- * accepted, so no request can open a run longer than the hard cap.
- * @see docs/public/raw/23-RUN-STRUCTURE.md §1
+ * Accepting a contract at the inn and setting out (#228, reshaped in #260).
+ *
+ * The depth is the commitment a *dungeon* asks for (~45 min at 3 floors, 2h30
+ * at 7), and only the canon depths are accepted so no request can open a run
+ * longer than the hard cap. Every other family has no floors at all, and the
+ * refinement below rejects a request that pairs the two rather than quietly
+ * dropping one — a client sending `escort` with a depth is confused about what
+ * it is starting, and must be told.
+ * @see docs/public/raw/23-RUN-STRUCTURE.md §1, §2
  */
-export const startRunSchema = z.object({
-  sessionId: z.string().min(1),
-  destination: z.string().min(1).max(120),
-  targetDepth: z.union([z.literal(3), z.literal(5), z.literal(7)]),
-  rewardGold: z.number().int().min(0).max(10_000),
-  objective: z.string().min(1).max(280),
-})
+export const startRunSchema = z
+  .object({
+    sessionId: z.string().min(1),
+    family: z.enum([
+      'dungeon',
+      'escort',
+      'investigation',
+      'hunt',
+      'recovery',
+      'negotiation',
+      'dilemma',
+    ]),
+    destination: z.string().min(1).max(120),
+    commissioner: z.string().min(1).max(120),
+    danger: z.enum(['easy', 'medium', 'hard']),
+    duration: z.enum(['short', 'long', 'major']),
+    targetDepth: z.union([z.literal(3), z.literal(5), z.literal(7)]).optional(),
+    rewardGold: z.number().int().min(0).max(10_000),
+    objective: z.string().min(1).max(280),
+    successCondition: z.string().min(1).max(280),
+    failureConditions: z.array(z.string().min(1).max(280)).max(5).default([]),
+  })
+  .refine((value) => (value.family === 'dungeon') === (value.targetDepth !== undefined), {
+    message: 'targetDepth is required for a dungeon contract, and forbidden for any other family',
+    path: ['targetDepth'],
+  })
 
 export type StartRunRequest = z.infer<typeof startRunSchema>
 

--- a/apps/backend/src/services/run.service.test.ts
+++ b/apps/backend/src/services/run.service.test.ts
@@ -51,10 +51,38 @@ function contractedSession(overrides: Partial<GameSession> = {}): GameSession {
   return session({
     gameMode: 'exploration',
     contractId: 'contract-1',
+    contractFamily: 'dungeon',
     contractDestination: 'Les Salines Basses',
+    contractCommissioner: 'La guilde du sel',
+    contractDanger: 'medium',
+    contractDuration: 'long',
     contractTargetDepth: 5,
     contractRewardGold: 120,
     contractObjective: 'Rapporter le sceau du contremaître',
+    contractSuccessCondition: 'Le sceau est dans le sac au retour',
+    contractFailureConditions: [],
+    ...overrides,
+  })
+}
+
+/**
+ * A row as #228 wrote it: a dungeon, with none of the #260 columns. These
+ * sessions are live in the database and must keep reading back.
+ */
+function legacySession(overrides: Partial<GameSession> = {}): GameSession {
+  return session({
+    gameMode: 'exploration',
+    contractId: 'contract-1',
+    contractFamily: null,
+    contractDestination: 'Les Salines Basses',
+    contractCommissioner: null,
+    contractDanger: null,
+    contractDuration: null,
+    contractTargetDepth: 5,
+    contractRewardGold: 120,
+    contractObjective: 'Rapporter le sceau du contremaître',
+    contractSuccessCondition: null,
+    contractFailureConditions: [],
     ...overrides,
   })
 }
@@ -73,10 +101,15 @@ function runState(targetDepth: ContractDepth = 5): RunState {
   return createRunState(
     createContract({
       id: 'contract-1',
+      family: 'dungeon',
       destination: 'Les Salines Basses',
+      commissioner: 'La guilde du sel',
+      danger: 'medium',
+      duration: 'long',
       targetDepth,
       rewardGold: 120,
       objective: 'Rapporter le sceau du contremaître',
+      successCondition: 'Le sceau est dans le sac au retour',
     })
   )
 }
@@ -223,11 +256,64 @@ describe('readRunState', () => {
 
     expect(toContractPersistence(state.contract)).toEqual({
       contractId: source.contractId,
+      contractFamily: source.contractFamily,
       contractDestination: source.contractDestination,
+      contractCommissioner: source.contractCommissioner,
+      contractDanger: source.contractDanger,
+      contractDuration: source.contractDuration,
       contractTargetDepth: source.contractTargetDepth,
       contractRewardGold: source.contractRewardGold,
       contractObjective: source.contractObjective,
+      contractSuccessCondition: source.contractSuccessCondition,
+      contractFailureConditions: source.contractFailureConditions,
     })
+  })
+})
+
+describe('readContract — quest families (#260)', () => {
+  it('reads a floorless contract back with no depth at all', () => {
+    const contract = readContract(
+      contractedSession({ contractFamily: 'escort', contractTargetDepth: null })
+    )
+
+    expect(contract).not.toBeNull()
+    expect(contract!.family).toBe('escort')
+    expect(contract!.targetDepth).toBeUndefined()
+    // Derived from the duration tag, since there are no floors to derive from.
+    expect(contract!.targetDurationMinutes).toBe(90)
+  })
+
+  it('rejects a dungeon whose depth went missing', () => {
+    // Reading it back as a floorless run would hand the player a dungeon they
+    // can never descend — better no contract than a silently broken one.
+    expect(readContract(contractedSession({ contractTargetDepth: null }))).toBeNull()
+  })
+
+  it('rejects a floorless family that somehow carries a depth', () => {
+    expect(readContract(contractedSession({ contractFamily: 'negotiation' }))).toBeNull()
+  })
+
+  it('reads a pre-#260 row as the dungeon it was, with neutral tags', () => {
+    const contract = readContract(legacySession())
+
+    expect(contract).not.toBeNull()
+    expect(contract!.family).toBe('dungeon')
+    expect(contract!.targetDepth).toBe(5)
+    // Nothing was recorded, so the tags land mid-scale rather than underselling.
+    expect(contract!.danger).toBe('medium')
+    expect(contract!.duration).toBe('long')
+    expect(contract!.commissioner).toBe('Commanditaire inconnu')
+    // The objective is the only success condition such a row ever had.
+    expect(contract!.successCondition).toBe('Rapporter le sceau du contremaître')
+  })
+
+  it('falls back to mid-scale tags when a stored value is unreadable', () => {
+    const contract = readContract(
+      contractedSession({ contractDanger: 'catastrophique', contractDuration: 'éternelle' })
+    )
+
+    expect(contract!.danger).toBe('medium')
+    expect(contract!.duration).toBe('long')
   })
 })
 

--- a/apps/backend/src/services/run.service.ts
+++ b/apps/backend/src/services/run.service.ts
@@ -17,6 +17,9 @@ import type { Character as DbCharacter, GameSession } from '../generated/prisma/
 import type {
   ContractDepth,
   GameMode,
+  QuestDanger,
+  QuestDuration,
+  QuestFamily,
   ReturnEstimate,
   RunContract,
   RunState,
@@ -85,6 +88,32 @@ export function hasProvisionsInBag(inventory: PersistedInventoryItem[]): boolean
 }
 
 /**
+ * Commissioner recorded for contracts written before #260, which had no such
+ * column. The board needs someone to name; an honest "unknown" beats inventing
+ * a patron the player never met.
+ */
+const UNKNOWN_COMMISSIONER = 'Commanditaire inconnu'
+
+const QUEST_DANGERS: readonly QuestDanger[] = ['easy', 'medium', 'hard']
+const QUEST_DURATIONS: readonly QuestDuration[] = ['short', 'long', 'major']
+
+/**
+ * Reads a persisted danger tag, defaulting to the middle of the scale.
+ *
+ * Pre-#260 rows have none, and an unreadable value is treated the same way: a
+ * tag the board cannot parse must not silently read as `easy`, which would
+ * undersell a run the player is about to accept.
+ */
+function readDanger(value: string | null): QuestDanger {
+  return QUEST_DANGERS.includes(value as QuestDanger) ? (value as QuestDanger) : 'medium'
+}
+
+/** Reads a persisted duration tag. Same defaulting rule as `readDanger`. */
+function readDuration(value: string | null): QuestDuration {
+  return QUEST_DURATIONS.includes(value as QuestDuration) ? (value as QuestDuration) : 'long'
+}
+
+/**
  * True when the session carries an accepted contract. Sessions created before
  * #228 — and any session still at the inn — have none, and must keep working:
  * the run structure degrades to "no structure", never to a crash.
@@ -93,7 +122,6 @@ export function hasContract(session: GameSession): boolean {
   return (
     session.contractId !== null &&
     session.contractDestination !== null &&
-    session.contractTargetDepth !== null &&
     session.contractRewardGold !== null &&
     session.contractObjective !== null
   )
@@ -101,21 +129,39 @@ export function hasContract(session: GameSession): boolean {
 
 /**
  * Reads the persisted contract back into its shared shape. Returns null when
- * the session has no contract, or when the stored depth is not a canon depth —
- * a corrupted row must not be able to fabricate an 11-floor run.
+ * the session has no contract, or when a dungeon's stored depth is not a canon
+ * depth — a corrupted row must not be able to fabricate an 11-floor run.
+ *
+ * A null depth is not corruption on its own: every family but `dungeon` is
+ * meant to have none. It is only rejected when the family says there should be
+ * floors — a dungeon that lost its depth would otherwise read back as a run
+ * the player can never descend (#260).
  */
 export function readContract(session: GameSession): RunContract | null {
   if (!hasContract(session)) return null
 
+  // Sessions written before #260 carry no family and were all dungeons.
+  const family = (session.contractFamily ?? 'dungeon') as QuestFamily
   const depth = session.contractTargetDepth
-  if (depth === null || !isValidContractDepth(depth)) return null
+
+  if (family === 'dungeon') {
+    if (depth === null || !isValidContractDepth(depth)) return null
+  } else if (depth !== null) {
+    return null
+  }
 
   return createContract({
     id: session.contractId!,
+    family,
     destination: session.contractDestination!,
-    targetDepth: depth,
+    commissioner: session.contractCommissioner ?? UNKNOWN_COMMISSIONER,
+    danger: readDanger(session.contractDanger),
+    duration: readDuration(session.contractDuration),
+    ...(depth === null ? {} : { targetDepth: depth }),
     rewardGold: session.contractRewardGold!,
     objective: session.contractObjective!,
+    successCondition: session.contractSuccessCondition ?? session.contractObjective!,
+    failureConditions: session.contractFailureConditions,
   })
 }
 
@@ -164,20 +210,33 @@ export function toRunStatePersistence(state: RunState): RunStatePersistence {
 /** The contract columns, for the moment a run is started from the inn. */
 export interface ContractPersistence {
   contractId: string
+  contractFamily: QuestFamily
   contractDestination: string
-  contractTargetDepth: ContractDepth
+  contractCommissioner: string
+  contractDanger: QuestDanger
+  contractDuration: QuestDuration
+  /** Null for every family but `dungeon` — see `RunContract.targetDepth`. */
+  contractTargetDepth: ContractDepth | null
   contractRewardGold: number
   contractObjective: string
+  contractSuccessCondition: string
+  contractFailureConditions: string[]
 }
 
 /** Flattens a contract into the session columns it owns. */
 export function toContractPersistence(contract: RunContract): ContractPersistence {
   return {
     contractId: contract.id,
+    contractFamily: contract.family,
     contractDestination: contract.destination,
-    contractTargetDepth: contract.targetDepth,
+    contractCommissioner: contract.commissioner,
+    contractDanger: contract.danger,
+    contractDuration: contract.duration,
+    contractTargetDepth: contract.targetDepth ?? null,
     contractRewardGold: contract.rewardGold,
     contractObjective: contract.objective,
+    contractSuccessCondition: contract.successCondition,
+    contractFailureConditions: contract.failureConditions,
   }
 }
 

--- a/apps/backend/src/services/session.service.ts
+++ b/apps/backend/src/services/session.service.ts
@@ -7,6 +7,9 @@ import {
   type CombatAction,
   type CombatState,
   type ContractDepth,
+  type QuestDanger,
+  type QuestDuration,
+  type QuestFamily,
   type Difficulty,
   type FleeDirection,
   type InventoryActionResponse,
@@ -1046,20 +1049,28 @@ async function endSession(
 /**
  * Starts a run: the player accepts a contract at the inn and sets out.
  *
- * The contract is built by the backend from a validated depth — the client
- * never supplies a duration or a room count, both of which are derived. Only an
- * active session still at the inn may leave; a session already underground
- * cannot silently swap contracts mid-run.
- * @see docs/public/raw/23-RUN-STRUCTURE.md §1
+ * The contract is built by the backend from validated input — the client never
+ * supplies a duration in minutes or a room count, both of which are derived.
+ * A depth arrives only with a `dungeon` family, the schema having already
+ * rejected any other pairing (#260). Only an active session still at the inn
+ * may leave; a session already underground cannot silently swap contracts
+ * mid-run.
+ * @see docs/public/raw/23-RUN-STRUCTURE.md §1, §2
  */
 export async function startRun(
   sessionId: string,
   userId: string,
   contract: {
+    family: QuestFamily
     destination: string
-    targetDepth: ContractDepth
+    commissioner: string
+    danger: QuestDanger
+    duration: QuestDuration
+    targetDepth?: ContractDepth
     rewardGold: number
     objective: string
+    successCondition: string
+    failureConditions: string[]
   }
 ): Promise<SceneResponse | null> {
   const session = await prisma.gameSession.findFirst({
@@ -1070,7 +1081,18 @@ export async function startRun(
     return null
   }
 
-  const state = createRunState(createContract({ id: randomUUID(), ...contract }))
+  // `targetDepth` is spread only when present, so a non-dungeon contract is
+  // built without the key at all rather than with an explicit `undefined`. Both
+  // read the same to `createContract`'s guard today; keeping the key out means
+  // that stays true if the guard ever tightens to a `in`-style check.
+  const { targetDepth, ...rest } = contract
+  const state = createRunState(
+    createContract({
+      id: randomUUID(),
+      ...rest,
+      ...(targetDepth === undefined ? {} : { targetDepth }),
+    })
+  )
 
   const updated = await prisma.gameSession.update({
     where: { id: session.id },

--- a/docs/public/current-state/BACKEND.md
+++ b/docs/public/current-state/BACKEND.md
@@ -187,6 +187,33 @@ calcined`. L'ancien `inn` confondait « rentré avec l'objectif » (payé) et «
 - **Le tenancier du Comptoir n'est pas L'Aveugle.** Le Comptoir est purement transactionnel en
   v0.2.1 (aucun appel IA) ; si un dialogue lui est ajouté, il devra recevoir son propre constructeur
   de prompt — `buildAveugleTalkPrompt` est réservé à la voix de L'Aveugle.
+- **`RunContract.targetDepth` est optionnel, pas défaillant** (#260). Le canon §2 dit que « le
+  système ne suppose jamais que toute quête est un donjon », mais le type imposait `3 | 5 | 7` à
+  tous : une escorte devait mentir en se déclarant profonde de 3 paliers. La profondeur n'existe
+  désormais que pour `family: 'dungeon'`, et **aucune règle n'invente de valeur par défaut** —
+  `canDescend` répond `false` sur un contrat sans paliers, `estimateRemainingMinutes` renvoie la
+  durée cible du contrat. Un défaut aurait été pire que l'absence : il aurait fait pousser un donjon
+  sous une quête qui n'en a pas, silencieusement.
+- **Les tags sont qualitatifs côté client, chiffrés côté serveur.** `danger` (`easy | medium | hard`)
+  et `duration` (`short | long | major`) sont ce que le joueur lit ; `targetDurationMinutes` reste
+  interne. Publier les minutes transformerait une estimation qui dérive avec la façon de jouer en
+  une promesse que le moteur ne peut pas tenir. Le vocabulaire de danger est **neutre** (Facile /
+  Moyen / Difficile) et non fictionnel : un label in-world se lit comme de la saveur, pas comme un
+  avertissement — décision produit du 2026-08-09.
+- **Le narrateur garde la profondeur visée** (décision produit du 2026-08-09, prise contre ma
+  recommandation et assumée comme telle). Le prompt continue d'émettre `Target depth: N floors` pour
+  un donjon, afin que la descente s'écrive avec un sens de la distance. Le canon §4 a été **adapté**
+  plutôt que contredit : son interdiction porte sur l'**interface**, et la règle opposable à l'IA
+  devient « ne jamais l'écrire dans la prose ». Risque connu et inscrit au canon : un modèle à qui
+  l'on donne un nombre tend à l'imprimer ; si la prose annonce « il reste quatre paliers », c'est la
+  transmission qu'il faudra retirer, pas la consigne qu'il faudra durcir. Un contrat sans paliers ne
+  reçoit aucun chiffre et se voit interdire explicitement le vocabulaire de descente.
+- **Les colonnes #260 sont toutes nullables, et une famille absente se lit `dungeon`.** Les sessions
+  écrites avant la migration portent un contrat accepté qui doit rester jouable ; `readContract`
+  comble commanditaire et tags par des valeurs **milieu d'échelle** (`medium` / `long`), jamais
+  `easy`, pour ne pas sous-vendre un run que le joueur s'apprête à accepter. En revanche un donjon
+  dont la profondeur a disparu renvoie `null` : mieux vaut pas de contrat qu'un donjon que le joueur
+  ne pourra jamais descendre.
 
 ### Contrats et mémoire
 

--- a/docs/public/raw/23-RUN-STRUCTURE.md
+++ b/docs/public/raw/23-RUN-STRUCTURE.md
@@ -70,6 +70,22 @@ très dangereux, mais le système ne suppose jamais que toute quête est un donj
 Le backend choisit et valide cette structure. L'IA lui donne sa prose, ses personnages et ses
 scènes ; elle ne peut ni inventer la condition de victoire ni déclarer seule la quête terminée.
 
+La **famille** de quête est fermée : `dungeon`, `escort`, `investigation`, `hunt`, `recovery`,
+`negotiation`, `dilemma`. Seule `dungeon` descend, et elle seule porte une profondeur visée — les
+autres n'en ont aucune, et aucune règle du moteur n'a le droit de leur en inventer une pour combler
+un champ manquant (#260).
+
+Les deux tags sont **qualitatifs côté joueur, chiffrés côté moteur** :
+
+| Tag    | Valeurs affichées          | Ce qui reste interne                               |
+| ------ | -------------------------- | -------------------------------------------------- |
+| Danger | Facile / Moyen / Difficile | Le chiffrage qui pilote génération et équilibrage  |
+| Durée  | Court / Long / Majeur      | Les minutes cibles (45 / 90 / 150), et les paliers |
+
+Le vocabulaire de danger est volontairement **neutre et ludique**, pas fictionnel : le joueur doit
+lire l'arbitrage d'un coup d'œil, et un label in-world (« routine », « funeste ») se lit comme de la
+saveur, pas comme un avertissement.
+
 ### Le panneau
 
 - présente **trois contrats ordinaires** simultanément ;
@@ -131,6 +147,17 @@ Pour la v0.2.1, l'interface ne révèle jamais :
 - le numéro du palier ou la profondeur maximale ;
 - la carte ou les connexions du donjon ;
 - une estimation chiffrée ou qualitative du retour.
+
+**Le narrateur, lui, connaît la profondeur visée** (#260). Elle lui est transmise dans son contexte
+pour qu'il sache écrire une descente qui va quelque part — le ton d'un troisième palier sur sept
+n'est pas celui d'un dernier. Cette interdiction porte donc sur l'**interface**, pas sur le prompt :
+l'IA reçoit le chiffre, et la règle qui lui reste opposable est de ne jamais l'**écrire** dans sa
+prose, ni de le transformer en compte à rebours. Un contrat sans paliers ne reçoit aucun chiffre du
+tout, et le prompt lui interdit alors explicitement de parler de descente ou de profondeur.
+
+Le risque assumé est connu : un modèle à qui l'on donne un nombre a tendance à l'imprimer. Si la
+prose se met à annoncer « il reste quatre paliers », c'est cette transmission qu'il faudra retirer,
+pas la consigne qu'il faudra durcir.
 
 L'image montre le **lieu présent**, jamais la prochaine conséquence. La narration décrit ce que le
 personnage voit maintenant ; les choix restent des actions fictionnelles, pas des cartes de salles.

--- a/packages/shared/src/types/run.types.ts
+++ b/packages/shared/src/types/run.types.ts
@@ -13,11 +13,51 @@
 export type GameMode = "inn" | "exploration" | "combat" | "return";
 
 /**
+ * The kinds of work a commissioner puts on the board.
+ *
+ * Closed on purpose: the engine branches on this, so a family nobody wrote
+ * rules for must not typecheck. `dungeon` is the only one that descends —
+ * every other family resolves without floors, which is exactly why
+ * `RunContract.targetDepth` is optional (#260).
+ * @see 23-RUN-STRUCTURE.md §2
+ */
+export type QuestFamily =
+  | "dungeon"
+  | "escort"
+  | "investigation"
+  | "hunt"
+  | "recovery"
+  | "negotiation"
+  | "dilemma";
+
+/**
  * Contract depth in floors. The 7-floor ceiling is hard: no contract may
  * exceed it, because run length is capped at 2h30 (01-PILLARS §2).
+ * Only meaningful for `family: "dungeon"`.
  * @see 23-RUN-STRUCTURE.md §1
  */
 export type ContractDepth = 3 | 5 | 7;
+
+/**
+ * Danger tag shown on the contract board.
+ *
+ * Deliberately neutral game vocabulary rather than in-world phrasing: the
+ * player must be able to read the arbitrage at a glance, and a fictional label
+ * ("routine", "funeste") reads as flavour, not as a warning. The numeric
+ * weighting behind it stays backend-side and is never sent to the client.
+ * @see 23-RUN-STRUCTURE.md §2
+ */
+export type QuestDanger = "easy" | "medium" | "hard";
+
+/**
+ * Duration tag shown on the contract board — an evening's shape, not a clock.
+ *
+ * Qualitative on purpose: minutes are an engine estimate that drifts with how
+ * the player actually plays, so publishing them would turn an honest hint into
+ * a promise the engine cannot keep. `targetDurationMinutes` stays internal.
+ * @see 23-RUN-STRUCTURE.md §1, §2
+ */
+export type QuestDuration = "short" | "long" | "major";
 
 /** Hard ceiling on generated floors. The engine cannot produce more. */
 export const MAX_CONTRACT_DEPTH = 7;
@@ -37,22 +77,60 @@ export const CONTRACT_DURATION_MINUTES: Record<ContractDepth, number> = {
 };
 
 /**
- * What the player accepts at the inn before setting out. A run is never
- * "an adventure" — it has a destination, a depth, and a payout owed only on
- * return.
+ * Minutes a non-dungeon contract is expected to run, by duration tag.
+ *
+ * A dungeon derives its minutes from its depth; the other families have no
+ * floors to derive from, so the tag *is* the source. The values line up with
+ * `CONTRACT_DURATION_MINUTES` so both kinds of contract answer the same
+ * question in the same units.
  * @see 23-RUN-STRUCTURE.md §1
+ */
+export const QUEST_DURATION_MINUTES: Record<QuestDuration, number> = {
+  short: 45,
+  long: 90,
+  major: 150,
+};
+
+/**
+ * What the player accepts at the inn before setting out. A run is never
+ * "an adventure" — it has a commissioner, a destination, a payout owed only on
+ * return, and conditions under which it fails.
+ *
+ * `targetDepth` is optional because the board is not a list of dungeons: an
+ * escort or a negotiation has no floors, and forcing a depth on it would make
+ * the engine lie about what the player accepted (#260).
+ * @see 23-RUN-STRUCTURE.md §1, §2
  */
 export interface RunContract {
   id: string;
+  /** What kind of work this is. Decides which rules the run runs under. */
+  family: QuestFamily;
   /** Location archetype the contract sends the player to. @see 03-BESTIARY.md */
   destination: string;
-  targetDepth: ContractDepth;
-  /** Target duration in minutes, derived from `targetDepth`. */
+  /** Who put the contract on the board, and who pays on return. */
+  commissioner: string;
+  /** Danger tag shown on the board. The weighting behind it stays internal. */
+  danger: QuestDanger;
+  /** Duration tag shown on the board. Minutes stay internal. */
+  duration: QuestDuration;
+  /**
+   * Floors to descend. Present only for `family: "dungeon"` — no other family
+   * has floors, and no rule may invent a depth for one that lacks it.
+   */
+  targetDepth?: ContractDepth;
+  /**
+   * Target duration in minutes: derived from `targetDepth` for a dungeon, from
+   * `duration` otherwise. Internal — never shown as a number to the player.
+   */
   targetDurationMinutes: number;
   /** What the commissioner pays on a successful return, in gold. */
   rewardGold: number;
   /** Player-facing description of what must be brought back. */
   objective: string;
+  /** What the backend checks to call the contract fulfilled. */
+  successCondition: string;
+  /** Every way the contract can be lost. Empty means death is the only failure. */
+  failureConditions: string[];
 }
 
 /** What a room holds. @see 23-RUN-STRUCTURE.md §2 */


### PR DESCRIPTION
Closes #260

## Le problème

Le tableau de contrats était une liste de donjons déguisée : `RunContract` exigeait un `targetDepth`, donc toute quête devait avoir des paliers. Une escorte ou une négociation n'en a pas — le moteur mentait sur ce que le joueur acceptait.

## Ce que livre cette PR

La **forme** du contrat, pas encore sa mesure.

- `QuestFamily` fermé sur 7 familles (`dungeon` | `escort` | `investigation` | `hunt` | `recovery` | `negotiation` | `dilemma`). Type fermé volontairement : une famille sans règles ne doit pas typechecker.
- `targetDepth` devient optionnel et **réservé à `dungeon`**. `createContract` lève si une autre famille en porte un ; le schéma Zod rejette les deux erreurs symétriques (donjon sans profondeur, non-donjon avec profondeur) plutôt que d'en ignorer une silencieusement.
- Nouveaux champs de contrat : `commissioner`, `danger`, `duration`, `successCondition`, `failureConditions`.
- `danger` / `duration` sont des **tags affichés** ; le chiffrage et les minutes restent internes. Publier des minutes transformerait une estimation qui dérive avec le jeu réel en promesse que le moteur ne peut pas tenir.
- `QUEST_DURATION_MINUTES` donne les minutes des familles sans paliers, alignées sur `CONTRACT_DURATION_MINUTES`, pour que les deux types de contrat répondent à la même question dans la même unité.

## Règles qui ne fabriquent plus de donjon

- `canDescend` → `false` sans paliers, plutôt qu'une profondeur inventée.
- `estimateRemainingMinutes` → retombe sur `targetDurationMinutes` du contrat au lieu de déduire une descente qui n'existe pas.

## Migration

Six colonnes nullables ajoutées, plus `UPDATE ... SET contractFamily = 'dungeon' WHERE contractId IS NOT NULL` : les contrats antérieurs étaient tous des donjons, autant le nommer explicitement plutôt que laisser le moteur l'inférer d'un null pour toujours. Appliquée via MCP Supabase (la CLI `prisma migrate` est cassée contre le pooler) et vérifiée contre `information_schema`.

Rétrocompatibilité : `readContract` lit une famille absente comme `dungeon`, et un tag illisible retombe au milieu de l'échelle (`medium` / `long`) — jamais sur `easy`, qui sous-vendrait un run que le joueur s'apprête à accepter.

## Vérification

- `pnpm type-check` : 3/3
- `pnpm lint` : 3/3 sans cache
- `pnpm test` : backend 706 tests / 41 fichiers, frontend 113 / 24 — tout passe

## Suite connue

[#269](https://github.com/AdamDjo/Grimoire-game/issues/269) reviendra partiellement sur cette PR : il rouvre la restriction « profondeur = donjon uniquement » pour la remplacer par une `intensity` universelle. **#260 livre la forme du contrat ; #269 livrera la mesure.**
