### PR TITLE
docs(#281): gore signifiant, humour de potence et dread — positionnement Blasphemous/Darkest Dungeon

### DIFF
--- a/docs/canon/01-PILLARS.md
+++ b/docs/canon/01-PILLARS.md
@@ -138,14 +138,64 @@ GRIMOIRE navigue entre trois influences :
 - **RPG narratif** (Baldur's Gate 3, Disco Elysium) — choix moraux complexes, personnages qui comptent
 - **Roguelike** (Hades, Slay the Spire) — mort qui avance le méta, rejouabilité, progression entre les runs
 
+### Le positionnement de ton _(ajout 2026-08-15, #281)_
+
+> **Le monde est _Blasphemous_. La voix est _Darkest Dungeon_.**
+
+C'est la formule qui tranche toutes les hésitations de registre. Elle sépare **ce qu'on montre** de
+**comment on le raconte** :
+
+| Couche                                       | Registre                | Ce que ça donne concrètement                                                                               |
+| -------------------------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Le monde** (lieux, factions, iconographie) | Horreur sacrée baroque  | Masques votifs, cloches, étiquettes accrochées aux morts, Calcinés, reliquaires, rituels sans pitié        |
+| **La voix** (narration, PNJ, descriptions)   | Sec, ironique, constaté | Litote, phrase courte, chute pince-sans-rire — jamais de lyrisme liturgique qui commente sa propre gravité |
+
+Sans cette séparation, les deux registres s'annulent : un monde baroque **raconté** en liturgie
+devient pompeux, et une voix sèche appliquée à un monde neutre devient plate. Le contraste — image
+atroce, ton posé — est **la** signature de GRIMOIRE.
+
+Détail d'application de la voix : `15-GAME-MASTER §1.2`.
+
+### L'humour de potence _(ajout 2026-08-15, #281)_
+
+L'interdit « humour briseur de ton » ci-dessous **ne bannit pas le rire** : il bannit le rire qui
+sort le joueur du monde. L'humour autorisé est **l'humour de potence** — celui de gens qui vivent
+au milieu de l'horreur et l'ont banalisée.
+
+| ✅ Humour de potence (autorisé)                                       | ❌ Humour briseur (interdit)                   |
+| --------------------------------------------------------------------- | ---------------------------------------------- |
+| La litote sur l'atroce (_« Le péage reste ouvert. »_)                 | La vanne qui s'adresse au joueur               |
+| Un PNJ qui traite l'horreur comme de la routine administrative        | Le clin d'œil méta / la référence moderne      |
+| Le constat sec en fin de scène (_« Évidemment. »_)                    | Le personnage qui se moque de son propre monde |
+| L'absurde bureaucratique appliqué à la mort (trier, étiqueter, taxer) | Le running gag, la parodie                     |
+
+**Règle de dosage : une chute sèche maximum par scène.** Deux chutes dans la même narration = la
+scène devient un sketch, la tension meurt. Si le tour est déjà court ou tendu, aucune chute.
+
+### Le budget gore _(ajout 2026-08-15, #281)_
+
+Le gore n'est pas une intensité, c'est un **signal**. Un corps mutilé dans GRIMOIRE dit toujours
+quelque chose de mécanique : ce qui vit ici, ce qui est arrivé au dernier passant, ce qui attend le
+joueur au prochain tour.
+
+- **Une image forte maximum par scène.** Au-delà, l'horreur devient un bruit de fond que le joueur
+  scanne au lieu de lire.
+- **Gore signifiant uniquement.** Si l'image ne renseigne pas le joueur sur une menace, un lieu ou
+  une règle du monde, elle ne mérite pas ses tokens.
+- **Le corps est une information, pas une décoration.** Blessure localisée, marques de dents,
+  brûlure d'archonte : chaque détail doit être lisible comme un indice (cf. `09-ACTION-LOOP §3bis`).
+- **Jamais de complaisance** : la torture longue, le détail anatomique gratuit et la souffrance
+  d'enfant restent hors périmètre — public 18+ ne veut pas dire absence de goût.
+
 ### Trucs à éviter absolument
 
-- Humour briseur de ton (style Marvel)
+- Humour briseur de ton (style Marvel) — **mais l'humour de potence est autorisé, voir ci-dessus**
 - Power fantasy de surpuissance
 - Poncifs D&D (elfes/nains/orcs génériques)
 - Moralité binaire Bien/Mal
 - Exposition pavée
 - Gameplay qui étouffe la narration
+- Gore décoratif : une horreur qui n'apprend rien au joueur
 
 ### Trucs à viser
 
@@ -155,6 +205,9 @@ GRIMOIRE navigue entre trois influences :
 - Langage sensoriel : le sable, la soif, la lumière rasante, le silence
 - Lenteur comme outil narratif
 - La mort comme moment de récit, pas de frustration
+- **Humour de potence** : le constat sec sur l'atroce, une chute par scène maximum
+- **Gore signifiant** : une image forte par scène, qui renseigne toujours sur une menace
+- **Le présage** : le joueur doit pouvoir deviner ce qui l'attend s'il lit bien (cf. `09-ACTION-LOOP §3bis`)
 
 ---
 

--- a/docs/canon/06-SURVIVAL.md
+++ b/docs/canon/06-SURVIVAL.md
@@ -95,6 +95,35 @@ Le backend possède toutes les règles (cf. `15-GAME-MASTER §0`). Les condition
 
 🟢 _Règle : une condition non présente dans la table ci-dessus (id inconnu) est **rejetée** par le backend. L'IA ne peut pas inventer de condition._
 
+### La localisation des blessures _(ajout 2026-08-15, #281)_
+
+La condition `wound` porte désormais une **localisation persistée**. Objectif : le corps du
+personnage devient une **information lisible**, pas un compteur abstrait — le joueur se souvient de
+_ce qui lui est arrivé_, et l'IA a de quoi le lui rappeler à chaque scène.
+
+```ts
+wound: {
+  id: "wound",
+  location: "head" | "torso" | "left_arm" | "right_arm" | "left_leg" | "right_leg" | "hand" | "eye",
+  cause: string        // court, narratif : "morsure", "brûlure d'archonte", "lame ébréchée"
+}
+```
+
+- La **localisation est décidée par le backend** au moment où la condition est appliquée
+  (`wound` est une condition [BACKEND], cf. ci-dessus). L'IA ne la choisit pas — elle la **narre**.
+- Elle est **persistée sur le personnage** et réinjectée en contexte à chaque tour
+  (`{blessures_localisées_actives}`, cf. `15-GAME-MASTER §6`) : une jambe blessée reste une jambe
+  blessée trois scènes plus tard, dans la prose comme dans la mémoire du joueur.
+- **Aucun effet mécanique différencié en V1** : toutes les localisations produisent le même
+  Désavantage. La localisation est **narrative et mnémonique** — pas un système de dégâts
+  localisés. (Un malus par membre est explicitement **hors périmètre V1** : coût d'équilibrage
+  disproportionné pour un roguelike de 2h.)
+- Plusieurs `wound` de localisations différentes peuvent coexister ; le Désavantage, lui, **ne
+  s'empile pas** (cf. `08-DICE-RESOLUTION §5`).
+
+🟢 _Règle d'écriture : la blessure doit apparaître dans la narration quand elle gêne l'action tentée
+— jamais comme un rappel systématique en début de chaque scène._
+
 ### Traduction mécanique de l'effet « désavantage »
 
 Les conditions sévères n'appliquent **pas** de malus plat au d20. Elles imposent le **Désavantage** (2d20, garder le pire) — le mécanisme canon décrit dans `08-DICE-RESOLUTION §5`. Cela remplace toute lecture « -1 / -2 au jet » de la table pour l'implémentation moteur : le moteur applique le désavantage, l'affichage indique au joueur pourquoi.
@@ -167,6 +196,38 @@ La magie n'est jamais gratuite (voir `02-WORLD-BIBLE.md`). **Tout usage d'artefa
 | 100   | Transformation   | Le perso devient un Calciné → **mort du perso** |
 
 Implémentée par `calamineTier()` (`apps/backend/src/game-rules/conditions.ts`) : mêmes seuils.
+
+### Les hallucinations de Calamine _(ajout 2026-08-15, #281)_
+
+À partir du **stade 2 (Calamine ≥ 50)**, la corruption ne se contente plus de saigner le corps :
+elle **abîme ce que le personnage perçoit**. Le backend expose alors un drapeau de contexte à l'IA :
+
+```ts
+hallucinationAllowed: boolean; // true dès calamine >= 50
+```
+
+Ce que le drapeau autorise, et rien de plus :
+
+| ✅ Autorisé quand le drapeau est vrai                        | ❌ Interdit en toutes circonstances                |
+| ------------------------------------------------------------ | -------------------------------------------------- |
+| Une silhouette au bord du champ de vision, qui n'est plus là | Un PNJ halluciné listé dans `npcs_present`         |
+| Une voix connue qui appelle depuis un lieu vide              | Un objet halluciné proposé via `itemGained`        |
+| Une odeur, un bruit, une texture qui n'existent pas          | Un chiffre, une jauge, un résultat de dé faussé    |
+| Un détail du décor qui change entre deux phrases             | Une sortie, un chemin ou un choix qui n'existe pas |
+
+> **Règle absolue : l'hallucination est une ambiance, jamais une décision de jeu.**
+>
+> Le contrat `15-GAME-MASTER §0` reste entier — l'IA ne décide rien. Les validations de
+> `15-GAME-MASTER §4.2` (PNJ ∈ catalogue, item ∈ catégories connues) s'appliquent **inchangées**
+> même quand `hallucinationAllowed` est vrai. Un joueur peut douter de ce qu'il voit ; il ne doit
+> **jamais** douter de ce que l'UI lui affiche.
+
+- **Une hallucination maximum par scène**, et seulement si elle sert la tension.
+- L'IA ne **signale jamais** qu'il s'agit d'une hallucination : pas de _« peut-être une illusion »_.
+  Le doute appartient au joueur.
+- Au **stade 3 (≥ 75)**, la fréquence augmente mais les interdits ci-dessus ne bougent pas.
+- 🟢 _Lecture design : c'est la contrepartie perceptive du pacte magique. Plus le personnage tire
+  sur les artefacts, moins sa lecture du monde est fiable — mais le jeu, lui, reste honnête._
 
 ### Comment réduire la Calamine
 

--- a/docs/canon/09-ACTION-LOOP.md
+++ b/docs/canon/09-ACTION-LOOP.md
@@ -130,6 +130,32 @@ Les choix proposés sont **générés à chaque tour** par l'IA selon la scène.
 | **Adaptés à la vocation**                            | Un Tisse-Verbe voit "Tu sens un artefact dans cette ruine" qu'un Marcheur ne voit pas |
 | **Adaptés aux conditions**                           | Si le perso a la fièvre, "Se reposer ici" peut apparaître en priorité                 |
 | **Adaptés à la phase narrative**                     | En climax (acte 3 invisible, cf. §6), pas de choix "explorer un bâtiment au hasard"   |
+| **L'option vorace** _(#281)_                         | Une option qui offre un gain clair **et** annonce son prix — voir ci-dessous          |
+
+### L'option vorace _(ajout 2026-08-15, #281)_
+
+Parmi les 3-4 choix, **au moins un tour sur trois** propose une **option vorace** : un choix dont le
+bénéfice est explicite et immédiat, et dont le coût est **annoncé sans être chiffré**.
+
+- Le gain est **lisible** : de l'eau, un raccourci, une information, un artefact.
+- Le prix est **signalé mais flou** : un détail de la narration dit ce qu'on risque, jamais combien.
+- Le joueur doit pouvoir se dire _« j'y vais quand même »_ — et se souvenir qu'il l'a choisi.
+
+**Ce que ce n'est pas** :
+
+- ❌ Un piège aveugle. Un coût jamais annoncé est du RNG punitif, pas un dilemme (`01-PILLARS §9` :
+  la mort doit rester imputable au joueur).
+- ❌ Un choix optimal déguisé. Si le bon calcul est toujours « ne pas y aller », l'option est morte.
+- ❌ Un label qui chiffre le coût (_« -15 PV »_) — le label reste narratif, le moteur calcule.
+
+**Exemple** :
+
+> _Le puits est plein. L'eau est claire. Deux corps flottent au fond, gonflés, les mains encore
+> attachées au seau._
+
+1. 💧 Boire quand même, longuement _(option vorace : soif comblée, et l'eau a servi à autre chose)_
+2. 🪣 Remplir une gourde, ne pas boire ici _(pragmatique)_
+3. 🚶 Repartir, la gorge sèche _(prudente)_
 
 ### Exemple
 
@@ -141,6 +167,51 @@ Les choix proposés sont **générés à chaque tour** par l'IA selon la scène.
 2. 🪙 Aller au bar, commander un verre, attendre _(option pragmatique)_
 3. 👁️ Observer la salle, chercher une sortie discrète _(option RP/SOUFFLE)_
 4. ✍️ _Autre action_
+
+---
+
+## 3bis. Le cadavre-présage _(ajout 2026-08-15, #281)_
+
+> **Le joueur doit voir la conséquence avant la cause.**
+
+C'est le mécanisme qui transforme la lecture en anticipation : avant qu'une menace n'arrive, Velkhar
+en montre le **résultat sur quelqu'un d'autre**. Le joueur qui lit bien devine ; celui qui scanne
+subit. Dans les deux cas, la surprise est **méritée** — jamais gratuite.
+
+### Le principe
+
+Un lieu dangereux ne s'annonce pas par une phrase d'avertissement, mais par un **corps, un objet ou
+une trace** qui raconte ce qui est arrivé au précédent :
+
+| Le présage montre…                                | Le joueur peut en déduire…              |
+| ------------------------------------------------- | --------------------------------------- |
+| Des marques de dents sur un os propre             | Ce qui vit ici mange, et mange souvent  |
+| Une gourde pleine à côté d'un mort desséché       | Ce n'est pas la soif qui l'a tué        |
+| Des bottes triées par pointure devant un Calciné  | Il y a eu beaucoup de passants ici      |
+| Une cloche votive décrochée, cordon coupé         | Quelqu'un a voulu empêcher l'alerte     |
+| Un masque votif encore chaud, sans visage dessous | Ce qui portait ce masque est parti seul |
+
+### Les règles
+
+- **Un présage par lieu dangereux, pas par tour.** L'accumulation banalise le signal.
+- **Le présage précède toujours la menace** — jamais dans le même tour que sa réalisation.
+- **Il tient la promesse** : ce qui est annoncé arrive dans les **3 tours**, ou est **démenti de
+  façon signifiante** (le monstre était déjà mort, quelqu'un l'a tué avant toi). Un présage sans
+  suite entraîne le joueur à ne plus lire — c'est l'anti-objectif.
+- **Il ne dit jamais la règle**, il montre son effet. Pas de _« attention, cette eau est
+  empoisonnée »_ : un mort à côté du puits, gourde pleine.
+- Le tour qui porte un présage prend le **mood `dread`** (cf. `15-GAME-MASTER §4.1`), pas
+  `dangerous` : la menace n'est pas encore là.
+
+### Le contrat moteur
+
+L'IA déclare son présage via le champ optionnel `foreshadow` (cf. `15-GAME-MASTER §4.1`) :
+l'indice est **déjà dans la narration**, le champ le rend seulement lisible par le backend, qui le
+persiste et le réinjecte en contexte tant qu'il n'est pas résolu (3 tours max). Le joueur ne voit
+jamais le champ `threat` — seulement l'indice, dans la prose.
+
+🟢 _Lien pilier : c'est la traduction mécanique de « le joueur doit chercher à savoir ce qui va lui
+arriver » (`01-PILLARS §4`, Trucs à viser)._
 
 ---
 

--- a/docs/canon/14-META-WORLD.md
+++ b/docs/canon/14-META-WORLD.md
@@ -224,6 +224,36 @@ Seulement **3 catégories** de traces persistent :
 
 Pas de tracking de chaque PNJ secondaire, pas de "tous les marchands se souviennent de toi" — économie de DB + cohérence narrative.
 
+### La dépouille du perso précédent _(ajout 2026-08-15, #281)_
+
+Une **quatrième catégorie de trace**, la seule qui soit à la fois narrative et **utile** au joueur :
+là où le personnage précédent est mort, il **reste**.
+
+| Catégorie         | Contenu                                                          | Persistance                       |
+| ----------------- | ---------------------------------------------------------------- | --------------------------------- |
+| **`corpse_left`** | Lieu de mort + cause + une image du corps + son équipement porté | 1 run (consommée à la découverte) |
+
+- Le backend écrit la trace **à la fin du run** depuis le `endReason` (cf. `09-ACTION-LOOP §7`) et
+  le dernier lieu connu. Aucune décision IA : c'est un enregistrement mécanique.
+- Au run suivant, si le nouveau personnage **passe au même endroit**, le corps est injecté en
+  contexte comme un **cadavre-présage** (cf. `09-ACTION-LOOP §3bis`) : il annonce ce qui a tué le
+  précédent, exactement comme n'importe quel présage du monde.
+- La cause de mort est **montrée, jamais nommée** : le run N+1 voit une gorge ouverte, une peau
+  grise de Calamine, une gourde vide — pas l'étiquette `endReason`.
+- **L'équipement porté est récupérable**, dans la limite fixée par `11-INVENTORY-ECONOMY` (sac plein,
+  objets liés). C'est la seule exception apparente à la règle « pas d'équipement cumulé d'un run à
+  l'autre » (§1bis) — et elle n'en est pas une : le joueur ne récupère **rien** s'il ne retourne pas
+  sur les lieux, ce qui coûte du temps, de la soif et du risque. Le gain est **payé dans le run**,
+  pas offert entre les runs.
+- **Une seule dépouille active** : la mort du run N remplace celle du run N-1. Pas de cimetière
+  cumulatif (saturation DB, et l'effet s'émousse).
+- Si le run précédent s'est terminé par `calcined`, il n'y a **pas de dépouille** — il y a un
+  **Calciné qui marche encore** dans le secteur. Il porte l'équipement, il ne le rend pas.
+
+🟢 _Pourquoi ça marche : c'est le crochet de rétention le plus court du jeu. « Mon dernier perso est
+mort là-bas, avec ma bonne lame » est une raison de relancer un run qui ne coûte ni contenu ni
+équilibrage — et qui fabrique une histoire personnelle au passage._
+
 ### Format DB
 
 ```json

--- a/docs/canon/15-GAME-MASTER.md
+++ b/docs/canon/15-GAME-MASTER.md
@@ -77,6 +77,41 @@ GRIMOIRE n'a **aucun audio en V1**. Tout passe par le **texte**. Mais le texte a
 >
 > « Tu marches depuis trois heures. La soif est devenue une pensée fixe. »
 
+#### Le registre de potence _(ajout 2026-08-15, #281)_
+
+Le Narrateur applique le positionnement de `01-PILLARS §4` : **le monde est baroque, sa voix reste
+sèche**. Il ne commente pas l'horreur, il la **constate** — et c'est le décalage entre l'atrocité de
+l'image et la platitude du ton qui produit le rire noir.
+
+**Trois outils, dans cet ordre de préférence** :
+
+1. **La litote** — dire moins que ce qu'on montre. _« Le péagier tient encore la main tendue. La
+   moitié basse manque. Le péage reste ouvert. »_
+2. **La routine administrative appliquée à l'horreur** — un PNJ qui trie, étiquette, compte ou taxe
+   des morts comme on ferait un inventaire. _« Il range les bottes par pointure. Les grandes se
+   vendent mieux. »_
+3. **La chute sèche** — une phrase courte, détachée, en fin de narration. _« Évidemment. »_
+
+**Règles de dosage (dures)** :
+
+- **Une chute maximum par scène.** Deux = sketch. Le backend surveille l'empilement en QA de voix
+  (cf. §8).
+- **Jamais de chute sur la mort du personnage joueur**, ni sur la blessure grave d'un PNJ auquel le
+  joueur s'est attaché. Le sarcasme s'applique au **monde**, jamais à la perte du joueur.
+- **Jamais d'adresse au joueur** : la potence est dans le monde, pas dans un clin d'œil.
+- Si le tour est un pivot tendu (combat décisif, agonie, révélation), la chute est **supprimée** —
+  le silence fait plus de travail.
+
+**Phrases canoniques du registre** :
+
+> « Le péagier tient encore la main tendue. La moitié basse manque. Le péage reste ouvert. »
+>
+> « Une étiquette pend à sa cheville. Un numéro, une date. Quelqu'un fait des comptes ici. »
+>
+> « Le Calciné trie les bottes par pointure. Il n'a pas levé la tête quand tu es entré. »
+>
+> « La cloche sonne trois fois. Personne ne vient. Elle sonne quand même. »
+
 ### 1.3 — PNJ génériques (tous les autres)
 
 **Ton** : neutre par défaut, avec **5 variantes culturelles légères** selon le peuple du PNJ. Une variante = 2-3 tics de langage, pas une voix complète.
@@ -161,12 +196,16 @@ Liste dure dans le prompt système. L'IA reçoit ces interdits explicitement. Le
 | **Lore inventé hors canon**         | _« Le grand Empire de Velkhar fondé en l'an 200... »_   | Le lore est dans [02-WORLD-BIBLE](02-WORLD-BIBLE.md). L'IA n'invente jamais d'histoire mondiale. |
 | **Décision mécanique**              | _« Tu perds 5 PV. »_                                    | Le backend annonce les dégâts via l'UI. La prose **décrit**, ne **calcule** pas.                 |
 | **Roulage de dé en prose**          | _« Tu lances un d20... 14 ! Réussite. »_                | Le backend roule, l'IA narre le résultat. Cf. [08-DICE-RESOLUTION](08-DICE-RESOLUTION.md).       |
+| **Gore décoratif**                  | _« Des viscères partout, du sang partout, l'horreur. »_ | L'horreur doit **renseigner** (menace, cause de mort, règle du monde). Cf. `01-PILLARS §4`.      |
+| **Humour adressé au joueur**        | _« Bon courage avec ça ! »_                             | L'humour de potence est **dans le monde**, jamais un clin d'œil au lecteur.                      |
 
 ### Tolérés mais à doser
 
 - Métaphores poétiques (1 par scène max — on évite la prose surchargée)
 - Dialogues internes du perso (interdits si Narrateur, autorisés si L'Aveugle commente)
 - Cliffhangers (autorisés si naturels, pas forcés)
+- **Humour de potence** (1 chute sèche par scène max, jamais sur la mort du joueur — cf. §1.2)
+- **Image gore forte** (1 par scène max, et seulement si elle informe — cf. `01-PILLARS §4`)
 
 ---
 
@@ -182,12 +221,48 @@ Chaque réponse IA doit matcher ce schéma :
 {
   narration: string (max 250 tokens),
   choices: Array<{ id: string, label: string }> (3-4 max, label max 20 tokens),
-  mood: "calm" | "tense" | "festive" | "sacred" | "dangerous",
+  mood: "calm" | "tense" | "festive" | "sacred" | "dangerous" | "dread",
   npcs_present: string[] (noms des PNJ en scène)
 }
 ```
 
 Si parse Zod échoue → **retry avec prompt enrichi** _« Ton dernier output ne respectait pas le format JSON imposé. Renvoie strictement : ... »_.
+
+#### Le mood `dread` _(ajout 2026-08-15, #281)_
+
+`dread` est le **sixième mood**, distinct de `tense` et `dangerous` :
+
+| Mood        | Ce qu'il signifie                                                  | Exemple                                                |
+| ----------- | ------------------------------------------------------------------ | ------------------------------------------------------ |
+| `tense`     | Quelque chose **peut** mal tourner, maintenant                     | Un garde pose la main sur son arme                     |
+| `dangerous` | La menace est **présente et identifiée**                           | Trois silhouettes armées barrent le passage            |
+| `dread`     | La menace n'est pas encore là — le monde **annonce** qu'elle vient | Un cadavre frais, encore chaud, sans agresseur visible |
+
+`dread` est le mood du **présage** (`09-ACTION-LOOP §3bis`) : le joueur voit la conséquence avant la
+cause. C'est la couleur émotionnelle qui porte l'effet de surprise recherché — il doit pouvoir
+anticiper s'il lit bien.
+
+Côté frontend, `dread` reçoit un traitement visuel propre (ambiance sourde, pas d'alerte rouge :
+c'est de l'appréhension, pas du combat). Implémentation : ticket moteur séparé.
+
+#### Le champ `foreshadow` _(ajout 2026-08-15, #281)_
+
+Un champ **optionnel** en sortie, qui laisse l'IA signaler qu'elle a semé un présage exploitable :
+
+```ts
+foreshadow?: {
+  hint: string,        // le détail semé, max 15 tokens — ex : "traces de dents sur l'os"
+  threat: string       // ce qu'il annonce, jamais montré au joueur — ex : "meute de Ventre-Gris"
+}
+```
+
+`hint` est **déjà dans la narration** ; le champ ne fait que le rendre lisible par le moteur. Le
+backend le persiste dans le `SceneLog` et le réinjecte en contexte au tour suivant, pour que la
+menace annoncée **arrive vraiment** (ou soit démentie de façon signifiante). `threat` n'est **jamais
+affiché** au joueur — c'est de la mémoire moteur, pas de la prose.
+
+🔴 **Interdit** : un `foreshadow` sans conséquence dans les 3 tours suivants. Un présage qui ne se
+réalise jamais entraîne le joueur à ne plus lire les détails — c'est l'inverse de l'effet voulu.
 
 ### 4.2 — Vérification contextuelle
 
@@ -200,6 +275,8 @@ Après parse, le backend vérifie :
 | `mood: "festive"` alors que le perso est à 1 PV              | Rejet + retry                                                      |
 | `npcs_present` contient un PNJ mort dans un run précédent    | Rejet + retry                                                      |
 | Narration mentionne un lieu inexistant dans Velkhar canon    | Rejet + retry **après 2 tentatives → renvoyer fallback générique** |
+| `foreshadow.hint` absent du texte de `narration`             | Champ ignoré (la narration reste)                                  |
+| `mood: "dread"` alors qu'aucune menace n'existe au contexte  | Ramené à `calm` (pas de retry — coût inutile)                      |
 
 ### 4.3 — Hard timeout 12 sec
 
@@ -310,12 +387,28 @@ Tu écris en 3 voix selon le contexte :
 3. PNJ GÉNÉRIQUES — neutre + variante culturelle selon peuple
    [5 variantes × 1 exemple chacune]
 
+[TON — LE MONDE EST BAROQUE, TA VOIX EST SÈCHE]
+Velkhar est une horreur sacrée : masques votifs, cloches, morts étiquetés,
+Calcinés. Tu montres cela sans jamais le commenter. Tu constates.
+- Une image forte maximum par scène, et elle doit RENSEIGNER le joueur
+  (une menace, une cause de mort, une règle du monde). Jamais de gore décoratif.
+- Une chute sèche maximum par scène (litote, constat pince-sans-rire).
+  Jamais sur la mort du joueur. Jamais adressée au joueur.
+- Le corps est une information : blessure localisée, marques, brûlure.
+
+[PRÉSAGE]
+Si la scène contient un indice de ce qui attend le joueur, sème-le dans la
+narration ET déclare-le dans "foreshadow". L'indice est visible, la menace
+qu'il annonce ne l'est pas. Ne sème jamais un présage sans intention.
+
 [INTERDITS]
 - Adverbes émotionnels (tristement, mystérieusement...)
 - "Soudain !", questions rhétoriques au joueur
 - Emojis dans la prose
 - Lore inventé hors WORLD-BIBLE
 - Happy ending forcé (Velkhar est rude)
+- Gore décoratif qui n'apprend rien
+- Humour adressé au joueur (clin d'œil, référence moderne)
 
 [FORMAT DE SORTIE — STRICTEMENT JSON]
 {
@@ -325,18 +418,30 @@ Tu écris en 3 voix selon le contexte :
     { "id": "b", "label": "..." },
     { "id": "c", "label": "..." }
   ],
-  "mood": "calm | tense | festive | sacred | dangerous",
-  "npcs_present": ["..."]
+  "mood": "calm | tense | festive | sacred | dangerous | dread",
+  "npcs_present": ["..."],
+  "foreshadow": { "hint": "...", "threat": "..." }   // optionnel
 }
 
 [CONTEXTE DE LA SCÈNE]
 {lore_velkhar_extrait}
 {état_perso : nom, vocation, peuple, PV, stats, inventaire bref}
+{blessures_localisées_actives}
 {souvenirs_nommés_pertinents}
 {mémoire_intra_run_compressée}
 {3-5_derniers_tours_en_clair}
+{présages_actifs_non_résolus}     // hint + threat des tours précédents
+{hallucinationAllowed}            // true si Calamine ≥ 50 (06-SURVIVAL §4)
 {action_du_joueur_au_tour_n}
 {résultat_dé_si_applicable}
+
+[HALLUCINATIONS]
+Si {hallucinationAllowed} est vrai, tu peux décrire UN élément sensoriel qui
+n'existe pas (une silhouette, une voix, une odeur). Jamais plus d'un par scène.
+Tu ne signales JAMAIS que c'est une hallucination.
+INTERDIT ABSOLU : halluciner une information mécanique — un PNJ dans
+"npcs_present", un objet ramassable, un chiffre, une sortie, un choix.
+L'hallucination est une ambiance, jamais une décision de jeu.
 
 [INSTRUCTION FINALE]
 Génère le tour N+1. Réponds STRICTEMENT en JSON. Une seule voix par
@@ -364,16 +469,20 @@ Détaillé dans [17-RUN-CHRONICLE](17-RUN-CHRONICLE.md). Vue côté GM :
 
 ## §8 — Risques & garde-fous
 
-| Risque                                                                        | Mitigation                                                                                                                                                          |
-| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Dérive de voix entre modèles** (DeepSeek vs Llama narrent différemment)     | Tests A/B systématiques sur 20 prompts canoniques par modèle. Si écart de style > seuil → exclure le modèle. Banque de phrases canoniques injectée à chaque prompt. |
-| **Hallucinations lore** (l'IA invente un peuple, un dieu, une région)         | Lore Velkhar injecté à chaque appel (max 500 tokens, extraits pertinents). Validation `lieu mentionné ∈ catalogue` côté backend.                                    |
-| **Latence variable free tier** (3-15 sec selon modèle/heure)                  | UI affiche _« Le MJ réfléchit... »_ avec animation discrète. Pas de timer visible.                                                                                  |
-| **Quotas free tier explosés**                                                 | Monitoring quotas en temps réel via `request_logs`. Alerte mail Adem à 80% quota. Cascade auto vers modèle suivant.                                                 |
-| **Style trop verbose** (modèles open source ont tendance à overdoser)         | Hard cap 250 tokens narration. Tronqué propre + retry si dépassement.                                                                                               |
-| **JSON cassé** (modèles open source moins fiables que Claude)                 | Parse Zod systématique. Retry avec exemple JSON valide en prompt. Au pire : fallback générique.                                                                     |
-| **Quotas free tier disparaissent** (OpenRouter retire un modèle sans préavis) | Liste cascade en env var modifiable sans redéploiement. Veille mensuelle Adem sur les modèles dispo.                                                                |
-| **Erreur fournisseur silencieuse** (modèle renvoie 200 mais contenu vide)     | Validation longueur min narration (10 tokens). Sinon retry.                                                                                                         |
+| Risque                                                                        | Mitigation                                                                                                                                                                                 |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Dérive de voix entre modèles** (DeepSeek vs Llama narrent différemment)     | Tests A/B systématiques sur 20 prompts canoniques par modèle. Si écart de style > seuil → exclure le modèle. Banque de phrases canoniques injectée à chaque prompt.                        |
+| **Hallucinations lore** (l'IA invente un peuple, un dieu, une région)         | Lore Velkhar injecté à chaque appel (max 500 tokens, extraits pertinents). Validation `lieu mentionné ∈ catalogue` côté backend.                                                           |
+| **Latence variable free tier** (3-15 sec selon modèle/heure)                  | UI affiche _« Le MJ réfléchit... »_ avec animation discrète. Pas de timer visible.                                                                                                         |
+| **Quotas free tier explosés**                                                 | Monitoring quotas en temps réel via `request_logs`. Alerte mail Adem à 80% quota. Cascade auto vers modèle suivant.                                                                        |
+| **Style trop verbose** (modèles open source ont tendance à overdoser)         | Hard cap 250 tokens narration. Tronqué propre + retry si dépassement.                                                                                                                      |
+| **JSON cassé** (modèles open source moins fiables que Claude)                 | Parse Zod systématique. Retry avec exemple JSON valide en prompt. Au pire : fallback générique.                                                                                            |
+| **Quotas free tier disparaissent** (OpenRouter retire un modèle sans préavis) | Liste cascade en env var modifiable sans redéploiement. Veille mensuelle Adem sur les modèles dispo.                                                                                       |
+| **Erreur fournisseur silencieuse** (modèle renvoie 200 mais contenu vide)     | Validation longueur min narration (10 tokens). Sinon retry.                                                                                                                                |
+| **Refus ou édulcoration du gore par un modèle free** (safety filters)         | Même protocole A/B que la dérive de voix : 20 prompts gore canoniques par modèle. Un modèle qui refuse ou lisse systématiquement descend dans la cascade. Test **avant** de figer l'ordre. |
+| **Dérive de l'humour vers le sketch** (2+ chutes par scène, ton parodique)    | Cap dur « 1 chute/scène » dans le prompt. QA de voix manuelle sur échantillon. Si un modèle empile, retirer les exemples de potence de **son** prompt (variante par modèle).               |
+| **Hallucination qui contamine la mécanique** (PNJ inventé en `npcs_present`)  | La règle `§4.2` existante s'applique inchangée : `npcs_present` et `itemGained` sont validés contre le catalogue. `hallucinationAllowed` n'assouplit **aucune** validation.                |
+| **Présage jamais résolu** (le joueur cesse de lire les détails)               | Les `foreshadow` non résolus sont réinjectés en contexte 3 tours ; au-delà, le backend les marque résolus-par-défaut et cesse de les injecter. Suivi en QA narrative.                      |
 
 ---
 


### PR DESCRIPTION
## Contexte

Le canon actuel est déjà sombre, mais trois choses manquaient pour atteindre le ton visé (le joueur doit **s'amuser dans la souffrance**, lire avec plaisir et **chercher à anticiper** ce qui va lui arriver) :

1. l'humour n'était pas autorisé (l'interdit « humour briseur de ton » couvrait tout),
2. le gore n'avait **aucune fonction mécanique** — donc rien qui justifie de le doser,
3. la surprise n'était **systématisée nulle part** : rien n'obligeait le monde à annoncer ses menaces.

## Positionnement acté

> **Le monde est _Blasphemous_. La voix est _Darkest Dungeon_.**

Le monde (lieux, factions, iconographie) est une horreur sacrée baroque ; la voix qui le raconte reste sèche et ironique. Cette séparation évite que les deux registres s'annulent — un monde baroque raconté en liturgie devient pompeux, une voix sèche sur un monde neutre devient plate. Le contraste **image atroce / ton posé** est la signature.

## Ce que la PR ajoute

| Fichier | Amendement |
| --- | --- |
| `01-PILLARS.md` §4 | Positionnement Blasphemous/Darkest Dungeon · **humour de potence** (autorisé vs briseur, 1 chute/scène) · **budget gore** (1 image forte/scène, gore signifiant uniquement) |
| `15-GAME-MASTER.md` §1.2 | Registre de potence du Narrateur : litote / routine administrative / chute sèche + 4 phrases canoniques + règles de dosage dures |
| `15-GAME-MASTER.md` §3, §4.1, §4.2, §6, §8 | Mood **`dread`** (6ᵉ mood, distinct de `tense`/`dangerous`) · champ optionnel **`foreshadow { hint, threat }`** · interdits « gore décoratif » et « humour adressé au joueur » · squelette de prompt (blocs TON / PRÉSAGE / HALLUCINATIONS, contexte enrichi) · 4 nouveaux risques |
| `06-SURVIVAL.md` §2, §4 | **Localisation des blessures** persistée (narrative, aucun malus différencié V1) · **hallucinations de Calamine** au stade 2+ via `hallucinationAllowed` |
| `09-ACTION-LOOP.md` §3, §3bis | **Option vorace** (gain clair, prix annoncé mais non chiffré, 1 tour sur 3) · nouvelle section **cadavre-présage** : voir la conséquence avant la cause |
| `14-META-WORLD.md` §3 | **Dépouille du perso précédent** (`corpse_left`) : le corps du run N devient le présage du run N+1, équipement récupérable sur place |

## Garde-fous préservés

- **`15-GAME-MASTER §0` reste intact** : l'IA propose, le backend dispose. `hallucinationAllowed` n'assouplit **aucune** validation — un PNJ halluciné n'entre jamais dans `npcs_present`, un objet halluciné n'entre jamais dans `itemGained`. L'hallucination est une ambiance, jamais une décision de jeu.
- **Pas de méta-progression de puissance** : l'équipement de la dépouille n'est récupérable qu'en retournant sur les lieux — le gain est payé dans le run, pas offert entre les runs.
- **Pas de RNG punitif** : l'option vorace annonce toujours son prix, le présage tient sa promesse en 3 tours ou est démenti de façon signifiante.
- **Interdit de complaisance** maintenu (torture longue, détail anatomique gratuit, souffrance d'enfant hors périmètre).

## Points de vigilance signalés

- **Les modèles free-tier peuvent refuser ou lisser le gore.** Un risque + son protocole de test (A/B sur 20 prompts gore canoniques, avant de figer l'ordre de cascade) sont inscrits en `15-GAME-MASTER §8`.
- **Le budget de 250 tokens de narration est serré** avec présage + image forte + chute. Priorité d'écriture si arbitrage nécessaire : présage > chute > ambiance.

## Hors périmètre

Cette PR ne touche **que le canon**. L'implémentation moteur (enum `mood` dans `packages/shared`, champ `foreshadow` dans le schéma Zod, flag `hallucinationAllowed`, `wound.location`, trace `corpse_left`, traitement visuel de `dread`) fera l'objet de tickets séparés.

Closes #281
