### PR TITLE
refactor(#275): supprimer le code mort backend

### DIFF
--- a/apps/backend/src/routes/aveugle.routes.test.ts
+++ b/apps/backend/src/routes/aveugle.routes.test.ts
@@ -12,7 +12,6 @@ const getAveugleHubState = vi.fn()
 const markTopicSeen = vi.fn()
 const generateAveugleTalkResponse = vi.fn()
 const spendSouvenirForLore = vi.fn()
-const priceForExchange = vi.fn()
 
 class SouvenirNotFoundError extends Error {}
 class SouvenirNotSpendableError extends Error {}
@@ -22,7 +21,6 @@ vi.mock('../services/aveugle.service', () => ({
   markTopicSeen,
   generateAveugleTalkResponse,
   spendSouvenirForLore,
-  priceForExchange,
   SouvenirNotFoundError,
   SouvenirNotSpendableError,
 }))
@@ -60,7 +58,6 @@ beforeEach(() => {
   markTopicSeen.mockReset()
   generateAveugleTalkResponse.mockReset()
   spendSouvenirForLore.mockReset()
-  priceForExchange.mockReset()
 })
 
 describe('GET /hub', () => {

--- a/apps/backend/src/routes/aveugle.routes.ts
+++ b/apps/backend/src/routes/aveugle.routes.ts
@@ -7,7 +7,6 @@ import {
   generateAveugleTalkResponse,
   getAveugleHubState,
   markTopicSeen,
-  priceForExchange,
   SouvenirNotFoundError,
   SouvenirNotSpendableError,
   spendSouvenirForLore,
@@ -178,6 +177,3 @@ aveugleRouter.post(
     }
   }
 )
-
-// Exported for the exchange price table the frontend may want to render.
-export { priceForExchange }

--- a/apps/backend/src/services/run.service.ts
+++ b/apps/backend/src/services/run.service.ts
@@ -13,7 +13,7 @@ import {
   type ReturnWarning,
 } from '../game-rules/run'
 
-import type { Character as DbCharacter, GameSession } from '../generated/prisma/client'
+import type { GameSession } from '../generated/prisma/client'
 import type {
   ContractDepth,
   GameMode,
@@ -326,9 +326,4 @@ export function detectThresholdCrossings(
   after: CarriedSupplies
 ): ReturnWarning[] {
   return detectReturnWarnings(nextState, before, after, previousState)
-}
-
-/** Convenience read of the supplies a character carries right now. */
-export function readSupplies(character: DbCharacter): CarriedSupplies {
-  return countCarriedSupplies(character.inventory as unknown as PersistedInventoryItem[])
 }


### PR DESCRIPTION
## Contexte

Passe `knip` sur le backend pour éliminer le code réellement mort.

## Ce qui est supprimé

- `run.service.ts` — `readSupplies()` : 0 appelant, 0 test. L'import `Character as DbCharacter` devenu orphelin part avec.
- `aveugle.routes.ts` — le re-export spéculatif `export { priceForExchange }` (commentaire : « the frontend may want to render ») et son import. Le mock correspondant dans `aveugle.routes.test.ts` disparaît aussi.

`priceForExchange` reste exporté depuis `aveugle.service.ts` : `aveugle.service.test.ts` le teste directement.

## Ce qui est volontairement laissé

`knip` signale 16 exports + 10 types de plus, tous des **faux positifs** : l'entry point backend est `src/index.ts`, donc knip ne traverse pas les `*.test.ts` ni ne voit l'usage intra-fichier. Chaque symbole a été vérifié par comptage de références :

- utilisés par les tests uniquement (ex. `engageReturn`, 8 références dans `run.test.ts`) ;
- utilisés dans leur propre fichier (ex. `FLEE_DC` / `COMMAND_DC` pilotent `combat.ts:452` et `:554`) — le mot-clé `export` est superflu, le code est vivant ;
- outillage hors graphe d'entrée (`eslint.config.js`, `prettier`, `@prisma/client`).

Aucun fichier jamais importé, aucun symbole top-level jamais référencé, aucun TODO/FIXME/@deprecated dans le backend.

## Vérifications

- `pnpm test --filter @grimoire/backend` : **706/706** (41 fichiers)
- `lint` + `type-check` verts
- `knip` : unused exports 18 → 16

Closes #275