### PR TITLE
fix(#279): remplacer la jauge fantôme de Cendre par Calamine

### DIFF
--- a/docs/canon/00-SOMMAIRE.md
+++ b/docs/canon/00-SOMMAIRE.md
@@ -10,7 +10,7 @@
 
 Le joueur incarne un aventurier — Marcheur-du-Sel, Lame-Ombre, Veilleur ou Tisse-Verbe — et vit une aventure complète en **3 à 15 heures**. À la fin du run, une **Chronique** est générée : le récit de son histoire. Le joueur peut recommencer avec la même vocation ou une autre — le **méta-monde** aura changé, et l'IA générera une toute nouvelle aventure.
 
-La **survie** est la pression de tous les jours. La **magie** est une tentation rare, corruptrice, qui coûte la **Cendre** — et peut mener à la **Calamine**.
+La **survie** est la pression de tous les jours. La **magie** est une tentation rare, corruptrice, qui coûte de la **Calamine** — et peut mener à la transformation en Calciné.
 
 Le jeu est en anglais, avec direction artistique dark fantasy désertique.
 

--- a/docs/canon/04-ATTRIBUTES.md
+++ b/docs/canon/04-ATTRIBUTES.md
@@ -178,17 +178,17 @@ Jet de dés = d20 + modificateur d'attribut + bonus de compétence
 
 ### Exemples concrets
 
-| Action                  | Attribut        | Jet                                                      |
-| ----------------------- | --------------- | -------------------------------------------------------- |
-| Frapper au sabre        | SANG            | d20 + mod SANG + compétence Mêlée                        |
-| Tirer à l'arc           | SOUFFLE         | d20 + mod SOUFFLE + compétence Tir                       |
-| Se cacher dans l'ombre  | SOUFFLE         | d20 + mod SOUFFLE + compétence Furtivité                 |
-| Persuader un garde      | VOLONTÉ         | d20 + mod VOLONTÉ + compétence Persuasion                |
-| Intimider un prisonnier | SANG ou VOLONTÉ | selon l'approche (force ou peur)                         |
-| Éveiller un artefact    | SOUFFLE         | d20 + mod SOUFFLE + compétence Éveil (ET coût en Cendre) |
-| Résister à un sort      | VOLONTÉ         | d20 + mod VOLONTÉ (jet de sauvegarde)                    |
-| Résister au poison      | SANG            | d20 + mod SANG (jet de sauvegarde)                       |
-| Survivre dans le désert | SANG            | d20 + mod SANG + compétence Survie                       |
+| Action                  | Attribut        | Jet                                                        |
+| ----------------------- | --------------- | ---------------------------------------------------------- |
+| Frapper au sabre        | SANG            | d20 + mod SANG + compétence Mêlée                          |
+| Tirer à l'arc           | SOUFFLE         | d20 + mod SOUFFLE + compétence Tir                         |
+| Se cacher dans l'ombre  | SOUFFLE         | d20 + mod SOUFFLE + compétence Furtivité                   |
+| Persuader un garde      | VOLONTÉ         | d20 + mod VOLONTÉ + compétence Persuasion                  |
+| Intimider un prisonnier | SANG ou VOLONTÉ | selon l'approche (force ou peur)                           |
+| Éveiller un artefact    | SOUFFLE         | d20 + mod SOUFFLE + compétence Éveil (ET coût en Calamine) |
+| Résister à un sort      | VOLONTÉ         | d20 + mod VOLONTÉ (jet de sauvegarde)                      |
+| Résister au poison      | SANG            | d20 + mod SANG (jet de sauvegarde)                         |
+| Survivre dans le désert | SANG            | d20 + mod SANG + compétence Survie                         |
 
 🟢 _Un attribut donné n'est pas figé à une action. Intimider peut être SANG (force) ou VOLONTÉ (peur) selon la manière décrite par le joueur. Le MJ IA interprète l'intention._
 
@@ -244,7 +244,7 @@ Les attributs influencent aussi les statistiques de survie (détail dans `06-SUR
 | Soif (résistance)      | SANG                                                          |
 | Fatigue (résistance)   | SANG                                                          |
 | Raison / Santé mentale | VOLONTÉ                                                       |
-| Cendre accumulée       | dépend de la magie utilisée (le Tisse-Verbe en accumule vite) |
+| Calamine accumulée     | dépend de la magie utilisée (le Tisse-Verbe en accumule vite) |
 
 ---
 
@@ -257,7 +257,7 @@ La magie est rare et coûteuse (voir `02-WORLD-BIBLE.md`). Le système est **uni
 - **Les artefacts** = la seule source de vraie magie. Chacun unique, chacun offre un pouvoir unique.
 - **Tout le monde** peut utiliser un artefact (pouvoir de base).
 - **Le Tisse-Verbe** est le seul à pouvoir **éveiller** un artefact (en tirer le pouvoir total). Il utilise son SOUFFLE pour "parler" à l'artefact.
-- **La Calamine** = le coût universel. Tout usage accumule de la Cendre dans le corps. Le Tisse-Verbe l'accumule plus vite.
+- **La Calamine** = le coût universel. Tout usage accumule de la Calamine dans le corps. Le Tisse-Verbe l'accumule plus vite.
 
 ### Quel attribut pour quel usage ?
 
@@ -302,7 +302,7 @@ La magie est rare et coûteuse (voir `02-WORLD-BIBLE.md`). Le système est **uni
 | ------------------------------------------------ | ----------------------------------------------------------------------------------- |
 | Trop simple par rapport à D&D (6 stats)          | La profondeur vient des **compétences** (~12) greffées sur les 3 attributs          |
 | Une vocation "meilleure" que les autres          | Balancing par playtests, chaque attribut a ses forces                               |
-| Le Tisse-Verbe trop puissant (magie = pouvoir)   | La magie coûte de la Cendre → Calamine → mort/transformations                       |
+| Le Tisse-Verbe trop puissant (magie = pouvoir)   | La magie coûte de la Calamine → paliers → mort/transformations                      |
 | Attributs inutiles pour une vocation (dump stat) | Compétences qui utilisent tous les attributs (même le magicien doit parfois courir) |
 
 ---

--- a/docs/canon/05-VOCATIONS.md
+++ b/docs/canon/05-VOCATIONS.md
@@ -252,7 +252,7 @@ VOLONTÉ   12  (+1)   ← la volonté de manier la Cendre
 
 ### Lentille narrative
 
-> _Tu vois le monde comme un champs de ruines endormies — chaque artefact est une voix étouffée, et toi seul peux la réveiller. Tu es un **Tisse-Verbe**, l'un des rares êtres capables d'**éveiller** les objets archontiques. Le pouvoir est là, tapi dans le sable doré, attendant qu'une main le saisisse. Mais chaque éveil te coûte de la **Cendre** — et la **Calamine** guette. Le Culte te traque, les Veilleurs te convoitent, et chaque artefact que tu pousses trop loin te rapproche de la transformation._
+> _Tu vois le monde comme un champs de ruines endormies — chaque artefact est une voix étouffée, et toi seul peux la réveiller. Tu es un **Tisse-Verbe**, l'un des rares êtres capables d'**éveiller** les objets archontiques. Le pouvoir est là, tapi dans le sable doré, attendant qu'une main le saisisse. Mais chaque éveil te coûte de la **Calamine** — et la transformation guette. Le Culte te traque, les Veilleurs te convoitent, et chaque artefact que tu pousses trop loin te rapproche de la transformation._
 
 ### Scènes privilégiées
 
@@ -273,7 +273,7 @@ VOLONTÉ   12  (+1)   ← la volonté de manier la Cendre
 - **Éveil (SOUFFLE)** — réveiller et pousser un artéfact archontique
 - **Érudition (SOUFFLE)** — lire les langues anciennes, identifier les artefacts
 - **Discrétion (SOUFFLE)** — cacher sa nature d'éveilleur
-- **Résistance à la Cendre (VOLONTÉ)** — retarder la Calamine (un peu)
+- **Résistance à la Cendre (VOLONTÉ)** — retarder la montée de Calamine (un peu)
 
 ### Tabous
 

--- a/docs/canon/06-SURVIVAL.md
+++ b/docs/canon/06-SURVIVAL.md
@@ -144,14 +144,19 @@ Valeurs normatives appliquées par le backend (`game-rules/rest.ts`). Toutes les
 
 ---
 
-## 4. La Cendre et la Calamine
+## 4. La Calamine
 
-La magie n'est jamais gratuite (voir `02-WORLD-BIBLE.md`). **Tout usage d'artefact** accumule de la **Cendre** dans le corps de l'aventurier. Aucun n'y échappe — mais tous ne payent pas au même rythme.
+La magie n'est jamais gratuite (voir `02-WORLD-BIBLE.md`). **Tout usage d'artefact** accumule de la **Calamine** dans le corps de l'aventurier. Aucun n'y échappe — mais tous ne payent pas au même rythme.
 
-- 🩸 **Aventuriers ordinaires** (Marcheur-du-Sel, Lame-Ombre, Veilleur) — accumulent de la Cendre uniquement quand ils déclenchent un artefact (pouvoir de base). Lent.
+> **Une seule jauge.** La Calamine est le coût magique unique de Velkhar : il n'existe pas de
+> seconde jauge de « Cendre ». La **Cendre** désigne la matière du monde (le fléau, les Cendreurs,
+> _Of Ash and Salt_) — jamais une ressource de personnage. Le moteur ne connaît qu'un champ,
+> `calamine` (0–100). Ne jamais réintroduire une jauge de Cendre.
+
+- 🩸 **Aventuriers ordinaires** (Marcheur-du-Sel, Lame-Ombre, Veilleur) — accumulent de la Calamine uniquement quand ils déclenchent un artefact (pouvoir de base). Lent.
 - 🔥 **Tisse-Verbe** — accumule à chaque **éveil**, beaucoup plus vite que les autres. C'est le prix de son don : il tire le pouvoir total des artefacts, mais sa Calamine progresse en compte à rebours accéléré.
 
-### La jauge de Cendre (0–100)
+### La jauge de Calamine (0–100)
 
 | Seuil | Effet            | Narration                                       |
 | ----- | ---------------- | ----------------------------------------------- |
@@ -161,17 +166,21 @@ La magie n'est jamais gratuite (voir `02-WORLD-BIBLE.md`). **Tout usage d'artefa
 | 75–99 | Stade 3          | transformation en _Calciné_ imminente           |
 | 100   | Transformation   | Le perso devient un Calciné → **mort du perso** |
 
-### Comment réduire la Cendre
+Implémentée par `calamineTier()` (`apps/backend/src/game-rules/conditions.ts`) : mêmes seuils.
 
-- 🟢 **Repos long** : -10 Cendre
-- 🟢 **Sœurs du Silence** (rituel au Culte) : -30 Cendre, mais coût (or, quête, secret)
-- 🟢 **Artefact purificateur** (rare) : -50 Cendre une fois
+### Comment réduire la Calamine
+
+La Calamine ne régénère pas et ne redescend jamais seule : elle ne baisse que sur une action explicite.
+
+- 🟢 **Repos long** : -10 Calamine
+- 🟢 **Sœurs du Silence** (rituel au Culte) : -30 Calamine, mais coût (or, quête, secret)
+- 🟢 **Artefact purificateur** (rare) : -50 Calamine une fois
 
 🟢 _Tout aventurier qui touche aux artefacts gère un compte à rebours. Le Tisse-Verbe vit ce dilemme à chaque scène (éveiller = puissance immédiate, Calamine plus proche), les autres vocations ne le rencontrent qu'aux moments où elles décident d'activer un artefact trouvé._
 
-### Sources d'accumulation de Cendre (contrat moteur)
+### Sources d'accumulation de Calamine (contrat moteur)
 
-La Cendre **ne monte jamais toute seule** : pas de drain passif par tour. Elle augmente uniquement sur un **événement source** identifié. Le backend applique le delta ; l'IA ne peut le **proposer** (via `applyCondition` avec `id: "cendre_corrupt"`) que si le contexte correspond à l'une des sources canon ci-dessous — sinon le delta est **rejeté**.
+La Calamine **ne monte jamais toute seule** : pas de drain passif par tour. Elle augmente uniquement sur un **événement source** identifié. Le backend applique le delta ; l'IA ne peut le **proposer** (via `applyCondition` avec `id: "cendre_corrupt"` — identifiant historique de la condition, conservé tel quel côté code) que si le contexte correspond à l'une des sources canon ci-dessous — sinon le delta est **rejeté**.
 
 | Source                                           | Delta indicatif | Qui déclenche         |
 | ------------------------------------------------ | --------------- | --------------------- |
@@ -203,7 +212,7 @@ appliquées.
 
 ### Paliers de Calamine (contrat moteur)
 
-Le backend applique les effets de palier automatiquement dès franchissement du seuil (cf. table §4 « jauge de Cendre »). À **100**, la transformation en Calciné est **immédiate et non réversible** → fin de run avec `endReason: "calcined"` (cf. `09-ACTION-LOOP §7`). Pas d'héritage transmis (artefact corrompu).
+Le backend applique les effets de palier automatiquement dès franchissement du seuil (cf. table §4 « jauge de Calamine »). À **100**, la transformation en Calciné est **immédiate et non réversible** → fin de run avec `endReason: "calcined"` (cf. `09-ACTION-LOOP §7`). Pas d'héritage transmis (artefact corrompu).
 
 ---
 
@@ -280,17 +289,17 @@ appliqué.
 
 L'équipement de survie est **stocké en base** et injecté dans le prompt du MJ IA (voir `11-INVENTORY-ECONOMY.md`).
 
-| Équipement           | Effet sur la survie                                                 |
-| -------------------- | ------------------------------------------------------------------- |
-| Gourde               | + capacité d'eau, ralentit la soif                                  |
-| Vêtements du désert  | Résistent à la chaleur diurne et au gel nocturne                    |
-| Tente / toile        | Repos plus sûr, protège du Ventre-Gris                              |
-| Bandages             | Soin lors du repos                                                  |
-| Antidote             | Retire l'empoisonnement                                             |
-| Nourriture séchée    | Restaure la faim sans chasse                                        |
-| Boussole archontique | + navigation                                                        |
-| Outre de Cendre      | Permet au Tisse-Verbe de stocker de la Cendre (retarde la Calamine) |
-| Masque filtrant      | Protège du Ventre-Gris et des marais                                |
+| Équipement           | Effet sur la survie                                                        |
+| -------------------- | -------------------------------------------------------------------------- |
+| Gourde               | + capacité d'eau, ralentit la soif                                         |
+| Vêtements du désert  | Résistent à la chaleur diurne et au gel nocturne                           |
+| Tente / toile        | Repos plus sûr, protège du Ventre-Gris                                     |
+| Bandages             | Soin lors du repos                                                         |
+| Antidote             | Retire l'empoisonnement                                                    |
+| Nourriture séchée    | Restaure la faim sans chasse                                               |
+| Boussole archontique | + navigation                                                               |
+| Outre de Cendre      | Absorbe une part de la Calamine du Tisse-Verbe (retarde le palier suivant) |
+| Masque filtrant      | Protège du Ventre-Gris et des marais                                       |
 
 🟢 _Le MJ IA prend en compte l'équipement du joueur : "Ta gourde est vide depuis deux jours" ou "Ton masque filtrant grésille, le Ventre-Gris approche."_
 

--- a/docs/canon/08-DICE-RESOLUTION.md
+++ b/docs/canon/08-DICE-RESOLUTION.md
@@ -209,14 +209,14 @@ Le MJ IA génère des conséquences **fertiles** (voir `01-PILLARS.md`).
 - **Combat** : coup fatal, l'ennemi est désarmé, le sang gicle, les alliés dégainent
 - **Persuasion** : le garde devient un allié, offre une information, te laisse passer avec respect
 - **Furtivité** : tu disparais totalement, tu surprends une conversation, tu trouves une cachette parfaite
-- **Artefact** : l'effet est amplifié, ne coûte pas de Cendre cette fois, révèle une propriété oubliée
+- **Artefact** : l'effet est amplifié, ne coûte pas de Calamine cette fois, révèle une propriété oubliée
 
 ### Nat 1 — exemples
 
 - **Combat** : l'arme se coince, glisse, se brise
 - **Persuasion** : ton argument se retourne contre toi, le PNJ se ferme définitivement
 - **Furtivité** : tu fais du bruit, tu tombes sur un objet bruyant, un garde te repère
-- **Artefact** : l'effet se retourne, la Cendre accumulée est double, tu te blesses sur le coup
+- **Artefact** : l'effet se retourne, la Calamine accumulée est double, tu te blesses sur le coup
 
 🟢 _Le nat 1 doit créer de la situation, pas de la frustration._
 

--- a/docs/canon/09-ACTION-LOOP.md
+++ b/docs/canon/09-ACTION-LOOP.md
@@ -187,7 +187,7 @@ L'éveil suit un flux **particulier** parce que c'est le geste central du Tisse-
    ┌──────────────────────────────────────────┐
    │  Tu poses la main sur la Clé d'Ombre.    │
    │  Effet de base : tu désactives un piège. │
-   │  Coût : 10 Cendre.                       │
+   │  Coût : 10 Calamine.                     │
    │                                           │
    │  Veux-tu tenter une AMPLIFICATION ?       │
    │  → d20 + SOUFFLE vs DC 14                 │
@@ -198,11 +198,11 @@ L'éveil suit un flux **particulier** parce que c'est le geste central du Tisse-
    │  [ EFFET DE BASE ]  [ TENTER AMPLI ]      │
    └──────────────────────────────────────────┘
    ↓
-3a. Si EFFET DE BASE → l'effet a lieu, Cendre payée, on continue
+3a. Si EFFET DE BASE → l'effet a lieu, Calamine payée, on continue
 3b. Si AMPLIFICATION → roule d20
     ├── Réussite : effet majeur + bonus
     └── Échec    : juste effet de base
-    (Cendre payée UNE SEULE FOIS)
+    (Calamine payée UNE SEULE FOIS)
 ```
 
 🟢 _Règle d'or : l'éveil ne rate **jamais** totalement. Le joueur paye, le joueur reçoit au minimum l'effet de base._
@@ -227,7 +227,7 @@ L'IA bascule d'acte selon :
 
 - **Le rythme** (~30% du run en Installation, ~50% en Complications, ~20% en Climax)
 - **Les actions du joueur** (s'il fonce vers un boss, le climax arrive plus tôt)
-- **Les conditions de survie** (si la Cendre monte vers 80, l'IA pousse vers le climax)
+- **Les conditions de survie** (si la Calamine monte vers 80, l'IA pousse vers le climax)
 - **Les quêtes en cours** (une quête majeure résolue peut déclencher le climax)
 
 🟢 _Le joueur ressent le crescendo sans le voir. C'est exactement le but d'un bon récit : tu sais qu'il se passe quelque chose, pas comment ça marche._
@@ -266,7 +266,7 @@ secours, mort). Si mort effective → run terminé, Chronique générée, hérit
 
 ### 🌀 Fin par la Calamine
 
-Si la Cendre atteint 100 → transformation en Calciné → le perso devient un monstre du bestiaire. Run terminé, Chronique générée avec **fin spéciale** ("Tu es devenu ce que tu chassais"). Pas d'héritage transmis (l'artefact est corrompu).
+Si la Calamine atteint 100 → transformation en Calciné → le perso devient un monstre du bestiaire. Run terminé, Chronique générée avec **fin spéciale** ("Tu es devenu ce que tu chassais"). Pas d'héritage transmis (l'artefact est corrompu).
 
 ### Contrat moteur — `endReason`
 

--- a/docs/canon/10-COMBAT.md
+++ b/docs/canon/10-COMBAT.md
@@ -143,8 +143,8 @@ Voir §5. Le joueur **utilise sa voix** pour modifier le champ de bataille.
 
 Le joueur active un artefact (toute vocation, 1×/scène, voir `11-INVENTORY-ECONOMY §5`) :
 
-- **Pouvoir de base** : 1d8 dégâts ou effet narratif, coûte 5 Cendre
-- **Éveil** (Tisse-Verbe seul) : effet majeur garanti + d20 amplification, coûte 10 Cendre
+- **Pouvoir de base** : 1d8 dégâts ou effet narratif, coûte 5 Calamine
+- **Éveil** (Tisse-Verbe seul) : effet majeur garanti + d20 amplification, coûte 10 Calamine
 
 🟢 _L'artefact en combat = "spell slot" thématique. Précieux, à choisir au bon moment._
 
@@ -363,7 +363,7 @@ Pas de niveau, pas d'XP cumulatif. Les récompenses sont **immédiates et narrat
 | **TPK frustrant**                              | À 0 PV → inconscience d'abord, l'IA décide. Captivité = nouvelle scène, pas game over                             |
 | **Combat trash systématique**                  | Les ennemis ne sont jamais "pour XP". Chaque combat = enjeu narratif (lettre, contrat, témoin)                    |
 | **VOLONTÉ inutile**                            | Le rôle Leader est core, pas optionnel. Les builds VOLONTÉ doivent briller en combat                              |
-| **Tisse-Verbe OP**                             | Coût Cendre élevé (10/éveil), risque Calamine (cf. `06-SURVIVAL §4`), max 1-2 éveils par combat avant danger      |
+| **Tisse-Verbe OP**                             | Coût élevé (10 Calamine/éveil), risque de palier (cf. `06-SURVIVAL §4`), max 1-2 éveils par combat avant danger   |
 | **Fuite abusée**                               | Coût en dégâts + perte d'or potentielle + désavantage si échec                                                    |
 | **Joueur ne comprend pas pourquoi il a perdu** | Transparence dés (cf. `08-DICE §4`) + narration IA des dégâts (_"Le sabre traverse ton cuir, tu chancelles"_)     |
 

--- a/docs/canon/11-INVENTORY-ECONOMY.md
+++ b/docs/canon/11-INVENTORY-ECONOMY.md
@@ -324,7 +324,7 @@ Les artefacts sont **la seule source de pouvoir magique** dans Velkhar (cf. déc
 
 ### Le prix est toujours de la Calamine
 
-Chaque activation **coûte de la Calamine** — la Cendre qui s'accumule dans le corps du porteur
+Chaque activation **coûte de la Calamine** — la Cendre du monde qui s'accumule dans le corps du porteur
 (`06-SURVIVAL §4`, `02-WORLD-BIBLE`). C'est la boucle centrale de la magie de Velkhar :
 
 ```
@@ -345,7 +345,7 @@ L'arbitrage est permanent, et il se joue surtout au **retour** :
 
 ```
 - Usable 1× par scène
-- Coûte 5 Cendre (cf. 06-SURVIVAL §4)
+- Coûte 5 Calamine (cf. 06-SURVIVAL §4)
 - 1d8 dégâts OU effet narratif mineur défini par l'artefact
 - Le joueur ne connaît que l'effet de base (sauf si identifié)
 ```
@@ -356,11 +356,11 @@ L'arbitrage est permanent, et il se joue surtout au **retour** :
 
 ```
 - Usable 1× par scène
-- Coûte 10 Cendre
+- Coûte 10 Calamine
 - Effet majeur garanti (effet d'éveil défini par l'artefact)
 - Option d'amplification : d20 + SOUFFLE + VOLONTÉ + Éveil  vs  DC artefact
   → Succès : effet amplifié (dégâts doublés, zone élargie, condition spéciale)
-  → Échec : juste effet de base (Cendre payée UNE SEULE FOIS)
+  → Échec : juste effet de base (Calamine payée UNE SEULE FOIS)
 ```
 
 🟢 _L'éveil ne rate **jamais** totalement. Le Tisse-Verbe paye et reçoit toujours au minimum l'effet de base._
@@ -562,7 +562,7 @@ Le butin n'est jamais compté au moment où on le ramasse, seulement au moment o
 | **Artefact d'héritage abusé**                     | Dégradation après 3-4 transmissions. Garantit le besoin de trouver de nouveaux artefacts                                 |
 | **Souvenirs accumulés sans usage**                | L'Aveugle propose **toujours** des achats au retour. Le joueur ne doit jamais se demander "que faire de mes Souvenirs ?" |
 | **Mort frustrante (perte de 200 🪙)**             | Banque de L'Aveugle. Et l'héritage minimise la perte ressentie                                                           |
-| **Joueur qui spam les artefacts non-Tisse-Verbe** | Coût Cendre (5/usage) accumule la Calamine. Risque réel à long terme                                                     |
+| **Joueur qui spam les artefacts non-Tisse-Verbe** | Coût de 5 Calamine par usage, cumulatif. Risque réel à long terme                                                        |
 | **Donjon vide / sans loot**                       | Règle absolue : tout donjon termine sur **au moins** 1 récompense substantielle                                          |
 
 ---
@@ -602,10 +602,10 @@ Le butin n'est jamais compté au moment où on le ramasse, seulement au moment o
 ║                                                                    ║
 ║  ARTEFACTS                               HÉRITAGE                  ║
 ║  ─────────────────────────              ──────────────────────     ║
-║  Pouvoir de base : 1d8, 5 Cendre        1 artefact transmis        ║
+║  Pouvoir de base : 1d8, 5 Calamine      1 artefact transmis        ║
 ║   (toute vocation, 1×/scène)            Dégrade 3-4 runs           ║
 ║                                                                    ║
-║  Éveil (Tisse-Verbe) : 10 Cendre        + écho réputation/         ║
+║  Éveil (Tisse-Verbe) : 10 Calamine      + écho réputation/         ║
 ║   effet majeur garanti                    savoir mineur            ║
 ║   + amplif optionnelle (d20)                                       ║
 ║                                                                    ║

--- a/docs/canon/22-GLOSSARY.md
+++ b/docs/canon/22-GLOSSARY.md
@@ -52,14 +52,19 @@ Phénomène mystique du Makhzen : brume scintillante qui apparaît au crépuscul
 ## C
 
 **Calamine** _⚙️ Mécanique + 🌍 Lore_
-Coût magique unifié de Velkhar. Chaque action magique consomme de la Calamine (ressource interne au perso). Régénère lentement (au repos) ou rapidement (rituels). Représente le **prix charnel** de la magie — le corps brûle, littéralement.
-→ [10-COMBAT](10-COMBAT.md), [11-INVENTORY-ECONOMY](11-INVENTORY-ECONOMY.md)
-⚠️ Ne pas confondre avec **VOLONTÉ** (stat) ni avec **Calcinés** (lore).
+Coût magique unifié de Velkhar, et **seule jauge magique du jeu** : une valeur `calamine` de 0 à 100 par personnage. Chaque action magique en **accumule** (5 par usage d'artefact, 10 par éveil). Elle ne redescend jamais seule — seuls un repos long (−10), un rituel des Sœurs du Silence (−30) ou un artefact purificateur (−50) la réduisent. À 100, le personnage devient un Calciné : fin de run. Représente le **prix charnel** de la magie — le corps brûle, littéralement.
+→ [06-SURVIVAL §4](06-SURVIVAL.md), [10-COMBAT](10-COMBAT.md), [11-INVENTORY-ECONOMY](11-INVENTORY-ECONOMY.md)
+⚠️ Ne pas confondre avec **VOLONTÉ** (stat), **Calcinés** (lore) ni **Cendre** (la matière du monde). Il n'existe **pas** de jauge de « Cendre » : c'est la Calamine.
 
 **Calcinés (Les)** _🌍 Lore_
 Êtres tordus par un excès de Calamine — anciens mages, fanatiques, victimes de rituels ratés. Forme ennemie récurrente. Hybrides humain / cendre / pierre. Souvent muets, parfois prophétiques.
 → `docs/canon/`, [10-COMBAT](10-COMBAT.md)
 ⚠️ Lore distinct des Calmes (peuple Cendreur) — phonétique proche, sens opposés.
+
+**Cendre (La)** _🌍 Lore_
+La poussière dorée qui recouvre Velkhar : la magie des Archontes dispersée après le cataclysme. Trois formes — sable doré (partout, toléré), brume dorée (concentrée, mortelle), et **Calamine** lorsqu'elle s'accumule dans un corps humain. Matière du monde, jamais une ressource de personnage.
+→ [02-WORLD-BIBLE §3](02-WORLD-BIBLE.md), [06-SURVIVAL §4](06-SURVIVAL.md)
+⚠️ **Pas une jauge.** Ce qu'un personnage accumule s'appelle **Calamine**. L'attribut autrefois nommé CENDRE est devenu **VOLONTÉ** (#264).
 
 **Cendreurs** _🌍 Lore_
 Peuple mystique des hauts plateaux volcaniques. Voix elliptique, foi profonde dans la combustion sacrée, gardiens de rituels Calamine. Variante PNJ : voix mystique, métaphores.

--- a/packages/shared/src/types/character.types.ts
+++ b/packages/shared/src/types/character.types.ts
@@ -73,7 +73,7 @@ export interface SurvivalStats {
   thirst: number;
   hunger: number;
   energy: number;
-  /** Accumulated Cendre corruption (0–100). 100 = death (Calciné). */
+  /** Accumulated Calamine (0–100), the single magic cost gauge. 100 = death (Calciné). */
   calamine: number;
   /** True after the first 0-HP hit: one telegraphed turn of reprieve before a second 0-HP hit is definitive death. */
   isDying: boolean;


### PR DESCRIPTION
Closes #279

Le canon décrivait une « jauge de Cendre (0–100) » alors que le moteur n'a jamais eu qu'un seul champ `calamine`. Le canon avait donc un mot en trop, pas le code — la correction est documentaire.

## Vérité terrain vérifiée avant de trancher

- `schema.prisma` : `calamine Int`, aucune colonne `cendre`/`ash`
- `character.types.ts` : `calamine: number`
- `calamineTier()` implémente exactement les seuils 25/50/75/100 de la table canon

## Changements

Renommé en Calamine **uniquement** là où le terme désignait le coût payé par le personnage : jauge et paliers (`06-SURVIVAL`), coûts chiffrés 5/10 (`10-COMBAT`, `11-INVENTORY-ECONOMY`, `09-ACTION-LOOP`), réduction −10/−30/−50, sources d'accumulation, et les renvois dans `04-ATTRIBUTES`, `08-DICE-RESOLUTION`, `05-VOCATIONS`, `00-SOMMAIRE`.

Ajout d'un encadré dans `06-SURVIVAL §4` qui interdit explicitement de réintroduire une jauge de Cendre.

## Conservé intact

- Tout le **lore** : Cendre-matière, Culte des Cendres, Cendreurs, loot du bestiaire
- `cendre_corrupt` — identifiant réel de condition dans le code, simplement annoté comme historique
- `02-WORLD-BIBLE §3` qui définit correctement Calamine = « Cendre accumulée dans un corps humain »

## Deux défauts trouvés en passant

- Le glossaire affirmait que la Calamine « régénère lentement au repos » — l'inverse exact de la mécanique : elle s'accumule et ne baisse que sur action explicite. Corrigé, avec ajout de l'entrée **Cendre (La)** qui manquait alors que le canon met en garde contre la confusion.
- Le commentaire de `character.types.ts` portait lui-même la contradiction (« Accumulated Cendre corruption » sur le champ `calamine`). Corrigé.

Également : alignement d'une ligne de tableau markdown cassée dans `AGENTS.md`.

## Vérifications

- `pnpm type-check` vert sur les 3 packages
- 41 tests `conditions` verts
- Aucun impact fonctionnel : le seul changement hors docs est un commentaire